### PR TITLE
fix scroll after navigation

### DIFF
--- a/src/MudBlazor/Styles/core/_base.scss
+++ b/src/MudBlazor/Styles/core/_base.scss
@@ -6,7 +6,7 @@
     -moz-osx-font-smoothing: grayscale;
 }
 
-html,svg {
+svg {
     height: 100%;
 }
 


### PR DESCRIPTION
This fixes #297
```
html{
height:100%
}
```
This CSS rule is preventing Blazor default scroll to top after navigation to work properly.
I found out that Blazor already has implemented the default browser behavior of scroll to top after navigate to another page (see [this](https://github.com/dotnet/aspnetcore/blob/577f1a760fb56f67f59aa1057458a1bc0c6730e8/src/Components/Web.JS/src/Rendering/Renderer.ts#L82)) , but MudBlazor CSS layout is fighting against it.
I think that `html{height:100%}` has the same effect that  `html{height:100vh}`, limiting to the size of the screen the height of the body, that already has an unnecessary `body{height:100%}` .

So, if we remove the html height setting, everything works.
I think that the basic layout has to be reconsidered to use best practices to not limit body scroll, that is something unexpected.
I get that is more aesthetic to have the scroll bar under the navbar, but there should be another ways to get it. And the scroll functionality is more important than this minor aesthetic change.

This
![image](https://user-images.githubusercontent.com/13745954/102259646-4632fe00-3f07-11eb-8bdd-d73f184f42d8.png)

changes into this
![image](https://user-images.githubusercontent.com/13745954/102259706-5a76fb00-3f07-11eb-86bf-e6cd131f2c83.png)


