### PR TITLE
Fixed dense margin in mudtextfield

### DIFF
--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -12,7 +12,8 @@ namespace MudBlazor
             new CssBuilder("mud-input")
                 .AddClass($"mud-input-{Variant.ToDescriptionString()}")
                 .AddClass($"mud-input-adorned-{Adornment.ToDescriptionString()}", Adornment != Adornment.None)
-                .AddClass("mud-input-underline", when: () => DisableUnderLine == false && Variant != Variant.Outlined)
+                .AddClass($"mud-input-margin-{Margin.ToDescriptionString()}", when: () => Margin != Margin.None)
+                .AddClass("mud-input-underline", when: () => DisableUnderLine == false && Variant != Variant.Outlined)                
                 .AddClass("mud-shrink", when: () => !string.IsNullOrEmpty(Text) || Adornment == Adornment.Start)
                 .AddClass("mud-disabled", Disabled)
                 .AddClass("mud-error", HasErrors)
@@ -23,6 +24,7 @@ namespace MudBlazor
             new CssBuilder("mud-input-root")
                 .AddClass($"mud-input-root-{Variant.ToDescriptionString()}")
                 .AddClass($"mud-input-root-adorned-{Adornment.ToDescriptionString()}", Adornment != Adornment.None)
+                .AddClass($"mud-input-root-margin-{Margin.ToDescriptionString()}", when: () => Margin != Margin.None)
                 .AddClass(Class)
                 .Build();
 

--- a/src/MudBlazor/Components/Input/MudInputLabel.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInputLabel.razor.cs
@@ -11,6 +11,7 @@ namespace MudBlazor
          .AddClass("mud-input-label")
          .AddClass("mud-input-label-animated")
          .AddClass($"mud-input-label-{Variant.ToDescriptionString()}")
+         .AddClass($"mud-input-label-margin-{Margin.ToDescriptionString()}", when: () => Margin != Margin.None)
          .AddClass($"mud-disabled", Disabled)
          .AddClass("mud-error", Error)
          .AddClass(Class)
@@ -35,6 +36,11 @@ namespace MudBlazor
         /// Variant to use.
         /// </summary>
         [Parameter] public Variant Variant { get; set; } = Variant.Text;
+
+        /// <summary>
+        ///  Will adjust vertical spacing. 
+        /// </summary>
+        [Parameter] public Margin Margin { get; set; } = Margin.None;
 
     }
 }

--- a/src/MudBlazor/Components/InputControl/MudInputControl.razor
+++ b/src/MudBlazor/Components/InputControl/MudInputControl.razor
@@ -8,7 +8,7 @@
     @InputContent
     @if (!String.IsNullOrEmpty(Label))
     {
-        <MudInputLabel Class="mud-input-label-inputcontrol" Variant="@Variant" Disabled=@Disabled Error="@Error">
+        <MudInputLabel Class="mud-input-label-inputcontrol" Variant="@Variant" Disabled=@Disabled Error="@Error" Margin="@Margin">
             @Label
         </MudInputLabel>
     }

--- a/src/MudBlazor/Components/TextField/MudTextField.razor
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor
@@ -3,10 +3,10 @@
 @inherits MudBaseInput<T>
 
 <CascadingValue Name="Standalone" Value="false" IsFixed="true">
-    <MudInputControl Label="@Label" Variant="@Variant" HelperText="@HelperText" FullWidth="@FullWidth" Error="@HasErrors" ErrorText="@GetErrorText()" Disabled="@Disabled">
+    <MudInputControl Label="@Label" Variant="@Variant" HelperText="@HelperText" FullWidth="@FullWidth" Error="@HasErrors" ErrorText="@GetErrorText()" Disabled="@Disabled" Margin="@Margin">
         <InputContent>
             <MudInput @attributes="UserAttributes" InputType="@InputType" Lines="@Lines" Class="@Classname" Style="@Style" Variant="@Variant" @bind-Value="@Text" Placeholder="@Placeholder" Disabled=@Disabled ReadOnly="@ReadOnly"
-                      Adornment="@Adornment" AdornmentText="@AdornmentText" AdornmentIcon="@AdornmentIcon" IconSize="@IconSize" OnAdornmentClick="@OnAdornmentClick" Error="@Error" Immediate="@Immediate"
+                      Adornment="@Adornment" AdornmentText="@AdornmentText" AdornmentIcon="@AdornmentIcon" IconSize="@IconSize" OnAdornmentClick="@OnAdornmentClick" Error="@Error" Immediate="@Immediate" Margin="@Margin"
                       OnBlur="@OnBlurred" />
         </InputContent>
     </MudInputControl>

--- a/src/MudBlazor/Styles/Components/_input.scss
+++ b/src/MudBlazor/Styles/Components/_input.scss
@@ -14,14 +14,6 @@
     letter-spacing: 0.00938em;
     z-index: 10;
 
-    &.mud-input-multiline {
-        padding: 6px 0 7px;
-
-        &.mud-input-margin-dense {
-            padding-top: 3px;
-        }
-    }
-
     &.mud-input-full-width {
         width: 100%;
     }
@@ -96,16 +88,6 @@
             padding-right: 12px;
         }
 
-        &.mud-input-multiline {
-            padding: 27px 12px 10px;
-
-            &.mud-input-margin-dense {
-                padding-top: 23px;
-                padding-bottom: 6px;
-            }
-        }
-
-
         &.mud-input-underline {
             &:before {
                 left: 0;
@@ -170,15 +152,6 @@
 
         &.mud-input-adorned-end {
             padding-right: 14px;
-        }
-
-        &.mud-input-multiline {
-            padding: 18.5px 14px;
-
-            &.mud-input-margin-dense {
-                padding-top: 10.5px;
-                padding-bottom: 10.5px;
-            }
         }
     }
 }

--- a/src/MudBlazor/Styles/Components/_inputcontrol.scss
+++ b/src/MudBlazor/Styles/Components/_inputcontrol.scss
@@ -16,8 +16,8 @@
     }
 
     &.mud-input-control-margin-dense {
-        margin-top: 8px;
-        margin-bottom: 4px;
+        margin-top: 3px;
+        margin-bottom: 2px;
     }
 
     &.mud-input-control-full-width {


### PR DESCRIPTION
- Margin dense did not work. Needed to pass through the margin prop to label und input.
- Removed multiline classes in _input.scss. Multiline is done by textarea.
- Adjusted dense margin on input-control 