### PR TITLE
MudSelect; Set Margin is not possible. Margin prop should be delivered to the inner input

### DIFF
--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -9,7 +9,7 @@
                          Error="@Error" ErrorText="@ErrorText" Disabled="@Disabled" @onclick="@ToggleMenu">
             <InputContent>
                 <MudInput Variant="@Variant" Value="@Text" DisableUnderLine="@DisableUnderLine" Placeholder="@Placeholder" Disabled=@Disabled ReadOnly="@ReadOnly"
-                          Class="mud-select-input" Error="@Error" AdornmentIcon="@CurrentIcon" Adornment="Adornment.End" IconSize="Size.Medium"
+                          Class="mud-select-input" Error="@Error" AdornmentIcon="@CurrentIcon" Adornment="Adornment.End" IconSize="Size.Medium" Margin="@Margin"
                           InputType="@(CanRenderValue ? InputType.Hidden : InputType.Text)">
                     @if (CanRenderValue)
                     {


### PR DESCRIPTION
It is not possible to set MudSelect to Margin.Dense. The margin prop is not delivered to the MudInput component inside.