### PR TITLE
Fixes for Table's Commit Edit Command

### DIFF
--- a/src/MudBlazor.Docs/Models/DocStrings.generated.cs
+++ b/src/MudBlazor.Docs/Models/DocStrings.generated.cs
@@ -2499,7 +2499,7 @@ public const string MudTable_OnCommitEditClick = @"Button click event.";
 
 public const string MudTable_CommitEditCommand = @"Command executed when the user clicks on the CommitEdit Button.";
 
-public const string MudTable_CommitEditCommandParameter = @"Command parameter for the CommitEdit Button.";
+public const string MudTable_CommitEditCommandParameter = @"Command parameter for the CommitEdit Button. By default, will be the row level item model, if you won't set anything else.";
 
 public const string MudTable_CommitEditTooltip = @"Tooltip for the CommitEdit Button.";
 
@@ -2560,7 +2560,7 @@ public const string MudTableBase_OnCommitEditClick = @"Button click event.";
 
 public const string MudTableBase_CommitEditCommand = @"Command executed when the user clicks on the CommitEdit Button.";
 
-public const string MudTableBase_CommitEditCommandParameter = @"Command parameter for the CommitEdit Button.";
+public const string MudTableBase_CommitEditCommandParameter = @"Command parameter for the CommitEdit Button. By default, will be the row level item model, if you won't set anything else.";
 
 public const string MudTableBase_CommitEditTooltip = @"Tooltip for the CommitEdit Button.";
 
@@ -2846,6 +2846,44 @@ public const string MudTh_ChildContent = @"";
 public const string MudTh_Style = @"";
 
 public const string MudThemeProvider_Theme = @"";
+
+public const string MudTimeLine_Rounded = @"If true, sets the border-radius to theme default.";
+
+public const string MudTimeLine_Border = @"If true, sets a border.";
+
+public const string MudTimeLine_Outlined = @"If true, toolbar will be outlined.";
+
+public const string MudTimeLine_Elevation = @"Child content of component.";
+
+public const string MudTimeLine_ChildContent = @"Child content of component.";
+
+public const string MudTimeLine_Class = @"User class names, separated by space";
+
+public const string MudTimeLine_Style = @"User styles, applied on top of the component's own classes and styles";
+
+public const string MudTimeLine_Tag = @"Use Tag to attach any user data object to the component for your convenience.";
+
+public const string MudTimeLine_UserAttributes = @"UserAttributes carries all attributes you add to the component that don't match any of its parameters. They
+            will be splatted onto the underlying HTML tag.";
+
+public const string MudTimeLineItem_Elevation = @"Child content of component.";
+
+public const string MudTimeLineItem_Align = @"TimeLineItem's Alignment on main TimeLine component";
+
+public const string MudTimeLineItem_Icon = @"Icon for the TimeLineItem";
+
+public const string MudTimeLineItem_Color = @"Color for the TimeLineItem symbol";
+
+public const string MudTimeLineItem_ChildContent = @"Child content of component.";
+
+public const string MudTimeLineItem_Class = @"User class names, separated by space";
+
+public const string MudTimeLineItem_Style = @"User styles, applied on top of the component's own classes and styles";
+
+public const string MudTimeLineItem_Tag = @"Use Tag to attach any user data object to the component for your convenience.";
+
+public const string MudTimeLineItem_UserAttributes = @"UserAttributes carries all attributes you add to the component that don't match any of its parameters. They
+            will be splatted onto the underlying HTML tag.";
 
 public const string MudTimePicker_OpenTo = @"First view to show in the MudDatePicker.";
 

--- a/src/MudBlazor.Docs/Models/Snippets.generated.cs
+++ b/src/MudBlazor.Docs/Models/Snippets.generated.cs
@@ -3107,7 +3107,7 @@ public const string TableFixedHeaderExample = @"@using MudBlazor.Docs.Data
 public const string TableInlineEditExample = @"@using MudBlazor.Docs.Data
 @inject ISnackbar Snackbar
 
-<MudTable Items=""@PeriodicTable.GetElements()"" Dense=""@dense"" Hover=""@hover"" Filter=""new Func<Element,bool>(FilterFunc)"" @bind-SelectedItem=""selected_item"" SortLabel=""Sort By"" CommitEditTooltip=""Commit Edit"" OnCommitEditClick=""@(() => Snackbar.Add(""Commit Edit Handler Invoked""))"">
+<MudTable Items=""@PeriodicTable.GetElements()"" Dense=""@dense"" Hover=""@hover"" Filter=""new Func<Element,bool>(FilterFunc)"" @bind-SelectedItem=""selected_item"" SortLabel=""Sort By"" CommitEditTooltip=""Commit Edit"" OnCommitEditClick=""@(() => Snackbar.Add(""Commit Edit Handler Invoked""))"" CommitEditCommand=""@samplecmd"">
     <ToolBarContent>
         <MudText Typo=""Typo.h6"">Periodic Elements</MudText>
         <MudToolBarSpacer />
@@ -3166,6 +3166,12 @@ public const string TableInlineEditExample = @"@using MudBlazor.Docs.Data
     Element selected_item = null;
     HashSet<Element> selected_items = new HashSet<Element>();
 
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+        samplecmd = new Utilities.SampleCommand(SampleCommand_Executed);
+    }
+
     bool FilterFunc(Element element)
     {
         if (string.IsNullOrWhiteSpace(search_string))
@@ -3178,6 +3184,14 @@ public const string TableInlineEditExample = @"@using MudBlazor.Docs.Data
             return true;
         return false;
     }
+
+    private Utilities.SampleCommand samplecmd;
+
+    private void SampleCommand_Executed(object parameter)
+    {
+        Snackbar.Add($""Commit Edit Command Executed for parameter '{parameter.ToString()}'"");
+    }
+
 }";
 
 public const string TableMultiSelectExample = @"@using MudBlazor.Docs.Data

--- a/src/MudBlazor.Docs/Pages/Components/Table/Code/TableInlineEditExampleCode.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Code/TableInlineEditExampleCode.razor
@@ -5,7 +5,7 @@
 <span class="atSign">&#64;</span>using MudBlazor.Docs.Data
 <span class="atSign">&#64;</span>inject ISnackbar Snackbar
 
-<span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">MudTable</span> <span class="htmlAttributeName">Items</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue"><span class="atSign">&#64;</span>PeriodicTable.GetElements()</span><span class="quot">&quot;</span> <span class="htmlAttributeName">Dense</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="sharpVariable"><span class="atSign">&#64;</span>dense</span><span class="quot">&quot;</span> <span class="htmlAttributeName">Hover</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="sharpVariable"><span class="atSign">&#64;</span>hover</span><span class="quot">&quot;</span> <span class="htmlAttributeName">Filter</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">new Func&lt;Element,bool&gt;(FilterFunc)</span><span class="quot">&quot;</span> <span class="htmlAttributeName"><span class="atSign">&#64;</span>bind-SelectedItem</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">selected_item</span><span class="quot">&quot;</span> <span class="htmlAttributeName">SortLabel</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">Sort By</span><span class="quot">&quot;</span> <span class="htmlAttributeName">CommitEditTooltip</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">Commit Edit</span><span class="quot">&quot;</span> <span class="htmlAttributeName">OnCommitEditClick</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue"><span class="atSign">&#64;</span>(() =&gt; Snackbar.Add(&quot;Commit Edit Handler Invoked&quot;))</span><span class="quot">&quot;</span><span class="htmlTagDelimiter">&gt;</span>
+<span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">MudTable</span> <span class="htmlAttributeName">Items</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue"><span class="atSign">&#64;</span>PeriodicTable.GetElements()</span><span class="quot">&quot;</span> <span class="htmlAttributeName">Dense</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="sharpVariable"><span class="atSign">&#64;</span>dense</span><span class="quot">&quot;</span> <span class="htmlAttributeName">Hover</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="sharpVariable"><span class="atSign">&#64;</span>hover</span><span class="quot">&quot;</span> <span class="htmlAttributeName">Filter</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">new Func&lt;Element,bool&gt;(FilterFunc)</span><span class="quot">&quot;</span> <span class="htmlAttributeName"><span class="atSign">&#64;</span>bind-SelectedItem</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">selected_item</span><span class="quot">&quot;</span> <span class="htmlAttributeName">SortLabel</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">Sort By</span><span class="quot">&quot;</span> <span class="htmlAttributeName">CommitEditTooltip</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">Commit Edit</span><span class="quot">&quot;</span> <span class="htmlAttributeName">OnCommitEditClick</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue"><span class="atSign">&#64;</span>(() =&gt; Snackbar.Add(&quot;Commit Edit Handler Invoked&quot;))</span><span class="quot">&quot;</span> <span class="htmlAttributeName">CommitEditCommand</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="sharpVariable"><span class="atSign">&#64;</span>samplecmd</span><span class="quot">&quot;</span><span class="htmlTagDelimiter">&gt;</span>
     <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">ToolBarContent</span><span class="htmlTagDelimiter">&gt;</span>
         <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">MudText</span> <span class="htmlAttributeName">Typo</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="enum">Typo</span><span class="enumValue">.h6</span><span class="quot">&quot;</span><span class="htmlTagDelimiter">&gt;</span>Periodic Elements<span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">MudText</span><span class="htmlTagDelimiter">&gt;</span>
         <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">MudToolBarSpacer</span> <span class="htmlTagDelimiter">/&gt;</span>
@@ -65,6 +65,12 @@
     Element selected_item = <span class="keyword">null</span>;
     HashSet&lt;Element&gt; selected_items = <span class="keyword">new</span> HashSet&lt;Element&gt;();
 
+    <span class="keyword">protected</span> <span class="keyword">override</span> <span class="keyword">void</span> OnInitialized()
+    {
+        <span class="keyword">base</span>.OnInitialized();
+        samplecmd = <span class="keyword">new</span> Utilities.SampleCommand(SampleCommand_Executed);
+    }
+
     <span class="keyword">bool</span> FilterFunc(Element element)
     {
         <span class="keyword">if</span> (<span class="keyword">string</span>.IsNullOrWhiteSpace(search_string))
@@ -77,6 +83,14 @@
             <span class="keyword">return</span> <span class="keyword">true</span>;
         <span class="keyword">return</span> <span class="keyword">false</span>;
     }
+
+    <span class="keyword">private</span> Utilities.SampleCommand samplecmd;
+
+    <span class="keyword">private</span> <span class="keyword">void</span> SampleCommand_Executed(<span class="keyword">object</span> parameter)
+    {
+        Snackbar.Add($<span class="string">&quot;Commit Edit Command Executed for parameter &#39;{parameter.ToString()}&#39;&quot;</span>);
+    }
+
 }
 </pre></div>
 </div>

--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableInlineEditExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableInlineEditExample.razor
@@ -2,7 +2,7 @@
 @inject ISnackbar Snackbar
 @namespace MudBlazor.Docs.Examples
 
-<MudTable Items="@PeriodicTable.GetElements()" Dense="@dense" Hover="@hover" Filter="new Func<Element,bool>(FilterFunc)" @bind-SelectedItem="selected_item" SortLabel="Sort By" CommitEditTooltip="Commit Edit" OnCommitEditClick="@(() => Snackbar.Add("Commit Edit Handler Invoked"))">
+<MudTable Items="@PeriodicTable.GetElements()" Dense="@dense" Hover="@hover" Filter="new Func<Element,bool>(FilterFunc)" @bind-SelectedItem="selected_item" SortLabel="Sort By" CommitEditTooltip="Commit Edit" OnCommitEditClick="@(() => Snackbar.Add("Commit Edit Handler Invoked"))" CommitEditCommand="@samplecmd">
     <ToolBarContent>
         <MudText Typo="Typo.h6">Periodic Elements</MudText>
         <MudToolBarSpacer />
@@ -61,6 +61,12 @@
     Element selected_item = null;
     HashSet<Element> selected_items = new HashSet<Element>();
 
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+        samplecmd = new Utilities.SampleCommand(SampleCommand_Executed);
+    }
+
     bool FilterFunc(Element element)
     {
         if (string.IsNullOrWhiteSpace(search_string))
@@ -73,4 +79,12 @@
             return true;
         return false;
     }
+
+    private Utilities.SampleCommand samplecmd;
+
+    private void SampleCommand_Executed(object parameter)
+    {
+        Snackbar.Add($"Commit Edit Command Executed for parameter '{parameter.ToString()}'");
+    }
+
 }

--- a/src/MudBlazor.Docs/Utilities/SampleCommand.cs
+++ b/src/MudBlazor.Docs/Utilities/SampleCommand.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Windows.Input;
+
+namespace MudBlazor.Docs.Utilities
+{
+    public class SampleCommand : ICommand
+    {
+        public SampleCommand(Action<object> execute)
+        {
+            Action = execute;
+        }
+
+        public Action<object> Action { get; } = null;
+        public void Execute(object parameter)
+        {
+            if (Action != null)
+                Action(parameter);
+        }
+
+
+        public bool CanExecute(object parameter)
+        {
+            return true;
+        }
+        public event EventHandler CanExecuteChanged;
+
+    }
+}

--- a/src/MudBlazor.UnitTests/Generated/_AllApiPages.cs
+++ b/src/MudBlazor.UnitTests/Generated/_AllApiPages.cs
@@ -1302,6 +1302,34 @@ namespace MudBlazor.UnitTests.Components
 
 
         [Test]
+        public void MudTimeLine_API_Test()
+        {
+                using var ctx = new Bunit.TestContext();
+                ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager());
+                ctx.Services.AddSingleton<IDialogService>(new DialogService());
+                ctx.Services.AddSingleton<IResizeListenerService>(new MockResizeListenerService());
+                ctx.Services.AddSingleton<IHeadElementHelper>(new MockHeadElementHelper());
+                ctx.Services.AddSingleton<ISnackbar>(new MockSnackbar());
+                var comp = ctx.RenderComponent<DocsApi>(ComponentParameter.CreateParameter("Type", typeof(MudTimeLine)));
+                Console.WriteLine(comp.Markup);
+         }
+
+
+        [Test]
+        public void MudTimeLineItem_API_Test()
+        {
+                using var ctx = new Bunit.TestContext();
+                ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager());
+                ctx.Services.AddSingleton<IDialogService>(new DialogService());
+                ctx.Services.AddSingleton<IResizeListenerService>(new MockResizeListenerService());
+                ctx.Services.AddSingleton<IHeadElementHelper>(new MockHeadElementHelper());
+                ctx.Services.AddSingleton<ISnackbar>(new MockSnackbar());
+                var comp = ctx.RenderComponent<DocsApi>(ComponentParameter.CreateParameter("Type", typeof(MudTimeLineItem)));
+                Console.WriteLine(comp.Markup);
+         }
+
+
+        [Test]
         public void MudTimePicker_API_Test()
         {
                 using var ctx = new Bunit.TestContext();

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -145,9 +145,9 @@ namespace MudBlazor
         [Parameter] public ICommand CommitEditCommand { get; set; }
 
         /// <summary>
-        /// Command parameter for the CommitEdit Button.
+        /// Command parameter for the CommitEdit Button. By default, will be the row level item model, if you won't set anything else.
         /// </summary>
-        [Parameter] public string CommitEditCommandParameter { get; set; }
+        [Parameter] public object CommitEditCommandParameter { get; set; }
 
         /// <summary>
         /// Tooltip for the CommitEdit Button.
@@ -189,12 +189,15 @@ namespace MudBlazor
 
         public abstract void SetEditingItem(object item);
 
-        internal async Task OnCommitEditHandler(MouseEventArgs ev)
+        internal async Task OnCommitEditHandler(MouseEventArgs ev, object item)
         {
             await OnCommitEditClick.InvokeAsync(ev);
             if (CommitEditCommand?.CanExecute(CommitEditCommandParameter) ?? false)
             {
-                CommitEditCommand.Execute(CommitEditCommandParameter);
+                object parameter = CommitEditCommandParameter;
+                if (parameter == null)
+                    parameter = item;
+                CommitEditCommand.Execute(parameter);
             }
         }
 

--- a/src/MudBlazor/Components/Table/MudTr.razor
+++ b/src/MudBlazor/Components/Table/MudTr.razor
@@ -117,7 +117,7 @@
     {
         Context?.Table.SetEditingItem(null);
         _lockeditingentry = true;
-        Context?.Table.OnCommitEditHandler(ev);
+        Context?.Table.OnCommitEditHandler(ev, Item);
     }
 
 }


### PR DESCRIPTION
Work made:

 - Changed CommitEditCommandParameter Property from string to object;
 - Added (object)Item as parameter on OnCommitEditHandler void;
 - Implemented row level item as CommitEditCommand.Execute, if CommitEditCommandParameter  is null;
 - Added CommitEditCommand usage on Docs sample.

I would like to request a review to @henon , when possible.

Thanks.
