### PR TITLE
Changed TabPanelClass declaration frorm PanelsClassnames() to GetTabClass()

### DIFF
--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -31,7 +31,6 @@ namespace MudBlazor
         protected string PanelsClassnames =>
             new CssBuilder("mud-tabs-panels")
             .AddClass($"mud-tabs-vertical", Vertical)
-            .AddClass(TabPanelClass)
             .Build();
 
         /// <summary>
@@ -96,6 +95,7 @@ namespace MudBlazor
               .AddClass($"mud-tab-active", when: () => panel == ActivePanel)
               .AddClass($"mud-disabled", panel.Disabled)
               .AddClass($"mud-ripple" ,!DisableRipple)
+              .AddClass(TabPanelClass)
             .Build();
 
             return TabClass;


### PR DESCRIPTION
The ideia is about to apply custom classes for TabPanel, and not for the Active panel host. I'm fixing my mistake.