### PR TITLE
Fix breakpoints

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/dotnet-core
 
 trigger:
-- develop
+- master
 
 pool:
   vmImage: 'ubuntu-latest'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,11 +4,9 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/dotnet-core
 
 trigger:
-branches:
-    include:
-    - master
-    - develop
-    - net5
+- master
+- develop
+- net5
 
 
 pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,12 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/dotnet-core
 
 trigger:
-- master
+branches:
+    include:
+    - master
+    - develop
+    - net5
+
 
 pool:
   vmImage: 'ubuntu-latest'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,9 +5,6 @@
 
 trigger:
 - master
-- develop
-- net5
-
 
 pool:
   vmImage: 'ubuntu-latest'
@@ -18,7 +15,7 @@ variables:
 steps:
 - task: UseDotNet@2
   inputs:
-    version: 5.0.x
+    version: 3.1.x
 
 
 - task: DotNetCoreCLI@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ variables:
 steps:
 - task: UseDotNet@2
   inputs:
-    version: 3.1.x
+    version: 5.0.x
 
 
 - task: DotNetCoreCLI@2

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -2,3 +2,5 @@
 
 # CS1591: Missing XML comment for publicly visible type or member
 dotnet_diagnostic.CS1591.severity = none
+indent_style = space
+indent_size = 4

--- a/src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj
+++ b/src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="bunit" Version="1.0.0-beta-10" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="Moq" Version="4.15.2" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />

--- a/src/MudBlazor.UnitTests/Services/ResizeListenerServiceTests.cs
+++ b/src/MudBlazor.UnitTests/Services/ResizeListenerServiceTests.cs
@@ -20,25 +20,30 @@ namespace MudBlazor.UnitTests.Services
             _service = new ResizeListenerService(null, _browserWindowSizeProvider.Object);
         }
 
+        // 0 - 599
         [TestCase(Breakpoint.Xs, 0, true)]
         [TestCase(Breakpoint.Xs, 599, true)]
         [TestCase(Breakpoint.Xs, 600, false)]
 
+        // 600 - 959
         [TestCase(Breakpoint.Sm, 599, false)]
         [TestCase(Breakpoint.Sm, 600, true)]
         [TestCase(Breakpoint.Sm, 959, true)]
         [TestCase(Breakpoint.Sm, 960, false)]
 
+        // 960 - 1279
         [TestCase(Breakpoint.Md, 959, false)]
         [TestCase(Breakpoint.Md, 960, true)]
         [TestCase(Breakpoint.Md, 1279, true)]
         [TestCase(Breakpoint.Md, 1280, false)]
 
+        // 1280 - 1919
         [TestCase(Breakpoint.Lg, 1279, false)]
         [TestCase(Breakpoint.Lg, 1280, true)]
         [TestCase(Breakpoint.Lg, 1919, true)]
         [TestCase(Breakpoint.Lg, 1920, false)]
 
+        // 1920 - *
         [TestCase(Breakpoint.Xl, 1919, false)]
         [TestCase(Breakpoint.Xl, 1920, true)]
         [TestCase(Breakpoint.Xl, 9999, true)]

--- a/src/MudBlazor.UnitTests/Services/ResizeListenerServiceTests.cs
+++ b/src/MudBlazor.UnitTests/Services/ResizeListenerServiceTests.cs
@@ -1,0 +1,89 @@
+﻿using FluentAssertions;
+using Moq;
+using MudBlazor.Providers;
+using MudBlazor.Services;
+using NUnit.Framework;
+using System.Threading.Tasks;
+
+namespace MudBlazor.UnitTests.Services
+{
+    [TestFixture]
+    public class ResizeListenerServiceTests
+    {
+        private Mock<IBrowserWindowSizeProvider> _browserWindowSizeProvider;
+        private ResizeListenerService _service;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _browserWindowSizeProvider = new Mock<IBrowserWindowSizeProvider>();
+            _service = new ResizeListenerService(null, _browserWindowSizeProvider.Object);
+        }
+
+        [TestCase(Breakpoint.Xs, 0, true)]
+        [TestCase(Breakpoint.Xs, 599, true)]
+        [TestCase(Breakpoint.Xs, 600, false)]
+
+        [TestCase(Breakpoint.Sm, 599, false)]
+        [TestCase(Breakpoint.Sm, 600, true)]
+        [TestCase(Breakpoint.Sm, 959, true)]
+        [TestCase(Breakpoint.Sm, 960, false)]
+
+        [TestCase(Breakpoint.Md, 959, false)]
+        [TestCase(Breakpoint.Md, 960, true)]
+        [TestCase(Breakpoint.Md, 1279, true)]
+        [TestCase(Breakpoint.Md, 1280, false)]
+
+        [TestCase(Breakpoint.Lg, 1279, false)]
+        [TestCase(Breakpoint.Lg, 1280, true)]
+        [TestCase(Breakpoint.Lg, 1919, true)]
+        [TestCase(Breakpoint.Lg, 1920, false)]
+
+        [TestCase(Breakpoint.Xl, 1919, false)]
+        [TestCase(Breakpoint.Xl, 1920, true)]
+        [TestCase(Breakpoint.Xl, 9999, true)]
+
+        // >= 600
+        [TestCase(Breakpoint.SmAndUp, 599, false)]
+        [TestCase(Breakpoint.SmAndUp, 600, true)]
+        [TestCase(Breakpoint.SmAndUp, 9999, true)]
+
+        // >= 960
+        [TestCase(Breakpoint.MdAndUp, 959, false)]
+        [TestCase(Breakpoint.MdAndUp, 960, true)]
+        [TestCase(Breakpoint.MdAndUp, 9999, true)]
+
+        // >= 1280
+        [TestCase(Breakpoint.LgAndUp, 1279, false)]
+        [TestCase(Breakpoint.LgAndUp, 1280, true)]
+        [TestCase(Breakpoint.LgAndUp, 9999, true)]
+
+        // < 960
+        [TestCase(Breakpoint.SmAndDown, 960, false)]
+        [TestCase(Breakpoint.SmAndDown, 959, true)]
+        [TestCase(Breakpoint.SmAndDown, 0, true)]
+
+        // < 1280
+        [TestCase(Breakpoint.MdAndDown, 1280, false)]
+        [TestCase(Breakpoint.MdAndDown, 1279, true)]
+        [TestCase(Breakpoint.MdAndDown, 0, true)]
+
+        // < 1920
+        [TestCase(Breakpoint.LgAndDown, 1920, false)]
+        [TestCase(Breakpoint.LgAndDown, 1919, true)]
+        [TestCase(Breakpoint.LgAndDown, 0, true)]
+        public async Task IsMediaSizeReturnsCorrectValue(Breakpoint breakpoint, int browserWidth, bool expectedValue)
+        {
+            // Arrange
+            _browserWindowSizeProvider
+                .Setup(p => p.GetBrowserWindowSize())
+                .ReturnsAsync(new BrowserWindowSize { Width = browserWidth });
+
+            // Act
+            var actual = await _service.IsMediaSize(breakpoint);
+
+            // Assert
+            actual.Should().Be(expectedValue);
+        }
+    }
+}

--- a/src/MudBlazor/MudBlazor.xml
+++ b/src/MudBlazor/MudBlazor.xml
@@ -2113,6 +2113,23 @@
             If true, Sets display inine
             </summary>
         </member>
+        <member name="T:MudBlazor.Providers.BrowserWindowSizeProvider">
+            <summary>
+            This provider calls the JS method resizeListener.getBrowserWindowSize to get the browser window size
+            </summary>
+        </member>
+        <member name="M:MudBlazor.Providers.BrowserWindowSizeProvider.#ctor(Microsoft.JSInterop.IJSRuntime)">
+            <summary>
+            
+            </summary>
+            <param name="jsRuntime"></param>
+        </member>
+        <member name="M:MudBlazor.Providers.BrowserWindowSizeProvider.GetBrowserWindowSize">
+            <summary>
+            Get the current BrowserWindowSize, this includes the Height and Width of the document.
+            </summary>
+            <returns></returns>
+        </member>
         <member name="T:MudBlazor.Breakpoint">
             <summary>
             Breakpoints describe certain user interfaces sizes or ranges. Use them in conjunction with MudHidden or ResizeListenerService
@@ -2123,11 +2140,12 @@
             This service listens to browser resize events and allows you to react to a changing window size in Blazor
             </summary>
         </member>
-        <member name="M:MudBlazor.Services.ResizeListenerService.#ctor(Microsoft.JSInterop.IJSRuntime,Microsoft.Extensions.Options.IOptions{MudBlazor.Services.ResizeOptions})">
+        <member name="M:MudBlazor.Services.ResizeListenerService.#ctor(Microsoft.JSInterop.IJSRuntime,MudBlazor.Providers.IBrowserWindowSizeProvider,Microsoft.Extensions.Options.IOptions{MudBlazor.Services.ResizeOptions})">
             <summary>
             
             </summary>
             <param name="jsRuntime"></param>
+            <param name="browserWindowSizeProvider"></param>
             <param name="options"></param>
         </member>
         <member name="E:MudBlazor.Services.ResizeListenerService.OnResized">

--- a/src/MudBlazor/Providers/BrowserWindowSizeProvider.cs
+++ b/src/MudBlazor/Providers/BrowserWindowSizeProvider.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.JSInterop;
+using MudBlazor.Services;
+using System.Threading.Tasks;
+
+namespace MudBlazor.Providers
+{
+    public interface IBrowserWindowSizeProvider
+    {
+        ValueTask<BrowserWindowSize> GetBrowserWindowSize();
+    }
+
+    /// <summary>
+    /// This provider calls the JS method resizeListener.getBrowserWindowSize to get the browser window size
+    /// </summary>
+    public class BrowserWindowSizeProvider : IBrowserWindowSizeProvider
+    {
+        private readonly IJSRuntime _jsRuntime;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="jsRuntime"></param>
+        public BrowserWindowSizeProvider(IJSRuntime jsRuntime)
+        {
+            this._jsRuntime = jsRuntime;
+        }
+
+        /// <summary>
+        /// Get the current BrowserWindowSize, this includes the Height and Width of the document.
+        /// </summary>
+        /// <returns></returns>
+        public async ValueTask<BrowserWindowSize> GetBrowserWindowSize() =>
+            await _jsRuntime.InvokeAsync<BrowserWindowSize>($"resizeListener.getBrowserWindowSize");
+    }
+}

--- a/src/MudBlazor/Services/ResizeListener/ResizeListenerService.cs
+++ b/src/MudBlazor/Services/ResizeListener/ResizeListenerService.cs
@@ -139,8 +139,6 @@ namespace MudBlazor.Services
             if (_windowSize == null)
                 return false;
 
-            var windowWidth = _windowSize.Width;
-
             Breakpoint? minimumBreakpoint = null;
             Breakpoint? maximumBreakpoint = null;
 
@@ -191,8 +189,8 @@ namespace MudBlazor.Services
             }
 
             return
-                (!minimumBreakpoint.HasValue || windowWidth >= BreakpointDefinition[minimumBreakpoint.Value])
-                && (!maximumBreakpoint.HasValue || windowWidth < BreakpointDefinition[maximumBreakpoint.Value]);
+                (!minimumBreakpoint.HasValue || _windowSize.Width >= BreakpointDefinition[minimumBreakpoint.Value])
+                && (!maximumBreakpoint.HasValue || _windowSize.Width < BreakpointDefinition[maximumBreakpoint.Value]);
         }
 
         bool disposed;

--- a/src/MudBlazor/Services/ResizeListener/ResizeListenerService.cs
+++ b/src/MudBlazor/Services/ResizeListener/ResizeListenerService.cs
@@ -115,7 +115,7 @@ namespace MudBlazor.Services
         public async Task<Breakpoint> GetBreakpoint( ) {
             // note: we don't need to get the size if we are listening for updates, so only if onResized==null, get the actual size
             if (_onResized == null || _windowSize == null)
-                _windowSize = await GetBrowserWindowSize();
+                _windowSize = await _browserWindowSizeProvider.GetBrowserWindowSize();
             if (_windowSize == null)
                 return Breakpoint.Xs;
             if (_windowSize.Width >= BreakpointDefinition[Breakpoint.Xl])
@@ -134,39 +134,65 @@ namespace MudBlazor.Services
         {
             // note: we don't need to get the size if we are listening for updates, so only if onResized==null, get the actual size
             if (_onResized == null || _windowSize == null)
-                _windowSize = await GetBrowserWindowSize();
+                _windowSize = await _browserWindowSizeProvider.GetBrowserWindowSize();
+
             if (_windowSize == null)
                 return false;
-            if (_windowSize.Width >= BreakpointDefinition[Breakpoint.Xl])
+
+            var windowWidth = _windowSize.Width;
+
+            Breakpoint? minimumBreakpoint = null;
+            Breakpoint? maximumBreakpoint = null;
+
+            switch (breakpoint)
             {
-                if (breakpoint == Breakpoint.Xl ||
-                    breakpoint == Breakpoint.LgAndUp || breakpoint == Breakpoint.MdAndUp || breakpoint == Breakpoint.SmAndUp)
-                    return true;
+                case Breakpoint.Xs:
+                    minimumBreakpoint = breakpoint;
+                    maximumBreakpoint = Breakpoint.Sm;
+                    break;
+                case Breakpoint.Sm:
+                    minimumBreakpoint = breakpoint;
+                    maximumBreakpoint = Breakpoint.Md;
+                    break;
+                case Breakpoint.Md:
+                    minimumBreakpoint = breakpoint;
+                    maximumBreakpoint = Breakpoint.Lg;
+                    break;
+                case Breakpoint.Lg:
+                    minimumBreakpoint = breakpoint;
+                    maximumBreakpoint = Breakpoint.Xl;
+                    break;
+                case Breakpoint.Xl:
+                    minimumBreakpoint = breakpoint;
+                    maximumBreakpoint = null;
+                    break;
+
+                    // * and down
+                case Breakpoint.SmAndDown:
+                    maximumBreakpoint = Breakpoint.Md;
+                    break;
+                case Breakpoint.MdAndDown:
+                    maximumBreakpoint = Breakpoint.Lg;
+                    break;
+                case Breakpoint.LgAndDown:
+                    maximumBreakpoint = Breakpoint.Xl;
+                    break;
+
+                    // * and up
+                case Breakpoint.SmAndUp:
+                    minimumBreakpoint = Breakpoint.Sm;
+                    break;
+                case Breakpoint.MdAndUp:
+                    minimumBreakpoint = Breakpoint.Md;
+                    break;
+                case Breakpoint.LgAndUp:
+                    minimumBreakpoint = Breakpoint.Lg;
+                    break;
             }
-            else if (_windowSize.Width >= BreakpointDefinition[Breakpoint.Lg])
-            {
-                if (breakpoint == Breakpoint.Lg ||
-                    breakpoint == Breakpoint.LgAndUp || breakpoint == Breakpoint.MdAndUp || breakpoint == Breakpoint.SmAndUp ||
-                    breakpoint == Breakpoint.LgAndDown)
-                    return true;
-            }
-            else if (_windowSize.Width >= BreakpointDefinition[Breakpoint.Md])
-            {
-                if (breakpoint == Breakpoint.Md ||
-                    breakpoint == Breakpoint.MdAndUp || breakpoint == Breakpoint.SmAndUp ||
-                    breakpoint == Breakpoint.MdAndDown || breakpoint == Breakpoint.LgAndDown)
-                    return true;
-            }
-            else if (_windowSize.Width >= BreakpointDefinition[Breakpoint.Sm])
-            {
-                if (breakpoint == Breakpoint.Sm ||
-                    breakpoint == Breakpoint.SmAndUp ||
-                    breakpoint == Breakpoint.SmAndDown || breakpoint == Breakpoint.MdAndDown || breakpoint == Breakpoint.LgAndDown)
-                    return true;
-            }
-            else if (breakpoint == Breakpoint.Xs || breakpoint == Breakpoint.SmAndDown || breakpoint == Breakpoint.MdAndDown || breakpoint == Breakpoint.LgAndDown)
-                return true;
-            return false;
+
+            return
+                (!minimumBreakpoint.HasValue || windowWidth >= BreakpointDefinition[minimumBreakpoint.Value])
+                && (!maximumBreakpoint.HasValue || windowWidth < BreakpointDefinition[maximumBreakpoint.Value]);
         }
 
         bool disposed;

--- a/src/MudBlazor/Services/ResizeListener/ResizeListenerService.cs
+++ b/src/MudBlazor/Services/ResizeListener/ResizeListenerService.cs
@@ -1,10 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Options;
 using Microsoft.JSInterop;
-
+using MudBlazor.Providers;
 
 namespace MudBlazor.Services
 {
@@ -17,14 +16,17 @@ namespace MudBlazor.Services
         /// 
         /// </summary>
         /// <param name="jsRuntime"></param>
+        /// <param name="browserWindowSizeProvider"></param>
         /// <param name="options"></param>
-        public ResizeListenerService(IJSRuntime jsRuntime, IOptions<ResizeOptions> options = null)
+        public ResizeListenerService(IJSRuntime jsRuntime, IBrowserWindowSizeProvider browserWindowSizeProvider, IOptions<ResizeOptions> options = null)
         {
-            this._options = options.Value ?? new ResizeOptions();
+            this._options = options?.Value ?? new ResizeOptions();
             this._jsRuntime = jsRuntime;
+            this._browserWindowSizeProvider = browserWindowSizeProvider;
         }
 
         private readonly IJSRuntime _jsRuntime;
+        private readonly IBrowserWindowSizeProvider _browserWindowSizeProvider;
         private readonly ResizeOptions _options;
 #nullable enable
         private EventHandler<BrowserWindowSize>? _onResized;
@@ -84,8 +86,9 @@ namespace MudBlazor.Services
         /// Get the current BrowserWindowSize, this includes the Height and Width of the document.
         /// </summary>
         /// <returns></returns>
-        public async ValueTask<BrowserWindowSize> GetBrowserWindowSize() =>
-            await _jsRuntime.InvokeAsync<BrowserWindowSize>($"resizeListener.getBrowserWindowSize");
+        [Obsolete("Method has moved to IBrowserWindowSizeProvider.GetBrowserWindowSize, please use that instead")]
+        public ValueTask<BrowserWindowSize> GetBrowserWindowSize() =>
+            _browserWindowSizeProvider.GetBrowserWindowSize();
 
         /// <summary>
         /// Invoked by jsInterop, use the OnResized event handler to subscribe.
@@ -136,13 +139,13 @@ namespace MudBlazor.Services
                 return false;
             if (_windowSize.Width >= BreakpointDefinition[Breakpoint.Xl])
             {
-                if (breakpoint == Breakpoint.Xl || 
+                if (breakpoint == Breakpoint.Xl ||
                     breakpoint == Breakpoint.LgAndUp || breakpoint == Breakpoint.MdAndUp || breakpoint == Breakpoint.SmAndUp)
                     return true;
             }
             else if (_windowSize.Width >= BreakpointDefinition[Breakpoint.Lg])
             {
-                if (breakpoint == Breakpoint.Lg || 
+                if (breakpoint == Breakpoint.Lg ||
                     breakpoint == Breakpoint.LgAndUp || breakpoint == Breakpoint.MdAndUp || breakpoint == Breakpoint.SmAndUp ||
                     breakpoint == Breakpoint.LgAndDown)
                     return true;
@@ -151,17 +154,17 @@ namespace MudBlazor.Services
             {
                 if (breakpoint == Breakpoint.Md ||
                     breakpoint == Breakpoint.MdAndUp || breakpoint == Breakpoint.SmAndUp ||
-                    breakpoint == Breakpoint.MdAndDown)
+                    breakpoint == Breakpoint.MdAndDown || breakpoint == Breakpoint.LgAndDown)
                     return true;
             }
             else if (_windowSize.Width >= BreakpointDefinition[Breakpoint.Sm])
             {
                 if (breakpoint == Breakpoint.Sm ||
-                    breakpoint == Breakpoint.SmAndUp || 
-                    breakpoint == Breakpoint.SmAndDown)
+                    breakpoint == Breakpoint.SmAndUp ||
+                    breakpoint == Breakpoint.SmAndDown || breakpoint == Breakpoint.MdAndDown || breakpoint == Breakpoint.LgAndDown)
                     return true;
             }
-            else if (breakpoint == Breakpoint.Xs)
+            else if (breakpoint == Breakpoint.Xs || breakpoint == Breakpoint.SmAndDown || breakpoint == Breakpoint.MdAndDown || breakpoint == Breakpoint.LgAndDown)
                 return true;
             return false;
         }

--- a/src/MudBlazor/Services/ResizeListener/ServiceCollectionExtensions.cs
+++ b/src/MudBlazor/Services/ResizeListener/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using System;
 using MudBlazor.Services;
+using MudBlazor.Providers;
 
 namespace MudBlazor.Services
 {
@@ -14,6 +15,7 @@ namespace MudBlazor.Services
         public static IServiceCollection AddMudBlazorResizeListener(this IServiceCollection services, Action<ResizeOptions> configure)
         {
             services.AddScoped<IResizeListenerService, ResizeListenerService>();
+            services.AddScoped<IBrowserWindowSizeProvider, BrowserWindowSizeProvider>();
             services.Configure(configure);
             return services;
         }


### PR DESCRIPTION
I noticed `SmAndDown` didn't work properly when using `<MudHidden>`, @henon provided fixed code for this, I added unit tests. The tests were written using the old code and they indicated all 3 `*AndDown` returned incorrect values on the `ResizeListenerService.IsMediaSize` method. After replacing the code, the unit tests all indicated success.

Changes:
- Edited `.editorconfig` to specify indent_style = space and indent_size = 4 (my VS is set to tabs, needed to do this to get spaces)
- Created a new provider `BrowserWindowSizeProvider`/`IBrowserWindowSizeProvider`
- Moved `ResizeListenerService.GetBrowserWindowSize` to `BrowserWindowSizeProvider`.
- Made `ResizeListenerService.GetBrowserWindowSize` backwards compatible by calling the newly moved method in `BrowserWindowSizeProvider`
- Added `[Obsolete]` to `ResizeListenerService.GetBrowserWindowSize`
- Registered `BrowserWindowSizeProvider`/`IBrowserWindowSizeProvider` in `ServiceCollectionExtensions.AddMudBlazorResizeListener`
- Added Moq mocking framework to make writing unit tests much easier
- Added tests for all breakpoints, *AndUp, *AndDown
- Rewrote `IsMediaSize` method to be much easier to read and maintain