### PR TITLE
Use binary Docs.Compiler if available

### DIFF
--- a/src/MudBlazor.Docs/MudBlazor.Docs.csproj
+++ b/src/MudBlazor.Docs/MudBlazor.Docs.csproj
@@ -11,9 +11,27 @@
     <SolutionDir Condition=" '$(SolutionDir)' == '' ">$(MSBuildThisFileDirectory)..\</SolutionDir>
   </PropertyGroup>
 
+  <Choose>
+    <When Condition="Exists('$(SolutionDir)MudBlazor.Docs.Compiler/bin/Debug/netcoreapp3.1/MudBlazor.Docs.Compiler.dll')">
+      <PropertyGroup>
+        <RunCommand>dotnet "$(SolutionDir)MudBlazor.Docs.Compiler//bin/Debug/netcoreapp3.1/MudBlazor.Docs.Compiler.dll"</RunCommand>
+      </PropertyGroup>
+    </When>
+    <When Condition="Exists('$(SolutionDir)MudBlazor.Docs.Compiler/bin/Debug/net5.0/MudBlazor.Docs.Compiler.dll')">
+      <PropertyGroup>
+        <RunCommand>dotnet "$(SolutionDir)MudBlazor.Docs.Compiler//bin/Debug/net5.0/MudBlazor.Docs.Compiler.dll"</RunCommand>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <RunCommand>dotnet run --configuration release --project "$(SolutionDir)MudBlazor.Docs.Compiler/MudBlazor.Docs.Compiler.csproj"</RunCommand>
+      </PropertyGroup>     
+    </Otherwise>
+  </Choose>
+
   <Target Name="CompileDocs" BeforeTargets="BeforeBuild;BeforeRebuild" DependsOnTargets="IncludeGeneratedFiles">
-    <Message Text="Generating Docs and Tests" Importance="high"/>
-    <Exec Command='dotnet run --configuration release --project "$(SolutionDir)MudBlazor.Docs.Compiler/MudBlazor.Docs.Compiler.csproj"' />
+    <Message Text="Generating Docs and Tests using $(RunCommand)" Importance="high"/>
+    <Exec Command='$(RunCommand)' />
   </Target>
 
   <Target Name="IncludeGeneratedFiles" BeforeTargets="BeforeBuild;BeforeRebuild" >


### PR DESCRIPTION
- Change the csproj to use compiled `Docs.Compiler` if available.
- Saves a couple of seconds in the dev cycle.
@henon 