### PR TITLE
fixed rating flicker issue

### DIFF
--- a/src/MudBlazor/Components/Rating/MudRatingItem.razor.cs
+++ b/src/MudBlazor/Components/Rating/MudRatingItem.razor.cs
@@ -1,10 +1,8 @@
 ﻿using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
-using System;
-using System.Collections.Generic;
-using System.Text;
 using MudBlazor.Extensions;
 using MudBlazor.Utilities;
+using System.Threading.Tasks;
 
 namespace MudBlazor
 {
@@ -105,11 +103,17 @@ namespace MudBlazor
         }
 
         // rating item lose hover
-        private void HandleMouseOut(MouseEventArgs e)
+        private async Task HandleMouseOut(MouseEventArgs e)
         {
             if (Disabled) return;
-            IsActive = false;
-            ItemHovered.InvokeAsync(null);
+
+            // onmouseout from current item will always fire before onmouseover, if we don't wait here for potential onmouseover from another item there will be a flicker issue
+            await Task.Delay(10);
+            if (Rating.HoveredValue.HasValue && Rating.HoveredValue.Value == ItemValue)
+            {
+                IsActive = false;
+                await ItemHovered.InvokeAsync(null);
+            }
         }
 
         private void HandleMouseOver(MouseEventArgs e)


### PR DESCRIPTION
Hello!

Current behaviour: (looks worse "IRL", think gif capturer misses some frames)
![rating_before](https://user-images.githubusercontent.com/36196344/98699154-1f693100-2377-11eb-8611-e43e446779f1.gif)

New behaviour:
![rating_after](https://user-images.githubusercontent.com/36196344/98699177-25f7a880-2377-11eb-9156-ff949cd08f8f.gif)

Let me know if there is anything I can change.