### PR TITLE
Make ToDescriptionString() available to all Enum

### DIFF
--- a/src/MudBlazor.UnitTests/Extensions/EnumExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/EnumExtensionsTests.cs
@@ -1,0 +1,28 @@
+﻿using FluentAssertions;
+
+using Moq;
+
+using MudBlazor.Extensions;
+
+
+using NUnit.Framework;
+
+
+namespace MudBlazor.UnitTests.Extensions
+{
+    [TestFixture]
+    public class EnumExtensionsTests
+    {
+        
+
+       
+
+        [Test]
+        public void ToDescriptionString()
+        {
+            Adornment.Start.ToDescriptionString().Should().Be("start");
+            Align.Inherit.ToDescriptionString().Should().Be("inherit");
+            Breakpoint.Sm.ToDescriptionString().Should().Be("sm");
+        }
+    }
+}

--- a/src/MudBlazor/Extensions/EnumExtensions.cs
+++ b/src/MudBlazor/Extensions/EnumExtensions.cs
@@ -1,145 +1,17 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
 
 namespace MudBlazor.Extensions
 {
     public static class EnumExtensions
     {
-        public static string ToDescriptionString(this Color val)
+        public static string ToDescriptionString(this Enum val)
         {
             var attributes = (DescriptionAttribute[])val.GetType().GetField(val.ToString()).GetCustomAttributes(typeof(DescriptionAttribute), false);
-            return attributes.Length > 0 ? attributes[0].Description : string.Empty;
-        }
-
-        public static string ToDescriptionString(this Variant val)
-        {
-            var attributes = (DescriptionAttribute[])val.GetType().GetField(val.ToString()).GetCustomAttributes(typeof(DescriptionAttribute), false);
-            return attributes.Length > 0 ? attributes[0].Description : string.Empty;
-        }
-
-        public static string ToDescriptionString(this Edge val)
-        {
-            var attributes = (DescriptionAttribute[])val.GetType().GetField(val.ToString()).GetCustomAttributes(typeof(DescriptionAttribute), false);
-            return attributes.Length > 0 ? attributes[0].Description : string.Empty;
-        }
-
-        public static string ToDescriptionString(this Size val)
-        {
-            var attributes = (DescriptionAttribute[])val.GetType().GetField(val.ToString()).GetCustomAttributes(typeof(DescriptionAttribute), false);
-            return attributes.Length > 0 ? attributes[0].Description : string.Empty;
-        }
-
-        public static string ToDescriptionString(this MaxWidth val)
-        {
-            var attributes = (DescriptionAttribute[])val.GetType().GetField(val.ToString()).GetCustomAttributes(typeof(DescriptionAttribute), false);
-            return attributes.Length > 0 ? attributes[0].Description : string.Empty;
-        }
-
-        public static string ToDescriptionString(this Anchor val)
-        {
-            var attributes = (DescriptionAttribute[])val.GetType().GetField(val.ToString()).GetCustomAttributes(typeof(DescriptionAttribute), false);
-            return attributes.Length > 0 ? attributes[0].Description : string.Empty;
-        }
-
-        public static string ToDescriptionString(this Typo val)
-        {
-            var attributes = (DescriptionAttribute[])val.GetType().GetField(val.ToString()).GetCustomAttributes(typeof(DescriptionAttribute), false);
-            return attributes.Length > 0 ? attributes[0].Description : string.Empty;
-        }
-
-        public static string ToDescriptionString(this Align val)
-        {
-            var attributes = (DescriptionAttribute[])val.GetType().GetField(val.ToString()).GetCustomAttributes(typeof(DescriptionAttribute), false);
-            return attributes.Length > 0 ? attributes[0].Description : string.Empty;
-        }
-
-        public static string ToDescriptionString(this Underline val)
-        {
-            var attributes = (DescriptionAttribute[])val.GetType().GetField(val.ToString()).GetCustomAttributes(typeof(DescriptionAttribute), false);
-            return attributes.Length > 0 ? attributes[0].Description : string.Empty;
-        }
-
-        public static string ToDescriptionString(this Justify val)
-        {
-            var attributes = (DescriptionAttribute[])val.GetType().GetField(val.ToString()).GetCustomAttributes(typeof(DescriptionAttribute), false);
-            return attributes.Length > 0 ? attributes[0].Description : string.Empty;
-        }
-
-        public static string ToDescriptionString(this InputType val)
-        {
-            var attributes = (DescriptionAttribute[])val.GetType().GetField(val.ToString()).GetCustomAttributes(typeof(DescriptionAttribute), false);
-            return attributes.Length > 0 ? attributes[0].Description : string.Empty;
-        }
-
-        public static string ToDescriptionString(this Width val)
-        {
-            var attributes = (DescriptionAttribute[])val.GetType().GetField(val.ToString()).GetCustomAttributes(typeof(DescriptionAttribute), false);
-            return attributes.Length > 0 ? attributes[0].Description : string.Empty;
-        }
-
-        public static string ToDescriptionString(this Placement val)
-        {
-            var attributes = (DescriptionAttribute[])val.GetType().GetField(val.ToString()).GetCustomAttributes(typeof(DescriptionAttribute), false);
-            return attributes.Length > 0 ? attributes[0].Description : string.Empty;
-        }
-
-        public static string ToDescriptionString(this Severity val)
-        {
-            var attributes = (DescriptionAttribute[])val.GetType().GetField(val.ToString()).GetCustomAttributes(typeof(DescriptionAttribute), false);
-            return attributes.Length > 0 ? attributes[0].Description : string.Empty;
-        }
-
-        public static string ToDescriptionString(this Dialog.DialogPosition val)
-        {
-            var attributes = (DescriptionAttribute[])val.GetType().GetField(val.ToString()).GetCustomAttributes(typeof(DescriptionAttribute), false);
-            return attributes.Length > 0 ? attributes[0].Description : string.Empty;
-        }
-
-        public static string ToDescriptionString(this Margin val)
-        {
-            var attributes = (DescriptionAttribute[])val.GetType().GetField(val.ToString()).GetCustomAttributes(typeof(DescriptionAttribute), false);
-            return attributes.Length > 0 ? attributes[0].Description : string.Empty;
-        }
-
-        public static string ToDescriptionString(this DividerType val)
-        {
-            var attributes = (DescriptionAttribute[])val.GetType().GetField(val.ToString()).GetCustomAttributes(typeof(DescriptionAttribute), false);
-            return attributes.Length > 0 ? attributes[0].Description : string.Empty;
-        }
-
-        public static string ToDescriptionString(this Animation val)
-        {
-            var attributes = (DescriptionAttribute[])val.GetType().GetField(val.ToString()).GetCustomAttributes(typeof(DescriptionAttribute), false);
-            return attributes.Length > 0 ? attributes[0].Description : string.Empty;
-        }
-
-        public static string ToDescriptionString(this SkeletonType val)
-        {
-            var attributes = (DescriptionAttribute[])val.GetType().GetField(val.ToString()).GetCustomAttributes(typeof(DescriptionAttribute), false);
-            return attributes.Length > 0 ? attributes[0].Description : string.Empty;
-        }
-
-        public static string ToDescriptionString(this Adornment val)
-        {
-            var attributes = (DescriptionAttribute[])val.GetType().GetField(val.ToString()).GetCustomAttributes(typeof(DescriptionAttribute), false);
-            return attributes.Length > 0 ? attributes[0].Description : string.Empty;
-        }
-
-        public static string ToDescriptionString(this Direction val)
-        {
-            var attributes = (DescriptionAttribute[])val.GetType().GetField(val.ToString()).GetCustomAttributes(typeof(DescriptionAttribute), false);
-            return attributes.Length > 0 ? attributes[0].Description : string.Empty;
-        }
-
-        public static string ToDescriptionString(this ButtonType val)
-        {
-            var attributes = (DescriptionAttribute[])val.GetType().GetField(val.ToString()).GetCustomAttributes(typeof(DescriptionAttribute), false);
-            return attributes.Length > 0 ? attributes[0].Description : string.Empty;
-        }
-
-        public static string ToDescriptionString(this LegendPosition val)
-        {
-            var attributes = (DescriptionAttribute[])val.GetType().GetField(val.ToString()).GetCustomAttributes(typeof(DescriptionAttribute), false);
-            return attributes.Length > 0 ? attributes[0].Description : string.Empty;
+            
+            return attributes.Length > 0 
+                ? attributes[0].Description 
+                : val.ToString().ToLower();
         }
     }
 }


### PR DESCRIPTION
Instead of having to create an extension method for each component you want to call ToDescriptionString(), which is cumbersome and prone to errors, because you must copy the code each time and you can forget it, I made the extension available to all Enum. If they have a description, returns the description; if not, returns the ToString().ToLower() instead of empty.string, because it's the expected.