### PR TITLE
Custom CSS Classes for MudTabs and MudTabPanel

### DIFF
--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -11,6 +11,7 @@ namespace MudBlazor
         protected string TabsClassnames =>
             new CssBuilder("mud-tabs")
             .AddClass($"mud-tabs-vertical", Vertical)
+            .AddClass(Class)
             .Build();
 
         protected string ToolbarClassnames => 
@@ -30,6 +31,7 @@ namespace MudBlazor
         protected string PanelsClassnames =>
             new CssBuilder("mud-tabs-panels")
             .AddClass($"mud-tabs-vertical", Vertical)
+            .AddClass(TabPanelClass)
             .Build();
 
         /// <summary>
@@ -66,6 +68,12 @@ namespace MudBlazor
         /// Child content of component.
         /// </summary>
         [Parameter] public RenderFragment ChildContent { get; set; }
+
+        /// <summary>
+        /// Custom class/classes for TabPanel
+        /// </summary>
+        [Parameter] public string TabPanelClass { get; set; }
+
 
 
         public MudTabPanel ActivePanel { get; set; }


### PR DESCRIPTION
 - Added "Class" property on CssBuilder for TabsClassnames; 
- Added "TabPanelClass" property on MudTabs Component for using on CssBuilder for PanelsClassnames.

Usage:

        <MudBlazor.MudTabs Class="pt-4" TabPanelClass="pt-6" >
                  ...
        </MudBlazor.MudTabs>


MudTabs wasn't applying the values from Class property to element and also wasn't able to define custom classes for MudTabPanel.