### PR TITLE
Feature mud element in button

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Button/ButtonPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Button/ButtonPage.razor
@@ -76,5 +76,16 @@
             </SectionContent>
             <SectionSource Code="ButtonCustomizedExample" ShowCode="false" GitHubFolderName="Button" SnippetId="GuPYFNEY23jaQ3gK26" />
         </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader>
+                <Title>Link Button</Title>
+                <Description>Set the <CodeInline>Link</CodeInline> parameter and the MudButton will render an anchor element. If you also set the <CodeInline>Target</CodeInline> parameter to <CodeInline>_blank</CodeInline>, the component will add <CodeInline>rel="noopener"</CodeInline> automatically</Description>
+            </SectionHeader>
+            <SectionContent Outlined="true">
+                <ButtonLinkExample />
+            </SectionContent>
+            <SectionSource Code="ButtonLinkExample" ShowCode="true" GitHubFolderName="Button"/>
+        </DocsPageSection>
     </DocsPageContent>
 </DocsPage>

--- a/src/MudBlazor.Docs/Pages/Components/Button/Code/ButtonLinkExampleCode.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Button/Code/ButtonLinkExampleCode.razor
@@ -1,0 +1,16 @@
+@* Auto-generated markup. Any changes will be overwritten *@
+@namespace MudBlazor.Docs.Examples.Markup
+<div class="mud-codeblock">
+<div class="html"><pre>
+Visit our <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">MudButton</span> <span class="htmlAttributeName">Link</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">https://github.com/Garderoben/MudBlazor</span><span class="quot">&quot;</span>
+                      <span class="htmlAttributeName">Target</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">_blank</span><span class="quot">&quot;</span>
+                      <span class="htmlAttributeName">Variant</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="enum">Variant</span><span class="enumValue">.Text</span><span class="quot">&quot;</span>
+                      <span class="htmlAttributeName">EndIcon</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue"><span class="atSign">&#64;</span>Icons.Custom.GitHub</span><span class="quot">&quot;</span>
+                      <span class="htmlAttributeName">IconColor</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="enum">Color</span><span class="enumValue">.Dark</span><span class="quot">&quot;</span>
+                      <span class="htmlAttributeName">Color</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="enum">Color</span><span class="enumValue">.Secondary</span><span class="quot">&quot;</span>
+                      <span class="htmlAttributeName">Class</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">mx-2</span><span class="quot">&quot;</span>
+                      <span class="htmlAttributeName">Style</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">text-transform:unset</span><span class="quot">&quot;</span><span class="htmlTagDelimiter">&gt;</span>
+    GitHub page
+<span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">MudButton</span><span class="htmlTagDelimiter">&gt;</span>
+</pre></div>
+</div>

--- a/src/MudBlazor.Docs/Pages/Components/Button/Examples/ButtonLinkExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Button/Examples/ButtonLinkExample.razor
@@ -1,0 +1,11 @@
+﻿@namespace MudBlazor.Docs.Examples
+Visit our <MudButton Link="https://github.com/Garderoben/MudBlazor"
+                      Target="_blank"
+                      Variant="Variant.Text"
+                      EndIcon="@Icons.Custom.GitHub"
+                      IconColor="Color.Dark"
+                      Color="Color.Secondary"
+                      Class="mx-0"
+                      Style="text-transform:unset">
+    GitHub page
+</MudButton> 

--- a/src/MudBlazor.UnitTests/Components/ButtonsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ButtonsTests.cs
@@ -1,0 +1,189 @@
+﻿using Bunit;
+using FluentAssertions;
+using NUnit.Framework;
+using static Bunit.ComponentParameterFactory;
+using System.Reflection.Metadata;
+using System.Threading.Tasks;
+namespace MudBlazor.UnitTests
+{
+    [TestFixture]
+    public class ButtonsTests
+    {
+        /// <summary>
+        /// MudButton whithout specifying HtmlTag, renders a button
+        /// </summary>
+        [Test]
+        public void MudButtonShouldRenderAButtonByDefault()
+        {
+            using var ctx = new Bunit.TestContext();
+
+
+            var comp = ctx.RenderComponent<MudButton>();
+
+            //no HtmlTag nor Link properties are set, so HtmlTag is button by default
+            comp.Instance
+                .HtmlTag
+                .Should()
+                .Be("button");
+
+
+            //it is a button, and has by default stopPropagation on onclick
+            comp.Markup
+                .Replace(" ", string.Empty)
+                .Should()
+                .StartWith("<button")
+                .And
+                .Contain("__internal_stopPropagation_onclick");
+
+        }
+
+        /// <summary>
+        /// MudButton renders an anchor element when Link is set
+        /// </summary>
+        [Test]
+        public void MudButtonShouldRenderAnAnchorIfLinkIsSet()
+        {
+            using var ctx = new Bunit.TestContext();
+            var link = Parameter(nameof(MudButton.Link), "https://www.google.com");
+            var target = Parameter(nameof(MudButton.Target), "_blank");
+
+            var comp = ctx.RenderComponent<MudButton>(link, target);
+
+            //Link property is set, so it has to render an anchor element
+            comp.Instance
+                .HtmlTag
+                .Should()
+                .Be("a");
+
+            //Target property is set, so it must have the rel attribute set to noopener
+            comp.Markup
+                .Should()
+                .Contain("rel=\"noopener\"");
+
+            //it is an anchor and not contains stopPropagation 
+            comp.Markup
+                .Replace(" ", string.Empty)
+                .Should()
+                .StartWith("<a")
+                .And
+                .NotContain("__internal_stopPropagation_onclick");
+        }
+
+
+
+        /// <summary>
+        /// MudButton whithout specifying HtmlTag, renders a button
+        /// </summary>
+        [Test]
+        public void MudIconButtonShouldRenderAButtonByDefault()
+        {
+            using var ctx = new Bunit.TestContext();
+
+
+            var comp = ctx.RenderComponent<MudIconButton>();
+
+            //no HtmlTag nor Link properties are set, so HtmlTag is button by default
+            comp.Instance
+                .HtmlTag
+                .Should()
+                .Be("button");
+
+
+            //it is a button
+            comp.Markup
+                .Replace(" ", string.Empty)
+                .Should()
+                .StartWith("<button");
+
+        }
+
+        /// <summary>
+        /// MudButton renders an anchor element when Link is set
+        /// </summary>
+        [Test]
+        public void MudIconButtonShouldRenderAnAnchorIfLinkIsSet()
+        {
+            using var ctx = new Bunit.TestContext();
+            var link = Parameter(nameof(MudIconButton.Link), "https://www.google.com");
+            var target = Parameter(nameof(MudIconButton.Target), "_blank");
+
+            var comp = ctx.RenderComponent<MudIconButton>(link, target);
+
+            //Link property is set, so it has to render an anchor element
+            comp.Instance
+                .HtmlTag
+                .Should()
+                .Be("a");
+
+            //Target property is set, so it must have the rel attribute set to noopener
+            comp.Markup
+                .Should()
+                .Contain("rel=\"noopener\"");
+
+            //it is an anchor
+            comp.Markup
+                .Replace(" ", string.Empty)
+                .Should()
+                .StartWith("<a");
+        }
+
+        /// <summary>
+        /// MudButton whithout specifying HtmlTag, renders a button
+        /// </summary>
+        [Test]
+        public void MudFabShouldRenderAButtonByDefault()
+        {
+            using var ctx = new Bunit.TestContext();
+
+
+            var comp = ctx.RenderComponent<MudFab>();
+
+            //no HtmlTag nor Link properties are set, so HtmlTag is button by default
+            comp.Instance
+                .HtmlTag
+                .Should()
+                .Be("button");
+
+
+            //it is a button
+            comp.Markup
+                .Replace(" ", string.Empty)
+                .Should()
+                .StartWith("<button");
+
+        }
+
+        /// <summary>
+        /// MudButton renders an anchor element when Link is set
+        /// </summary>
+        [Test]
+        public void MudFabShouldRenderAnAnchorIfLinkIsSet()
+        {
+            using var ctx = new Bunit.TestContext();
+            var link = Parameter(nameof(MudFab.Link), "https://www.google.com");
+            var target = Parameter(nameof(MudFab.Target), "_blank");
+
+            var comp = ctx.RenderComponent<MudFab>(link, target);
+
+            //Link property is set, so it has to render an anchor element
+            comp.Instance
+                .HtmlTag
+                .Should()
+                .Be("a");
+
+            //Target property is set, so it must have the rel attribute set to noopener
+            comp.Markup
+                .Should()
+                .Contain("rel=\"noopener\"");
+
+            //it is an anchor
+            comp.Markup
+                .Replace(" ", string.Empty)
+                .Should()
+                .StartWith("<a");
+        }
+    }
+}
+
+
+

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -153,7 +153,7 @@ namespace MudBlazor.UnitTests
             textField.Value.Should().BeNull();
 
             //More than 1000 ms had elapsed, so Value should be updated
-            await Task.Delay(510);
+            await Task.Delay(550);
             textField.Value.Should().Be("Some Value");
         }
 

--- a/src/MudBlazor/Base/MudBaseButton.cs
+++ b/src/MudBlazor/Base/MudBaseButton.cs
@@ -16,6 +16,12 @@ namespace MudBlazor
         [Inject] public IJSRuntime JsRuntime { get; set; }
 
         /// <summary>
+        /// The HTML element that will be rendered in the root by the component
+        /// </summary>
+        [Parameter] public string HtmlTag { get; set; }
+
+
+        /// <summary>
         /// The button Type (Button, Submit, Refresh)
         /// </summary>
         [Parameter] public ButtonType ButtonType { get; set; }
@@ -51,22 +57,28 @@ namespace MudBlazor
         [Parameter] public EventCallback<MouseEventArgs> OnClick { get; set; }
 
         protected async Task OnClickHandler(MouseEventArgs ev)
-        {
-            if (Link != null)
-            {
-                if (string.IsNullOrWhiteSpace(Target))
-                    UriHelper.NavigateTo(Link, ForceLoad);
-                else
-                    await JsRuntime.InvokeVoidAsync("blazorOpen", new object[2] { Link, Target });
-            }
-            else
-            {
+        {          
                 await OnClick.InvokeAsync(ev);
                 if (Command?.CanExecute(CommandParameter) ?? false)
                 {
                     Command.Execute(CommandParameter);
-                }
+                }            
+        }
+
+        protected override void OnInitialized()
+        {
+            //default tag for a MudButton is "button"
+            if (string.IsNullOrWhiteSpace(HtmlTag))
+            {
+                HtmlTag = "button";
             }
+
+            //But if Link property is set, it changes to an anchor element automatically
+            if (!string.IsNullOrWhiteSpace(Link))
+            {
+                HtmlTag = "a";
+            }
+            base.OnInitialized();
         }
     }
 }

--- a/src/MudBlazor/Base/MudBaseButton.cs
+++ b/src/MudBlazor/Base/MudBaseButton.cs
@@ -11,10 +11,7 @@ namespace MudBlazor
 {
     public abstract class MudBaseButton : MudComponentBase
     {
-        [Inject] public Microsoft.AspNetCore.Components.NavigationManager UriHelper { get; set; }
-
-        [Inject] public IJSRuntime JsRuntime { get; set; }
-
+      
         /// <summary>
         /// The HTML element that will be rendered in the root by the component
         /// </summary>

--- a/src/MudBlazor/Components/Button/MudButton.razor
+++ b/src/MudBlazor/Components/Button/MudButton.razor
@@ -9,6 +9,8 @@
             @onclick="OnClickHandler"
             type="@ButtonType.ToDescriptionString()"
             href="@Link" 
+            target="@Target"
+            rel="@(Target=="_blank"?"noopener":null)"
             disabled="@Disabled">
 
     <span class="mud-button-label">

--- a/src/MudBlazor/Components/Button/MudButton.razor
+++ b/src/MudBlazor/Components/Button/MudButton.razor
@@ -2,7 +2,15 @@
 @inherits MudBaseButton
 @using MudBlazor.Extensions
 
-<button @attributes="UserAttributes" type="@ButtonType.ToDescriptionString()" class="@Classname" style="@Style" @onclick="OnClickHandler" @onclick:stopPropagation="true" href="@Link" disabled="@Disabled">
+<MudElement HtmlTag="@HtmlTag"
+            Class="@Classname" 
+            Style="@Style"
+            @attributes="UserAttributes"
+            @onclick="OnClickHandler"
+            type="@ButtonType.ToDescriptionString()"
+            href="@Link" 
+            disabled="@Disabled">
+
     <span class="mud-button-label">
         @if (!string.IsNullOrWhiteSpace(StartIcon))
         {
@@ -18,4 +26,5 @@
             </span>
         }
     </span>
-</button>
+
+</MudElement>

--- a/src/MudBlazor/Components/Button/MudFab.razor
+++ b/src/MudBlazor/Components/Button/MudFab.razor
@@ -9,6 +9,8 @@
             @onclick="OnClickHandler"
             type="@ButtonType.ToDescriptionString()"
             href="@Link"
+            target="@Target"
+            rel="@(Target=="_blank"?"noopener":null)"
             disabled="@Disabled">
     <span class="mud-fab-label">
         <MudIcon Icon="@Icon" Color="@IconColor"></MudIcon>

--- a/src/MudBlazor/Components/Button/MudFab.razor
+++ b/src/MudBlazor/Components/Button/MudFab.razor
@@ -2,10 +2,17 @@
 @inherits MudBaseButton
 @using MudBlazor.Extensions
 
-<button @attributes="UserAttributes" type="@ButtonType.ToDescriptionString()" class="@Classname" style="@Style" @onclick="OnClickHandler" @onclick:stopPropagation="true" href="@Link" disabled="@Disabled">
+<MudElement HtmlTag="@HtmlTag"
+            Class="@Classname"
+            Style="@Style"
+            @attributes="UserAttributes"
+            @onclick="OnClickHandler"
+            type="@ButtonType.ToDescriptionString()"
+            href="@Link"
+            disabled="@Disabled">
     <span class="mud-fab-label">
         <MudIcon Icon="@Icon" Color="@IconColor"></MudIcon>
         @Label
     </span>
-</button>
+</MudElement>
   

--- a/src/MudBlazor/Components/Button/MudFab.razor.cs
+++ b/src/MudBlazor/Components/Button/MudFab.razor.cs
@@ -10,7 +10,7 @@ namespace MudBlazor
     public partial class MudFab : MudBaseButton
     {
         protected string Classname =>
-        new CssBuilder("mud-fab-root mud-fab")
+        new CssBuilder("mud-button-root mud-fab")
           .AddClass($"mud-fab-extended", !String.IsNullOrEmpty(Label))
           .AddClass($"mud-fab-{Color.ToDescriptionString()}")
           .AddClass($"mud-fab-size-{Size.ToDescriptionString()}")

--- a/src/MudBlazor/Components/Button/MudIconButton.razor
+++ b/src/MudBlazor/Components/Button/MudIconButton.razor
@@ -6,9 +6,11 @@
             Class="@Classname" 
             Style="@Style"
             @attributes="UserAttributes" 
-            @onclick="OnClickHandler" 
+            @onclick="OnClickHandler"
             type="@ButtonType.ToDescriptionString()" 
             href="@Link" 
+            target="@Target"
+            rel="@(Target=="_blank"?"noopener":null)"
             disabled="@Disabled">
 
         @if (!String.IsNullOrEmpty(Icon))

--- a/src/MudBlazor/Components/Button/MudIconButton.razor
+++ b/src/MudBlazor/Components/Button/MudIconButton.razor
@@ -2,7 +2,15 @@
 @inherits MudBaseButton
 @using MudBlazor.Extensions
 
-<button @attributes="UserAttributes" type="@ButtonType.ToDescriptionString()" class="@Classname" style="@Style" @onclick="OnClickHandler" @onclick:stopPropagation="true" href="@Link" disabled="@Disabled">
+<MudElement HtmlTag="@HtmlTag"
+            Class="@Classname" 
+            Style="@Style"
+            @attributes="UserAttributes" 
+            @onclick="OnClickHandler" 
+            type="@ButtonType.ToDescriptionString()" 
+            href="@Link" 
+            disabled="@Disabled">
+
         @if (!String.IsNullOrEmpty(Icon))
         {
         <span class="mud-icon-button-label">
@@ -12,4 +20,5 @@
         {
             <MudText Typo="Typo.body2" Color="Color.Inherit">@ChildContent</MudText>
         }
-</button>
+
+</MudElement>

--- a/src/MudBlazor/Components/Element/MudElement.cs
+++ b/src/MudBlazor/Components/Element/MudElement.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace MudBlazor
 {
@@ -26,7 +27,14 @@ namespace MudBlazor
             builder.AddMultipleAttributes(1, UserAttributes);
             builder.AddAttribute(2, "class", Class);
             builder.AddAttribute(3, "style", Style);
-            builder.AddContent(4, ChildContent);
+           
+            //the order matters. This has to be before content is added
+            if (HtmlTag == "button")
+             builder.AddEventStopPropagationAttribute(5, "onclick", true); 
+            
+            builder.AddContent(10, ChildContent);
+
+
             builder.CloseElement();
         }
     }

--- a/src/MudBlazor/TScripts/window-open.js
+++ b/src/MudBlazor/TScripts/window-open.js
@@ -1,3 +1,0 @@
-window.blazorOpen = (args) => {
-    window.open(args);
-};


### PR DESCRIPTION
This enables button to render the html element you want through the `HtmlTag` parameter.
Also, if the `Link` parameter is set, the button renders automatically an anchor element. Fixes #293 
If the `Target` parameter is set, the component adds automatically `rel="noopener"`, for safety.

This will also enable the creation of a file upload button, rendering a label instead of a button (#181)

Fixes #286 

Added tests and examples