### PR TITLE
Debounced TextField

### DIFF
--- a/src/MudBlazor.Docs/Models/DocStrings.generated.cs
+++ b/src/MudBlazor.Docs/Models/DocStrings.generated.cs
@@ -1023,6 +1023,88 @@ public const string MudDatePicker_Tag = @"Use Tag to attach any user data object
 public const string MudDatePicker_UserAttributes = @"UserAttributes carries all attributes you add to the component that don't match any of its parameters. They
             will be splatted onto the underlying HTML tag.";
 
+public const string MudDebouncedInput_DebounceInterval = @"Interval to be awaited in milliseconds before changing the Text value";
+
+public const string MudDebouncedInput_OnDebounceIntervalElapsed = @"callback to be called when the debounce interval has elapsed
+            receives the Text as a parameter";
+
+public const string MudDebouncedInput_Disabled = @"";
+
+public const string MudDebouncedInput_ReadOnly = @"";
+
+public const string MudDebouncedInput_FullWidth = @"";
+
+public const string MudDebouncedInput_Immediate = @"";
+
+public const string MudDebouncedInput_DisableUnderLine = @"";
+
+public const string MudDebouncedInput_Label = @"";
+
+public const string MudDebouncedInput_Placeholder = @"";
+
+public const string MudDebouncedInput_HelperText = @"";
+
+public const string MudDebouncedInput_AdornmentIcon = @"";
+
+public const string MudDebouncedInput_AdornmentText = @"";
+
+public const string MudDebouncedInput_Adornment = @"";
+
+public const string MudDebouncedInput_IconSize = @"";
+
+public const string MudDebouncedInput_OnAdornmentClick = @"";
+
+public const string MudDebouncedInput_InputType = @"";
+
+public const string MudDebouncedInput_Variant = @"";
+
+public const string MudDebouncedInput_Margin = @"";
+
+public const string MudDebouncedInput_Lines = @"";
+
+public const string MudDebouncedInput_Text = @"";
+
+public const string MudDebouncedInput_TextChanged = @"";
+
+public const string MudDebouncedInput_OnBlur = @"";
+
+public const string MudDebouncedInput_OnKeyDown = @"";
+
+public const string MudDebouncedInput_OnKeyPress = @"";
+
+public const string MudDebouncedInput_OnKeyUp = @"";
+
+public const string MudDebouncedInput_ValueChanged = @"";
+
+public const string MudDebouncedInput_Value = @"";
+
+public const string MudDebouncedInput_Converter = @"";
+
+public const string MudDebouncedInput_Culture = @"";
+
+public const string MudDebouncedInput_Format = @"";
+
+public const string MudDebouncedInput_Required = @"";
+
+public const string MudDebouncedInput_RequiredError = @"";
+
+public const string MudDebouncedInput_ErrorText = @"";
+
+public const string MudDebouncedInput_Error = @"";
+
+public const string MudDebouncedInput_Validation = @"";
+
+public const string MudDebouncedInput_For = @"";
+
+public const string MudDebouncedInput_Class = @"User class names, separated by space";
+
+public const string MudDebouncedInput_Style = @"User styles, applied on top of the component's own classes and styles";
+
+public const string MudDebouncedInput_Tag = @"Use Tag to attach any user data object to the component for your convenience.";
+
+public const string MudDebouncedInput_UserAttributes = @"UserAttributes carries all attributes you add to the component that don't match any of its parameters. They
+            will be splatted onto the underlying HTML tag.";
+
 public const string MudDialog_DialogContent = @"";
 
 public const string MudDialog_DialogActions = @"";
@@ -2671,6 +2753,10 @@ public const string MudText_Tag = @"Use Tag to attach any user data object to th
 public const string MudText_UserAttributes = @"UserAttributes carries all attributes you add to the component that don't match any of its parameters. They
             will be splatted onto the underlying HTML tag.";
 
+public const string MudTextField_DebounceInterval = @"";
+
+public const string MudTextField_OnDebounceIntervalElapsed = @"";
+
 public const string MudTextField_Disabled = @"";
 
 public const string MudTextField_ReadOnly = @"";
@@ -2747,6 +2833,11 @@ public const string MudTextField_Tag = @"Use Tag to attach any user data object 
 
 public const string MudTextField_UserAttributes = @"UserAttributes carries all attributes you add to the component that don't match any of its parameters. They
             will be splatted onto the underlying HTML tag.";
+
+public const string MudTextFieldString_DebounceInterval = @"Interval to be awaited in milliseconds before changing the Text value";
+
+public const string MudTextFieldString_OnDebounceIntervalElapsed = @"callback to be called when the debounce interval has elapsed
+            receives the Text as a parameter";
 
 public const string MudTextFieldString_Disabled = @"If true, the input element will be disabled.";
 

--- a/src/MudBlazor.Docs/Models/Snippets.generated.cs
+++ b/src/MudBlazor.Docs/Models/Snippets.generated.cs
@@ -3129,6 +3129,35 @@ public const string TabsWithBagdesExample = @"<MudTabs Elevation=""1"" Rounded="
 
 public const string TemplateExample = @"";
 
+public const string DebouncedTextFieldExample = @"@using MudBlazor.Docs.Data 
+<MudGrid>
+    <MudItem xs=""12"" sm=""6"">
+        <MudTextField @bind-Value=""@_searchText""
+                      Label=""Search""
+                      Variant=""Variant.Outlined""
+                      Adornment=""Adornment.End""
+                      AdornmentIcon=""@Filled.Search""
+                      DebounceInterval=""500""
+                      OnDebounceIntervalElapsed=""HandleIntervalElapsed""/>
+    </MudItem>
+</MudGrid>
+<div>
+    <MudText Typo=""@MudBlazor.Typo.h6"">Search text:</MudText>
+    <MudText>@_searchText</MudText>
+</div>
+
+
+@code { 
+    string _searchText;
+
+    void HandleIntervalElapsed(string debouncedText)
+    {
+        // at this stage, interval has elapsed
+    }
+
+
+}";
+
 public const string TextFieldAdornmentsExample = @"<MudGrid>
     <MudItem xs=""12"" sm=""12"" md=""12"">
         <MudTextField @bind-Value=""Amount"" Label=""Amount"" Variant=""Variant.Text"" Adornment=""Adornment.Start"" AdornmentText=""Kr"" />

--- a/src/MudBlazor.Docs/Pages/Components/TextField/Code/DebouncedTextFieldExampleCode.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TextField/Code/DebouncedTextFieldExampleCode.razor
@@ -1,0 +1,34 @@
+@* Auto-generated markup. Any changes will be overwritten *@
+@namespace MudBlazor.Docs.Examples.Markup
+<div class="mud-codeblock">
+<div class="html"><pre>
+<span class="atSign">&#64;</span>using MudBlazor.Docs.Data 
+<span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">MudGrid</span><span class="htmlTagDelimiter">&gt;</span>
+    <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">MudItem</span> <span class="htmlAttributeName">xs</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">12</span><span class="quot">&quot;</span> <span class="htmlAttributeName">sm</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">6</span><span class="quot">&quot;</span><span class="htmlTagDelimiter">&gt;</span>
+        <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">MudTextField</span> <span class="htmlAttributeName"><span class="atSign">&#64;</span>bind-Value</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue"><span class="atSign">&#64;</span>_searchText</span><span class="quot">&quot;</span>
+                      <span class="htmlAttributeName">Label</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">Search</span><span class="quot">&quot;</span>
+                      <span class="htmlAttributeName">Variant</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="enum">Variant</span><span class="enumValue">.Outlined</span><span class="quot">&quot;</span>
+                      <span class="htmlAttributeName">Adornment</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="enum">Adornment</span><span class="enumValue">.End</span><span class="quot">&quot;</span>
+                      <span class="htmlAttributeName">AdornmentIcon</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue"><span class="atSign">&#64;</span>Filled.Search</span><span class="quot">&quot;</span>
+                      <span class="htmlAttributeName">DebounceInterval</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">500</span><span class="quot">&quot;</span>
+                      <span class="htmlAttributeName">OnDebounceIntervalElapsed</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">HandleIntervalElapsed</span><span class="quot">&quot;</span><span class="htmlTagDelimiter">/&gt;</span>
+    <span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">MudItem</span><span class="htmlTagDelimiter">&gt;</span>
+<span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">MudGrid</span><span class="htmlTagDelimiter">&gt;</span>
+<span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">div</span><span class="htmlTagDelimiter">&gt;</span>
+    <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">MudText</span> <span class="htmlAttributeName">Typo</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue"><span class="atSign">&#64;</span>MudBlazor.Typo.h6</span><span class="quot">&quot;</span><span class="htmlTagDelimiter">&gt;</span>Search text:<span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">MudText</span><span class="htmlTagDelimiter">&gt;</span>
+    <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">MudText</span><span class="htmlTagDelimiter">&gt;</span><span class="atSign">&#64;</span>_searchText<span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">MudText</span><span class="htmlTagDelimiter">&gt;</span>
+<span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">div</span><span class="htmlTagDelimiter">&gt;</span>
+</pre></div>
+<div class="csharp"><pre>
+<span class="atSign">&#64;</span>code { 
+    <span class="keyword">string</span> _searchText;
+
+    <span class="keyword">void</span> HandleIntervalElapsed(<span class="keyword">string</span> debouncedText)
+    {
+        <span class="comment">// at this stage, interval has elapsed</span>
+    }
+
+
+}
+</pre></div>
+</div>

--- a/src/MudBlazor.Docs/Pages/Components/TextField/Examples/DebouncedTextFieldExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TextField/Examples/DebouncedTextFieldExample.razor
@@ -1,0 +1,29 @@
+﻿@namespace MudBlazor.Docs.Examples
+@using MudBlazor.Docs.Data 
+<MudGrid>
+    <MudItem xs="12" sm="6">
+        <MudTextField @bind-Value="@_searchText"
+                      Label="Search"
+                      Variant="Variant.Outlined"
+                      Adornment="Adornment.End"
+                      AdornmentIcon="@Filled.Search"
+                      DebounceInterval="500"
+                      OnDebounceIntervalElapsed="HandleIntervalElapsed"/>
+    </MudItem>
+</MudGrid>
+<div>
+    <MudText Typo="@MudBlazor.Typo.h6">Search text:</MudText>
+    <MudText>@_searchText</MudText>
+</div>
+
+
+@code { 
+    string _searchText;
+
+    void HandleIntervalElapsed(string debouncedText)
+    {
+        // at this stage, interval has elapsed
+    }
+
+
+}

--- a/src/MudBlazor.Docs/Pages/Components/TextField/TextFieldPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TextField/TextFieldPage.razor
@@ -56,6 +56,16 @@
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>
+                <Title>Debounced TextFields</Title>
+                <Description>Debounce your <CodeInline>TextField</CodeInline> setting the <CodeInline>DebounceInterval</CodeInline> parameter to the amount of milliseconds you want to await before updating the binded value. If you need to know when the interval elapses, you can pass an <CodeInline>OnDebounceIntervalElapsed</CodeInline> EventCallback. Notice how, in this example, it only updates the text 500 ms after you stop typing</Description>
+            </SectionHeader>
+            <SectionContent Outlined="true" FullWidth="true">
+                <DebouncedTextFieldExample />
+            </SectionContent>
+            <SectionSource Code="DebouncedTextFieldExample" ShowCode="false" GitHubFolderName="TextField" />
+        </DocsPageSection>
+        <DocsPageSection>
+            <SectionHeader>
                 <Title>Multiline</Title>
                 <Description></Description>
             </SectionHeader>

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.DependencyInjection;
 using MudBlazor.UnitTests.Mocks;
 using NUnit.Framework;
 using static MudBlazor.UnitTests.SelectWithEnumTest;
+using static Bunit.ComponentParameterFactory;
 
 namespace MudBlazor.UnitTests
 {
@@ -58,6 +59,66 @@ namespace MudBlazor.UnitTests
             textfield.Value.Should().Be(null);
             textfield.Text.Should().BeNullOrEmpty();
         }
+
+        /// <summary>
+        /// If Debounce Interval is null or 0, Value should change immediately
+        /// </summary>
+        [Test]
+        public void WithNoDebounceIntervalValueShouldChangeImmediatelyTest()
+        {
+            //Arrange
+            using var ctx = new Bunit.TestContext();
+            //no interval passed, so, by default is 0
+            // We pass the Immediate parameter set to true, in order to bind to oninput
+            var immediate = Parameter(nameof(MudTextField<string>.Immediate), true);
+            var comp = ctx.RenderComponent<MudTextField<string>>(immediate);
+            var textField = comp.Instance;
+            var input = comp.Find("input");
+
+            //Act
+            input.Input(new ChangeEventArgs() { Value = "Some Value" });
+
+            //Assert
+            //input value has changed, DebounceInterval is 0, so Value should change in TextField immediately
+          
+            textField.Value.Should().Be("Some Value");
+        }
+
+
+        /// <summary>
+        /// Value should not change immediately. Should respect the Debounce Interval
+        /// </summary>
+        [Test]
+        public async Task ShouldRespectDebounceIntervalPropertyInTextFieldTest()
+        {
+            //Arrange
+            using var ctx = new Bunit.TestContext();
+            var interval = Parameter(nameof(MudTextField<string>.DebounceInterval), 1000d);
+            var comp = ctx.RenderComponent<MudTextField<string>>(interval);
+            var textField = comp.Instance;
+            var input = comp.Find("input");
+            
+            //Act
+            input.Input(new ChangeEventArgs() { Value = "Some Value" });
+
+            //Assert
+            //if DebounceInterval is set, Immediate should be true by default
+            textField.Immediate.Should().BeTrue();
+
+            //input value has changed, but elapsed time is 0, so Value should not change in TextField
+            textField.Value.Should().BeNull();
+
+            //DebounceInterval is 1000 ms, so at 500 ms Value should not change in TextField
+            await Task.Delay(500);
+            textField.Value.Should().BeNull();
+
+            //More than 1000 ms had elapsed, so Value should be updated
+            await Task.Delay(510);
+            textField.Value.Should().Be("Some Value");
+        }
+
+
+
 
     }
 }

--- a/src/MudBlazor.UnitTests/Generated/_AllApiPages.cs
+++ b/src/MudBlazor.UnitTests/Generated/_AllApiPages.cs
@@ -415,6 +415,20 @@ namespace MudBlazor.UnitTests.Components
 
 
         [Test]
+        public void MudDebouncedInput_API_Test()
+        {
+                using var ctx = new Bunit.TestContext();
+                ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager());
+                ctx.Services.AddSingleton<IDialogService>(new DialogService());
+                ctx.Services.AddSingleton<IResizeListenerService>(new MockResizeListenerService());
+                ctx.Services.AddSingleton<IHeadElementHelper>(new MockHeadElementHelper());
+                ctx.Services.AddSingleton<ISnackbar>(new MockSnackbar());
+                var comp = ctx.RenderComponent<DocsApi>(ComponentParameter.CreateParameter("Type", typeof(MudDebouncedInput<T>)));
+                Console.WriteLine(comp.Markup);
+         }
+
+
+        [Test]
         public void MudDialog_API_Test()
         {
                 using var ctx = new Bunit.TestContext();

--- a/src/MudBlazor.UnitTests/Generated/_AllComponents.cs
+++ b/src/MudBlazor.UnitTests/Generated/_AllComponents.cs
@@ -2165,6 +2165,18 @@ namespace MudBlazor.UnitTests.Components
 
 
         [Test]
+        public void DebouncedTextFieldExample_Test()
+        {
+                using var ctx = new Bunit.TestContext();
+                ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager());
+                ctx.Services.AddSingleton<IDialogService>(new DialogService());
+                ctx.Services.AddSingleton<ISnackbar>(new MockSnackbar());
+                ctx.Services.AddSingleton<IResizeListenerService>(new MockResizeListenerService());
+                var comp = ctx.RenderComponent<DebouncedTextFieldExample>();
+        }
+
+
+        [Test]
         public void TextFieldAdornmentsExample_Test()
         {
                 using var ctx = new Bunit.TestContext();

--- a/src/MudBlazor/Components/Input/MudDebouncedInput.cs
+++ b/src/MudBlazor/Components/Input/MudDebouncedInput.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using MudBlazor.Utilities;
+using System.Timers;
+
+namespace MudBlazor
+{
+    public partial class MudDebouncedInput<T> : MudBaseInput<T>, IDisposable
+    {
+
+        private Timer _timer;
+
+        /// <summary>
+        /// Interval to be awaited in milliseconds before changing the Text value
+        /// </summary>
+        [Parameter] public double DebounceInterval { get; set; }
+
+        /// <summary>
+        /// callback to be called when the debounce interval has elapsed
+        /// receives the Text as a parameter
+        /// </summary>
+        [Parameter] public EventCallback<string> OnDebounceIntervalElapsed { get; set; }
+
+        protected override void StringValueChanged(string text)
+        {
+            //setting the Text property
+
+            if (DebounceInterval == 0)
+            {
+                base.StringValueChanged(text);
+                return;
+            }
+            //stops previous timer
+            _timer.Stop();
+
+            //starts the timer while user is typing
+            _timer.Start();
+        }
+
+        /// <summary>
+        /// It triggers when the interval has elapsed
+        /// </summary>
+        /// <param name="_">discard, not used</param>
+        /// <param name="__">discard, not used</param>
+        private void OnTimerComplete(object _, ElapsedEventArgs __)
+        {
+            base.StringValueChanged(Text);
+            OnDebounceIntervalElapsed.InvokeAsync(Text);
+        }
+
+        protected override Task OnParametersSetAsync()
+        {
+            if (DebounceInterval != 0)
+            {
+                //if input is to be debounced, makes sense to bind the change of the text to oninput
+                //so we set Immediate to true
+                Immediate = true;
+                SetTimer();
+            }
+            return base.OnParametersSetAsync();
+        }
+
+        /// <summary>
+        /// creates the timer 
+        /// </summary>
+        private void SetTimer()
+        {
+            _timer = new Timer(DebounceInterval);
+            _timer.Elapsed += OnTimerComplete;
+            _timer.AutoReset = false;
+        }
+
+        /// <summary>
+        /// cleaning
+        /// </summary>
+        public void Dispose()
+        {
+            if (_timer == null) return;
+            _timer.Elapsed -= OnTimerComplete;
+            _timer.Dispose();
+        }
+
+
+    }
+
+
+}

--- a/src/MudBlazor/Components/TextField/MudTextField.razor
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor
 @typeparam T
-@inherits MudBaseInput<T>
+@inherits MudDebouncedInput<T>
 
 <CascadingValue Name="Standalone" Value="false" IsFixed="true">
     <MudInputControl Label="@Label" Variant="@Variant" HelperText="@HelperText" FullWidth="@FullWidth" Error="@HasErrors" ErrorText="@GetErrorText()" Disabled="@Disabled" Margin="@Margin" Required="@Required">

--- a/src/MudBlazor/Components/TextField/MudTextField.razor.cs
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Components.Web;
 
 namespace MudBlazor
 {
-    public partial class MudTextField<T> : MudBaseInput<T>
+    public partial class MudTextField<T> : MudDebouncedInput<T>
     {
         protected string Classname =>
            new CssBuilder("mud-input-input-control").AddClass(Class)


### PR DESCRIPTION
This adds `MudDebouncedInput` class in order to provide `TextField `with capabilities to perform debounced searches.
`TextField `now inherits from `MudDebouncedInput`, instead from `MudBaseInput`.
The two parameters that `MudDebounceInput `adds are double `DebounceInterval `(named this way after the same property in Autocomplete) and an `EventCallback<string> OnDebounceIntervalElapsed,` that triggers when the interval has elapsed.
Also, if `DebounceInterval `is set, Immediate is set to true automatically.
Added example in `TextFieldPage`
Added tests for this new functionality in `TextField`