### PR TITLE
Remove unused usings and sort

### DIFF
--- a/src/MudBlazor.Docs.Client/Program.cs
+++ b/src/MudBlazor.Docs.Client/Program.cs
@@ -1,9 +1,9 @@
-using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
-using Microsoft.Extensions.DependencyInjection;
-using MudBlazor.Docs.Extensions;
 using System;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor.Docs.Extensions;
 using Toolbelt.Blazor.Extensions.DependencyInjection;
 
 namespace MudBlazor.Docs.Client

--- a/src/MudBlazor.Docs.Compiler/T.cs
+++ b/src/MudBlazor.Docs.Compiler/T.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace MudBlazor.UnitTests
+﻿namespace MudBlazor.UnitTests
 {
     public class T  { }
 }

--- a/src/MudBlazor.Docs.Server/Program.cs
+++ b/src/MudBlazor.Docs.Server/Program.cs
@@ -1,13 +1,5 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 
 namespace MudBlazor.Docs.Server
 {

--- a/src/MudBlazor.Docs.Server/Startup.cs
+++ b/src/MudBlazor.Docs.Server/Startup.cs
@@ -1,11 +1,5 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.HttpsPolicy;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;

--- a/src/MudBlazor.Docs/Data/PeriodicTable.cs
+++ b/src/MudBlazor.Docs/Data/PeriodicTable.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Text;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 

--- a/src/MudBlazor.Docs/Extensions/DocsViewExtension.cs
+++ b/src/MudBlazor.Docs/Extensions/DocsViewExtension.cs
@@ -1,6 +1,4 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
-using MudBlazor.Dialog;
 using MudBlazor.Services;
 
 namespace MudBlazor.Docs.Extensions

--- a/src/MudBlazor.Docs/Extensions/StringExtensions.cs
+++ b/src/MudBlazor.Docs/Extensions/StringExtensions.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 

--- a/src/MudBlazor.Docs/Models/ApiLink.cs
+++ b/src/MudBlazor.Docs/Models/ApiLink.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using MudBlazor.Docs.Extensions;
 
 namespace MudBlazor.Docs.Models
 {

--- a/src/MudBlazor.Docs/Models/ApiProperty.cs
+++ b/src/MudBlazor.Docs/Models/ApiProperty.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace MudBlazor.Docs.Models
+﻿namespace MudBlazor.Docs.Models
 {
     public class ApiProperty
     {

--- a/src/MudBlazor.Docs/Models/DocStrings.cs
+++ b/src/MudBlazor.Docs/Models/DocStrings.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text;
 using System.Text.RegularExpressions;
 
 namespace MudBlazor.Docs.Models

--- a/src/MudBlazor.Docs/Models/DocsComponents.cs
+++ b/src/MudBlazor.Docs/Models/DocsComponents.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace MudBlazor.Docs.Models
 {

--- a/src/MudBlazor.Docs/Models/MudComponent.cs
+++ b/src/MudBlazor.Docs/Models/MudComponent.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace MudBlazor.Docs.Models
 {

--- a/src/MudBlazor.Docs/Models/Snippets.cs
+++ b/src/MudBlazor.Docs/Models/Snippets.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
 using System.Reflection;
-using System.Text;
 
 namespace MudBlazor.Docs.Models
 {

--- a/src/MudBlazor.Docs/Models/T.cs
+++ b/src/MudBlazor.Docs/Models/T.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace MudBlazor.Docs.Models
+﻿namespace MudBlazor.Docs.Models
 {
     public class T  { }
 }

--- a/src/MudBlazor.Docs/Models/XmlDocumentation.cs
+++ b/src/MudBlazor.Docs/Models/XmlDocumentation.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml;
 

--- a/src/MudBlazor.Docs/Utilities/SampleCommand.cs
+++ b/src/MudBlazor.Docs/Utilities/SampleCommand.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Windows.Input;
 
 namespace MudBlazor.Docs.Utilities

--- a/src/MudBlazor.UnitTests.Viewer/Program.cs
+++ b/src/MudBlazor.UnitTests.Viewer/Program.cs
@@ -1,12 +1,8 @@
 using System;
 using System.Net.Http;
-using System.Collections.Generic;
 using System.Threading.Tasks;
-using System.Text;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 
 namespace MudBlazor.UnitTests
 {

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
@@ -9,7 +7,6 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using MudBlazor.UnitTests.Mocks;
 using NUnit.Framework;
-using static MudBlazor.UnitTests.SelectWithEnumTest;
 
 namespace MudBlazor.UnitTests
 {

--- a/src/MudBlazor.UnitTests/Components/ButtonsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ButtonsTests.cs
@@ -1,9 +1,6 @@
-﻿using Bunit;
-using FluentAssertions;
+﻿using FluentAssertions;
 using NUnit.Framework;
 using static Bunit.ComponentParameterFactory;
-using System.Reflection.Metadata;
-using System.Threading.Tasks;
 namespace MudBlazor.UnitTests
 {
     [TestFixture]

--- a/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using Bunit;
 using Bunit.Rendering;
 using FluentAssertions;

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;

--- a/src/MudBlazor.UnitTests/Components/ElementTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ElementTests.cs
@@ -1,9 +1,6 @@
 ﻿using Bunit;
-using FluentAssertions;
 using NUnit.Framework;
 using static Bunit.ComponentParameterFactory;
-using System.Reflection.Metadata;
-using System.Threading.Tasks;
 namespace MudBlazor.UnitTests
 {
     [TestFixture]

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -1,16 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Bunit;
 using Bunit.Rendering;
 using FluentAssertions;
-using Microsoft.AspNetCore.Components;
-using Microsoft.Extensions.DependencyInjection;
-using MudBlazor.UnitTests.Mocks;
 using NUnit.Framework;
-using static MudBlazor.UnitTests.SelectWithEnumTest;
 
 namespace MudBlazor.UnitTests
 {

--- a/src/MudBlazor.UnitTests/Components/HighlighterTests.cs
+++ b/src/MudBlazor.UnitTests/Components/HighlighterTests.cs
@@ -1,9 +1,7 @@
-﻿using Bunit;
+﻿using System.Collections.Generic;
+using Bunit;
 using FluentAssertions;
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
-
 using static Bunit.ComponentParameterFactory;
 using static MudBlazor.Components.Highlighter.Splitter;
 

--- a/src/MudBlazor.UnitTests/Components/RadioTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RadioTests.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using Bunit;
 using FluentAssertions;
 using NUnit.Framework;

--- a/src/MudBlazor.UnitTests/Components/RatingTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RatingTests.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using AngleSharp.Dom;
 using Bunit;
 using FluentAssertions;
 using NUnit.Framework;

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Reflection.Metadata;
-using System.Text;
 using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Bunit;
 using Bunit.Rendering;
@@ -11,7 +8,6 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using MudBlazor.UnitTests.Mocks;
 using NUnit.Framework;
-using static MudBlazor.UnitTests.SelectWithEnumTest;
 using static Bunit.ComponentParameterFactory;
 
 namespace MudBlazor.UnitTests

--- a/src/MudBlazor.UnitTests/Components/ToggleIconButtonTest.cs
+++ b/src/MudBlazor.UnitTests/Components/ToggleIconButtonTest.cs
@@ -1,13 +1,10 @@
-﻿using Bunit;
+﻿using System.Threading.Tasks;
+using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
 using MudBlazor.UnitTests.Mocks;
 using NUnit.Framework;
-using System;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace MudBlazor.UnitTests.Components
 {

--- a/src/MudBlazor.UnitTests/Mocks/MockHeadElementHelper.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockHeadElementHelper.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Toolbelt.Blazor.HeadElement;
 

--- a/src/MudBlazor.UnitTests/Mocks/MockNavigationManager.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockNavigationManager.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Microsoft.AspNetCore.Components;
+﻿using Microsoft.AspNetCore.Components;
 
 namespace MudBlazor.UnitTests.Mocks
 {

--- a/src/MudBlazor.UnitTests/Mocks/MockResizeListenerService.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockResizeListenerService.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 using MudBlazor.Services;
 

--- a/src/MudBlazor.UnitTests/Mocks/MockSnackbar.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockSnackbar.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace MudBlazor.UnitTests.Mocks
 {

--- a/src/MudBlazor.UnitTests/Services/ResizeListenerServiceTests.cs
+++ b/src/MudBlazor.UnitTests/Services/ResizeListenerServiceTests.cs
@@ -1,9 +1,9 @@
-﻿using FluentAssertions;
+﻿using System.Threading.Tasks;
+using FluentAssertions;
 using Moq;
 using MudBlazor.Providers;
 using MudBlazor.Services;
 using NUnit.Framework;
-using System.Threading.Tasks;
 
 namespace MudBlazor.UnitTests.Services
 {

--- a/src/MudBlazor.UnitTests/Utilities/BindingConverterTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/BindingConverterTests.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Text;
 using FluentAssertions;
 using NUnit.Framework;
 

--- a/src/MudBlazor.UnitTests/Utilities/MarkupCompilerTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/MarkupCompilerTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 
 namespace MudBlazor.UnitTests.Utilities
 {

--- a/src/MudBlazor.UnitTests/Utilities/StringExtensionTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/StringExtensionTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
+﻿
 using FluentAssertions;
 using MudBlazor.Docs.Extensions;
 using NUnit.Framework;

--- a/src/MudBlazor.UnitTests/Utilities/StyleBuilderTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/StyleBuilderTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 using FluentAssertions;
 using MudBlazor.Utilities;
 using NUnit.Framework;

--- a/src/MudBlazor/Base/MudBaseButton.cs
+++ b/src/MudBlazor/Base/MudBaseButton.cs
@@ -1,11 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using System.Windows.Input;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
-using Microsoft.JSInterop;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -1,16 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using System.Linq.Expressions;
-using System.Text;
+﻿using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.AspNetCore.Components.Web;
-using MudBlazor.Interfaces;
-using MudBlazor.Utilities;
-using System.Globalization;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Base/MudBasePicker.cs
+++ b/src/MudBlazor/Base/MudBasePicker.cs
@@ -1,13 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Input;
-using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Web;
-using Microsoft.JSInterop;
-using MudBlazor.Utilities;
+﻿using Microsoft.AspNetCore.Components;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Base/MudBaseSelectItem.cs
+++ b/src/MudBlazor/Base/MudBaseSelectItem.cs
@@ -1,9 +1,6 @@
-﻿using Microsoft.AspNetCore.Components;
+﻿using System.Windows.Input;
+using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
-using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Windows.Input;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Base/MudBooleanInput.cs
+++ b/src/MudBlazor/Base/MudBooleanInput.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 
 namespace MudBlazor

--- a/src/MudBlazor/Base/MudComponentBase.cs
+++ b/src/MudBlazor/Base/MudComponentBase.cs
@@ -1,13 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Globalization;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Input;
 using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Web;
-using Microsoft.JSInterop;
-using MudBlazor.Utilities;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;

--- a/src/MudBlazor/Colors/Colors.cs
+++ b/src/MudBlazor/Colors/Colors.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace MudBlazor
+﻿namespace MudBlazor
 {
     public static class Colors
     {

--- a/src/MudBlazor/Components/AppBar/MudAppBar.razor.cs
+++ b/src/MudBlazor/Components/AppBar/MudAppBar.razor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Microsoft.AspNetCore.Components;
+﻿using Microsoft.AspNetCore.Components;
 using MudBlazor.Extensions;
 using MudBlazor.Utilities;
 

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -1,15 +1,12 @@
-﻿using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Web;
-using MudBlazor.Utilities;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
-using System.Linq.Expressions;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using Microsoft.JSInterop;
+using MudBlazor.Utilities;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Components/Badge/MudBadge.razor.cs
+++ b/src/MudBlazor/Components/Badge/MudBadge.razor.cs
@@ -1,11 +1,7 @@
-﻿using Microsoft.AspNetCore.Components;
-using MudBlazor.Utilities;
+﻿using System;
+using Microsoft.AspNetCore.Components;
 using MudBlazor.Extensions;
-using System.Windows.Input;
-using Microsoft.JSInterop;
-using Microsoft.AspNetCore.Components.Web;
-using System.Threading.Tasks;
-using System;
+using MudBlazor.Utilities;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Components/Button/MudButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudButton.razor.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.Windows.Input;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Components;
-using MudBlazor.Utilities;
+﻿using Microsoft.AspNetCore.Components;
 using MudBlazor.Extensions;
+using MudBlazor.Utilities;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Components/Button/MudFab.razor.cs
+++ b/src/MudBlazor/Components/Button/MudFab.razor.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Windows.Input;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
-using MudBlazor.Utilities;
 using MudBlazor.Extensions;
+using MudBlazor.Utilities;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Components/Button/MudIconButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudIconButton.razor.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.Windows.Input;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Components;
-using MudBlazor.Utilities;
+﻿using Microsoft.AspNetCore.Components;
 using MudBlazor.Extensions;
+using MudBlazor.Utilities;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Components/Button/MudToggleIconButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudToggleIconButton.razor.cs
@@ -1,6 +1,6 @@
 ﻿
-using Microsoft.AspNetCore.Components;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Components/Card/MudCardMedia.razor.cs
+++ b/src/MudBlazor/Components/Card/MudCardMedia.razor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Microsoft.AspNetCore.Components;
+﻿using Microsoft.AspNetCore.Components;
 using MudBlazor.Utilities;
 
 namespace MudBlazor

--- a/src/MudBlazor/Components/Chart/Charts/Donut.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Donut.razor.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
+﻿using System.Collections.Generic;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.Charts.SVG.Models;
 

--- a/src/MudBlazor/Components/Chart/Charts/Line.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Line.razor.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
+﻿using System.Collections.Generic;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.Charts.SVG.Models;
 

--- a/src/MudBlazor/Components/Chart/Charts/Pie.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Pie.razor.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.Charts.SVG.Models;
 

--- a/src/MudBlazor/Components/Chart/Models/ChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Models/ChartOptions.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace MudBlazor
+﻿namespace MudBlazor
 {
     public class ChartOptions
     {

--- a/src/MudBlazor/Components/Chart/Models/ChartSeries.cs
+++ b/src/MudBlazor/Components/Chart/Models/ChartSeries.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace MudBlazor
+﻿namespace MudBlazor
 {
     public class ChartSeries
     {

--- a/src/MudBlazor/Components/Chart/MudChart.razor.cs
+++ b/src/MudBlazor/Components/Chart/MudChart.razor.cs
@@ -1,12 +1,10 @@
-﻿using Microsoft.AspNetCore.Components;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Text;
-using MudBlazor.Charts;
-using MudBlazor.Utilities;
+using Microsoft.AspNetCore.Components;
 using MudBlazor.Extensions;
+using MudBlazor.Utilities;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
+++ b/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
@@ -1,12 +1,6 @@
-﻿using System;
-using System.ComponentModel.DataAnnotations;
-using System.Windows.Input;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Web;
-using MudBlazor.Utilities;
+﻿using Microsoft.AspNetCore.Components;
 using MudBlazor.Extensions;
-using MudBlazor.Interfaces;
+using MudBlazor.Utilities;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Components/Chip/MudChip.razor.cs
+++ b/src/MudBlazor/Components/Chip/MudChip.razor.cs
@@ -1,11 +1,11 @@
-﻿using Microsoft.AspNetCore.Components;
-using MudBlazor.Utilities;
-using MudBlazor.Extensions;
-using System.Windows.Input;
-using Microsoft.JSInterop;
-using Microsoft.AspNetCore.Components.Web;
+﻿using System;
 using System.Threading.Tasks;
-using System;
+using System.Windows.Input;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.JSInterop;
+using MudBlazor.Extensions;
+using MudBlazor.Utilities;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Components/ChipSet/MudChipSet.razor.cs
+++ b/src/MudBlazor/Components/ChipSet/MudChipSet.razor.cs
@@ -1,13 +1,9 @@
-﻿using Microsoft.AspNetCore.Components;
-using MudBlazor.Utilities;
-using MudBlazor.Extensions;
-using System.Windows.Input;
-using Microsoft.JSInterop;
-using Microsoft.AspNetCore.Components.Web;
-using System.Threading.Tasks;
-using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using MudBlazor.Utilities;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.razor.cs
@@ -1,12 +1,11 @@
-﻿using Microsoft.AspNetCore.Components;
-using MudBlazor.Extensions;
-using MudBlazor.Utilities;
-using System;
-using System.Collections;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
+using MudBlazor.Extensions;
+using MudBlazor.Utilities;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Components/Dialog/DialogReference.cs
+++ b/src/MudBlazor/Components/Dialog/DialogReference.cs
@@ -7,9 +7,9 @@
 // See https://github.com/Blazored
 
 
-using Microsoft.AspNetCore.Components;
 using System;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
 
 namespace MudBlazor.Dialog
 {

--- a/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
@@ -4,7 +4,6 @@
 
 
 using Microsoft.AspNetCore.Components;
-using MudBlazor.Extensions;
 using MudBlazor.Utilities;
 
 namespace MudBlazor

--- a/src/MudBlazor/Components/Dialog/MudDialogInstance.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialogInstance.razor.cs
@@ -7,11 +7,11 @@
 // See https://github.com/Blazored
 
 
+using System;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.Extensions;
 using MudBlazor.Utilities;
-using System;
-using System.Threading.Tasks;
 
 namespace MudBlazor.Dialog
 {

--- a/src/MudBlazor/Components/Dialog/MudDialogProvider.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialogProvider.razor.cs
@@ -7,13 +7,12 @@
 // See https://github.com/Blazored
 
 
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Routing;
-using System.Collections.ObjectModel;
-using System.Threading.Tasks;
-
-using System;
-using System.Linq;
 
 namespace MudBlazor.Dialog
 {

--- a/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor.cs
+++ b/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor.cs
@@ -1,7 +1,6 @@
-﻿using Microsoft.AspNetCore.Components;
+﻿using System;
+using Microsoft.AspNetCore.Components;
 using MudBlazor.Utilities;
-using System;
-using System.Linq;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanels.razor.cs
+++ b/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanels.razor.cs
@@ -1,8 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.Utilities;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Components/Field/MudField.razor.cs
+++ b/src/MudBlazor/Components/Field/MudField.razor.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Extensions;
 using MudBlazor.Utilities;
-using Microsoft.AspNetCore.Components.Web;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Components/Hidden/MudHidden.razor.cs
+++ b/src/MudBlazor/Components/Hidden/MudHidden.razor.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Web;
-using MudBlazor.Extensions;
 using MudBlazor.Services;
-using MudBlazor.Utilities;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Components/Icon/MudIcon.razor.cs
+++ b/src/MudBlazor/Components/Icon/MudIcon.razor.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Extensions;
 using MudBlazor.Utilities;
 

--- a/src/MudBlazor/Components/Input/MudDebouncedInput.cs
+++ b/src/MudBlazor/Components/Input/MudDebouncedInput.cs
@@ -1,8 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Components;
-using MudBlazor.Utilities;
 using System.Timers;
+using Microsoft.AspNetCore.Components;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -1,8 +1,7 @@
-﻿using Microsoft.AspNetCore.Components;
-using MudBlazor.Utilities;
+﻿using System;
+using Microsoft.AspNetCore.Components;
 using MudBlazor.Extensions;
-using System;
-using Microsoft.AspNetCore.Components.Web;
+using MudBlazor.Utilities;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Components/Input/MudInputLabel.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInputLabel.razor.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.AspNetCore.Components;
-using MudBlazor.Utilities;
 using MudBlazor.Extensions;
+using MudBlazor.Utilities;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Components/InputControl/MudInputControl.razor.cs
+++ b/src/MudBlazor/Components/InputControl/MudInputControl.razor.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Components;
+﻿using Microsoft.AspNetCore.Components;
 using MudBlazor.Extensions;
 using MudBlazor.Utilities;
 

--- a/src/MudBlazor/Components/Link/MudLink.razor.cs
+++ b/src/MudBlazor/Components/Link/MudLink.razor.cs
@@ -1,11 +1,6 @@
-﻿using System;
-using System.Windows.Input;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Web;
-
-using MudBlazor.Utilities;
+﻿using Microsoft.AspNetCore.Components;
 using MudBlazor.Extensions;
+using MudBlazor.Utilities;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Components/List/MudListItem.razor.cs
+++ b/src/MudBlazor/Components/List/MudListItem.razor.cs
@@ -1,7 +1,7 @@
-﻿using Microsoft.AspNetCore.Components;
+﻿using System.Windows.Input;
+using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Utilities;
-using System.Windows.Input;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -1,9 +1,6 @@
-﻿using Microsoft.AspNetCore.Components;
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
 using MudBlazor.Utilities;
-using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Components/Overlay/MudOverlay.razor.cs
+++ b/src/MudBlazor/Components/Overlay/MudOverlay.razor.cs
@@ -1,11 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Text;
-using System.Windows.Input;
+﻿using System.Windows.Input;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
-using MudBlazor.Extensions;
 using MudBlazor.Utilities;
 
 namespace MudBlazor

--- a/src/MudBlazor/Components/Popover/MudPopover.razor.cs
+++ b/src/MudBlazor/Components/Popover/MudPopover.razor.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.AspNetCore.Components;
-using MudBlazor.Utilities;
 using MudBlazor.Extensions;
+using MudBlazor.Utilities;
 
 
 namespace MudBlazor

--- a/src/MudBlazor/Components/Radio/MudRadio.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadio.razor.cs
@@ -1,11 +1,6 @@
-﻿using System;
-using System.Windows.Input;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Web;
-
-using MudBlazor.Utilities;
+﻿using Microsoft.AspNetCore.Components;
 using MudBlazor.Extensions;
+using MudBlazor.Utilities;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Components/Radio/MudRadioGroup.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadioGroup.razor.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using Microsoft.AspNetCore.Components;
 
 namespace MudBlazor

--- a/src/MudBlazor/Components/Rating/MudRating.razor.cs
+++ b/src/MudBlazor/Components/Rating/MudRating.razor.cs
@@ -1,11 +1,6 @@
-﻿using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Web;
-using System;
-using System.Collections.Generic;
-using System.Text;
-using MudBlazor.Extensions;
+﻿using System;
+using Microsoft.AspNetCore.Components;
 using MudBlazor.Utilities;
-using System.ComponentModel.DataAnnotations;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Components/Rating/MudRatingItem.razor.cs
+++ b/src/MudBlazor/Components/Rating/MudRatingItem.razor.cs
@@ -1,8 +1,8 @@
-﻿using Microsoft.AspNetCore.Components;
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Extensions;
 using MudBlazor.Utilities;
-using System.Threading.Tasks;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Components/Select/IMudSelect.cs
+++ b/src/MudBlazor/Components/Select/IMudSelect.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace MudBlazor.Components.Select
+﻿namespace MudBlazor.Components.Select
 {
     internal interface IMudSelect
     {

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -1,11 +1,10 @@
-﻿using Microsoft.AspNetCore.Components;
-using MudBlazor.Utilities;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
 using MudBlazor.Components.Select;
+using MudBlazor.Utilities;
 using MudBlazor.Utilities.Exceptions;
 
 namespace MudBlazor

--- a/src/MudBlazor/Components/Select/MudSelectItem.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelectItem.razor.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.Components.Select;
-using MudBlazor.Utilities;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Components/Slider/MudSlider.razor.cs
+++ b/src/MudBlazor/Components/Slider/MudSlider.razor.cs
@@ -1,9 +1,6 @@
-﻿using Microsoft.AspNetCore.Components;
+﻿using System.Globalization;
+using Microsoft.AspNetCore.Components;
 using MudBlazor.Utilities;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Text;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Components/Switch/MudSwitch.razor.cs
+++ b/src/MudBlazor/Components/Switch/MudSwitch.razor.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Windows.Input;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Web;
-using MudBlazor.Utilities;
+﻿using Microsoft.AspNetCore.Components;
 using MudBlazor.Extensions;
+using MudBlazor.Utilities;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -1,10 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
-using MudBlazor.Components.Table;
 using MudBlazor.Utilities;
 
 

--- a/src/MudBlazor/Components/Table/MudTablePager.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTablePager.razor.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using Microsoft.AspNetCore.Components;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Components/Table/MudTableSortLabel.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTableSortLabel.razor.cs
@@ -1,9 +1,6 @@
-﻿using Microsoft.AspNetCore.Components;
-
+﻿using System;
+using Microsoft.AspNetCore.Components;
 using MudBlazor.Utilities;
-
-using System;
-using System.Collections.Generic;
 
 
 namespace MudBlazor

--- a/src/MudBlazor/Components/Table/MudTr.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTr.razor.cs
@@ -1,10 +1,7 @@
-﻿using System;
-using System.Windows.Input;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
-using MudBlazor.Utilities;
-using MudBlazor.Extensions;
 using Microsoft.AspNetCore.Components.Web;
+using MudBlazor.Utilities;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Components/Table/TableContext.cs
+++ b/src/MudBlazor/Components/Table/TableContext.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using MudBlazor.Extensions;
 
 namespace MudBlazor

--- a/src/MudBlazor/Components/Table/TableRowClickEventArgs.cs
+++ b/src/MudBlazor/Components/Table/TableRowClickEventArgs.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using Microsoft.AspNetCore.Components.Web;
 
 namespace MudBlazor.Components.Table

--- a/src/MudBlazor/Components/Table/TableState.cs
+++ b/src/MudBlazor/Components/Table/TableState.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections;
 using System.Collections.Generic;
 
 namespace MudBlazor

--- a/src/MudBlazor/Components/TableSimple/MudSimpleTable.razor.cs
+++ b/src/MudBlazor/Components/TableSimple/MudSimpleTable.razor.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using Microsoft.AspNetCore.Components;
+﻿using Microsoft.AspNetCore.Components;
 using MudBlazor.Utilities;
 
 

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -1,10 +1,8 @@
-﻿using Microsoft.AspNetCore.Components;
-using MudBlazor.Utilities;
-using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
+using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Extensions;
+using MudBlazor.Utilities;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Components/TextField/MudTextField.razor.cs
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Windows.Input;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Components;
-using MudBlazor.Utilities;
-using MudBlazor.Extensions;
-using Microsoft.AspNetCore.Components.Web;
+﻿using MudBlazor.Utilities;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Components/ThemeProvider/MudThemeProvider.razor.cs
+++ b/src/MudBlazor/Components/ThemeProvider/MudThemeProvider.razor.cs
@@ -1,8 +1,8 @@
-﻿using Microsoft.AspNetCore.Components;
+﻿using System.Globalization;
+using System.Text;
+using Microsoft.AspNetCore.Components;
 using MudBlazor.Utilities;
 using MudColor = System.Drawing.Color;
-using System.Text;
-using System.Globalization;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -1,15 +1,10 @@
-﻿using Microsoft.AspNetCore.Components;
-using MudBlazor.Extensions;
-using MudBlazor.Utilities;
-using System;
-using System.Collections;
-using System.Collections.Generic;
+﻿using System;
 using System.Globalization;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
-using Microsoft.JSInterop;
+using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
-using MudBlazor.Services;
+using MudBlazor.Extensions;
+using MudBlazor.Utilities;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Components/Typography/MudText.razor.cs
+++ b/src/MudBlazor/Components/Typography/MudText.razor.cs
@@ -1,8 +1,6 @@
 ﻿using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Web;
-
-using MudBlazor.Utilities;
 using MudBlazor.Extensions;
+using MudBlazor.Utilities;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Extensions/DateTimeExtensions.cs
+++ b/src/MudBlazor/Extensions/DateTimeExtensions.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) MudBlazor
 
 using System;
-using System.Globalization;
 
 // ReSharper disable once CheckNamespace
 internal static class DateTimeExtensions

--- a/src/MudBlazor/Extensions/ObjectExtensions.cs
+++ b/src/MudBlazor/Extensions/ObjectExtensions.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace MudBlazor.Extensions
+﻿namespace MudBlazor.Extensions
 {
     public static class ObjectExtensions
     {

--- a/src/MudBlazor/Extensions/ServiceCollectionExtensions.cs
+++ b/src/MudBlazor/Extensions/ServiceCollectionExtensions.cs
@@ -2,7 +2,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using MudBlazor.Dialog;
-using MudBlazor.Services;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Extensions/TimeSpanExtensions.cs
+++ b/src/MudBlazor/Extensions/TimeSpanExtensions.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) MudBlazor
 
 using System;
-using System.Globalization;
 
 // ReSharper disable once CheckNamespace
 internal static class TimeSpanExtensions

--- a/src/MudBlazor/Icons/Custom/FileFormats.cs
+++ b/src/MudBlazor/Icons/Custom/FileFormats.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace MudBlazor
+﻿namespace MudBlazor
 {
     public class FileFormats
     {

--- a/src/MudBlazor/Interfaces/IFormComponent.cs
+++ b/src/MudBlazor/Interfaces/IFormComponent.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Components;
 
 namespace MudBlazor.Interfaces
 {

--- a/src/MudBlazor/Providers/BrowserWindowSizeProvider.cs
+++ b/src/MudBlazor/Providers/BrowserWindowSizeProvider.cs
@@ -1,6 +1,6 @@
-﻿using Microsoft.JSInterop;
+﻿using System.Threading.Tasks;
+using Microsoft.JSInterop;
 using MudBlazor.Services;
-using System.Threading.Tasks;
 
 namespace MudBlazor.Providers
 {

--- a/src/MudBlazor/Services/DialogService.cs
+++ b/src/MudBlazor/Services/DialogService.cs
@@ -6,8 +6,8 @@
 // License: MIT
 // See https://github.com/Blazored
 
-using Microsoft.AspNetCore.Components;
 using System;
+using Microsoft.AspNetCore.Components;
 
 namespace MudBlazor.Dialog
 {

--- a/src/MudBlazor/Services/ResizeListener/Breakpoint.cs
+++ b/src/MudBlazor/Services/ResizeListener/Breakpoint.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace MudBlazor
+﻿namespace MudBlazor
 {
     /// <summary>
     /// Breakpoints describe certain user interfaces sizes or ranges. Use them in conjunction with MudHidden or ResizeListenerService

--- a/src/MudBlazor/Services/ResizeListener/BrowserWindowSize.cs
+++ b/src/MudBlazor/Services/ResizeListener/BrowserWindowSize.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace MudBlazor.Services
 {

--- a/src/MudBlazor/Services/ResizeListener/ServiceCollectionExtensions.cs
+++ b/src/MudBlazor/Services/ResizeListener/ServiceCollectionExtensions.cs
@@ -1,6 +1,5 @@
-﻿using Microsoft.Extensions.DependencyInjection;
-using System;
-using MudBlazor.Services;
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
 using MudBlazor.Providers;
 
 namespace MudBlazor.Services

--- a/src/MudBlazor/Themes/MudTheme.cs
+++ b/src/MudBlazor/Themes/MudTheme.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace MudBlazor
+﻿namespace MudBlazor
 {
     public class MudTheme
     {

--- a/src/MudBlazor/Utilities/BindingConverters/BoolConverter.cs
+++ b/src/MudBlazor/Utilities/BindingConverters/BoolConverter.cs
@@ -1,9 +1,8 @@
 ﻿using System;
-using System.Globalization;
 
 namespace MudBlazor
 {
-    
+
     /// <summary>
     /// A universal T to bool? binding converter
     /// </summary>

--- a/src/MudBlazor/Utilities/BindingConverters/DateConverter.cs
+++ b/src/MudBlazor/Utilities/BindingConverters/DateConverter.cs
@@ -1,9 +1,8 @@
 ﻿using System;
-using System.Globalization;
 
 namespace MudBlazor
 {
-    
+
     /// <summary>
     /// A ready made DateTime? to string binding converter with configurable date format and culture
     /// </summary>

--- a/src/MudBlazor/Utilities/BindingConverters/DefaultConverter.cs
+++ b/src/MudBlazor/Utilities/BindingConverters/DefaultConverter.cs
@@ -3,7 +3,7 @@ using System.Globalization;
 
 namespace MudBlazor
 {
-    
+
     /// <summary>
     /// A universal T to string binding converter
     /// </summary>

--- a/src/MudBlazor/Utilities/BindingConverters/NumericConverter.cs
+++ b/src/MudBlazor/Utilities/BindingConverters/NumericConverter.cs
@@ -3,7 +3,7 @@ using System.Globalization;
 
 namespace MudBlazor
 {
-    
+
     /// <summary>
     /// A universal T to double binding converter
     /// </summary>

--- a/src/MudBlazor/Utilities/ColorManager.cs
+++ b/src/MudBlazor/Utilities/ColorManager.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Text;
-using System.Collections.Generic;
 using System.Globalization;
 using MudColor = System.Drawing.Color;
 

--- a/src/MudBlazor/Utilities/ColorTransformation.cs
+++ b/src/MudBlazor/Utilities/ColorTransformation.cs
@@ -3,9 +3,8 @@
 // Stripped and adapted by Meinrad Recheis for MudBlazor
 
 using System;
-using System.Drawing;
-using SystemMath = System.Math;
 using MudColor = System.Drawing.Color;
+using SystemMath = System.Math;
 
 namespace MudBlazor.Utilities
 {

--- a/src/MudBlazor/Utilities/Exceptions/GenericTypeMismatchException.cs
+++ b/src/MudBlazor/Utilities/Exceptions/GenericTypeMismatchException.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace MudBlazor.Utilities.Exceptions
 {

--- a/src/MudBlazor/Utilities/StyleBuilder.cs
+++ b/src/MudBlazor/Utilities/StyleBuilder.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace MudBlazor.Utilities
 {


### PR DESCRIPTION
-  Why?
- Because it makes it clear what dependencies each code file has.
- Sorting with `System` references first means third party and library references are at the bottom and more visible.
- This is using Visual Studio code cleanup with this one job and is low risk.
- Because it changes the top of the file merge conflicts are very unlikely.