### PR TITLE
Inputfields get jumpy if you dont use helpertext.

### DIFF
--- a/src/MudBlazor/Components/InputControl/MudInputControl.razor
+++ b/src/MudBlazor/Components/InputControl/MudInputControl.razor
@@ -29,6 +29,10 @@
     {
         <p class="@HelperClass">@ErrorText</p>
     }
+    else
+    {
+        <p class="@HelperClass" style="visibility: hidden"> mocktext </p> //So same space always is taken, undependent of helpertext / errortext or not.
+    }
     @ChildContent
 </div>
 


### PR DESCRIPTION
To solve this I set a mocktext with visibility hidden, so the same space always is taken.

This can easily be seen at https://mudblazor.com/components/form under "Simple form validation". Click on username and click elsewhere so error messages get displayed, now you will see the input "jumps" to get the space needed for the error message.