### PR TITLE
Fix - All components should live in MudBlazor

### DIFF
--- a/src/MudBlazor.Docs.Compiler/TestsForApiPages.cs
+++ b/src/MudBlazor.Docs.Compiler/TestsForApiPages.cs
@@ -29,7 +29,6 @@ namespace MudBlazor.Docs.Compiler
                 cb.AddLine("using NUnit.Framework;");
                 cb.AddLine("using MudBlazor.UnitTests.Mocks;");
                 cb.AddLine("using MudBlazor.Docs.Examples;");
-                cb.AddLine("using MudBlazor.Dialog;");
                 cb.AddLine("using MudBlazor.Services;");
                 cb.AddLine("using MudBlazor.Docs.Components;");
                 cb.AddLine("using Bunit.Rendering;");

--- a/src/MudBlazor.Docs.Compiler/TestsForExamples.cs
+++ b/src/MudBlazor.Docs.Compiler/TestsForExamples.cs
@@ -30,7 +30,6 @@ namespace MudBlazor.Docs.Compiler
                 cb.AddLine("using MudBlazor.UnitTests.Mocks;");
                 cb.AddLine("using MudBlazor.Docs.Examples;");
                 cb.AddLine("using MudBlazor.Docs.Wireframes;");
-                cb.AddLine("using MudBlazor.Dialog;");
                 cb.AddLine("using MudBlazor.Services;");
                 cb.AddLine();
                 cb.AddLine("namespace MudBlazor.UnitTests.Components");

--- a/src/MudBlazor.Docs/_Imports.razor
+++ b/src/MudBlazor.Docs/_Imports.razor
@@ -5,8 +5,6 @@
 @using Microsoft.JSInterop
 
 @using MudBlazor
-@using MudBlazor.Dialog;
-
 @using MudBlazor.Docs.Pages
 @using MudBlazor.Docs.Shared
 @using MudBlazor.Docs.Models

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableRowClickTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableRowClickTest.razor
@@ -1,5 +1,4 @@
 ﻿@using MudBlazor;
-@using MudBlazor.Components.Table
 @namespace MudBlazor.UnitTests
 
 <MudTable T="int" Items="items" OnRowClick="@(args => OnRowClicked(args))">

--- a/src/MudBlazor.UnitTests.Viewer/_Imports.razor
+++ b/src/MudBlazor.UnitTests.Viewer/_Imports.razor
@@ -9,4 +9,3 @@
 @using MudBlazor.UnitTests.Shared
 
 @using MudBlazor
-@using MudBlazor.Dialog

--- a/src/MudBlazor/Components/Dialog/DialogOptions.cs
+++ b/src/MudBlazor/Components/Dialog/DialogOptions.cs
@@ -9,7 +9,7 @@
 
 using System.ComponentModel;
 
-namespace MudBlazor.Dialog
+namespace MudBlazor
 {
     public class DialogOptions
     {

--- a/src/MudBlazor/Components/Dialog/DialogParameters.cs
+++ b/src/MudBlazor/Components/Dialog/DialogParameters.cs
@@ -9,7 +9,7 @@
 
 using System.Collections.Generic;
 
-namespace MudBlazor.Dialog
+namespace MudBlazor
 {
     public class DialogParameters
     {

--- a/src/MudBlazor/Components/Dialog/DialogReference.cs
+++ b/src/MudBlazor/Components/Dialog/DialogReference.cs
@@ -11,7 +11,7 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 
-namespace MudBlazor.Dialog
+namespace MudBlazor
 {
     public class DialogReference : IDialogReference
     {

--- a/src/MudBlazor/Components/Dialog/IDialogReference.cs
+++ b/src/MudBlazor/Components/Dialog/IDialogReference.cs
@@ -9,7 +9,7 @@
 
 using System.Threading.Tasks;
 
-namespace MudBlazor.Dialog
+namespace MudBlazor
 {
     public interface IDialogReference
     {

--- a/src/MudBlazor/Components/Dialog/MudDialogInstance.razor
+++ b/src/MudBlazor/Components/Dialog/MudDialogInstance.razor
@@ -1,4 +1,4 @@
-﻿@namespace MudBlazor.Dialog
+﻿@namespace MudBlazor
 
 <div class="mud-dialog-container @Position">
     <MudOverlay Visible="true" OnClick="HandleBackgroundClick" Class="mud-overlay-dialog" DarkBackground="true" />

--- a/src/MudBlazor/Components/Dialog/MudDialogInstance.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialogInstance.razor.cs
@@ -13,7 +13,7 @@ using Microsoft.AspNetCore.Components;
 using MudBlazor.Extensions;
 using MudBlazor.Utilities;
 
-namespace MudBlazor.Dialog
+namespace MudBlazor
 {
     public partial class MudDialogInstance
     {

--- a/src/MudBlazor/Components/Dialog/MudDialogProvider.razor
+++ b/src/MudBlazor/Components/Dialog/MudDialogProvider.razor
@@ -1,4 +1,4 @@
-﻿@namespace MudBlazor.Dialog
+﻿@namespace MudBlazor
 
 <CascadingValue Value="this" IsFixed="true">
     <CascadingValue Value="GlobalDialogOptions">

--- a/src/MudBlazor/Components/Dialog/MudDialogProvider.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialogProvider.razor.cs
@@ -14,7 +14,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Routing;
 
-namespace MudBlazor.Dialog
+namespace MudBlazor
 {
     public partial class MudDialogProvider
     {

--- a/src/MudBlazor/Components/Select/IMudSelect.cs
+++ b/src/MudBlazor/Components/Select/IMudSelect.cs
@@ -1,4 +1,4 @@
-﻿namespace MudBlazor.Components.Select
+﻿namespace MudBlazor
 {
     internal interface IMudSelect
     {

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -1,6 +1,5 @@
 ﻿@namespace MudBlazor
 @typeparam T
-@using MudBlazor.Components.Select
 @inherits MudBaseInput<T>
 
 <CascadingValue Name="Standalone" Value="false" IsFixed="true">

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
-using MudBlazor.Components.Select;
 using MudBlazor.Utilities;
 using MudBlazor.Utilities.Exceptions;
 

--- a/src/MudBlazor/Components/Select/MudSelectItem.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelectItem.razor.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Components;
-using MudBlazor;
 
 namespace MudBlazor
 {
@@ -111,5 +110,4 @@ namespace MudBlazor
             catch (Exception) { }
         }
     }
-
 }

--- a/src/MudBlazor/Components/Select/MudSelectItem.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelectItem.razor.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Components;
-using MudBlazor.Components.Select;
+using MudBlazor;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -1,7 +1,6 @@
 ﻿@namespace MudBlazor
 @inherits MudTableBase
 @using MudBlazor.Extensions
-@using MudBlazor.Components.Table
 @typeparam T
 
 <div @attributes="UserAttributes" class="@Classname" style="@Style">

--- a/src/MudBlazor/Components/Table/TableRowClickEventArgs.cs
+++ b/src/MudBlazor/Components/Table/TableRowClickEventArgs.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Microsoft.AspNetCore.Components.Web;
 
-namespace MudBlazor.Components.Table
+namespace MudBlazor
 {
     public class TableRowClickEventArgs<T> : EventArgs
     {

--- a/src/MudBlazor/Extensions/ServiceCollectionExtensions.cs
+++ b/src/MudBlazor/Extensions/ServiceCollectionExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using MudBlazor.Dialog;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Interfaces/IDialogService.cs
+++ b/src/MudBlazor/Interfaces/IDialogService.cs
@@ -10,7 +10,7 @@
 using System;
 using Microsoft.AspNetCore.Components;
 
-namespace MudBlazor.Dialog
+namespace MudBlazor
 {
     public interface IDialogService
     {

--- a/src/MudBlazor/RemovedNamespaces/Components.Select.cs
+++ b/src/MudBlazor/RemovedNamespaces/Components.Select.cs
@@ -1,0 +1,9 @@
+namespace MudBlazor.Components.Select
+{
+    // This namespace has been removed.
+    // This file serves as a placeholder
+    // to prevent breaking existing using statements
+    public class Removed
+    {
+    }
+}

--- a/src/MudBlazor/RemovedNamespaces/Components.Table.cs
+++ b/src/MudBlazor/RemovedNamespaces/Components.Table.cs
@@ -1,0 +1,9 @@
+namespace MudBlazor.Components.Table
+{
+    // This namespace has been removed.
+    // This file serves as a placeholder
+    // to prevent breaking existing using statements
+    public class Removed
+    {        
+    }
+}

--- a/src/MudBlazor/RemovedNamespaces/Dialog.cs
+++ b/src/MudBlazor/RemovedNamespaces/Dialog.cs
@@ -1,0 +1,9 @@
+namespace MudBlazor.Dialog
+{
+    // This namespace has been removed.
+    // This file serves as a placeholder
+    // to prevent breaking existing using statements
+    public class Removed
+    {
+    }
+}

--- a/src/MudBlazor/Services/DialogResult.cs
+++ b/src/MudBlazor/Services/DialogResult.cs
@@ -8,7 +8,7 @@
 
 using System;
 
-namespace MudBlazor.Dialog
+namespace MudBlazor
 {
     public class DialogResult
     {

--- a/src/MudBlazor/Services/DialogService.cs
+++ b/src/MudBlazor/Services/DialogService.cs
@@ -9,7 +9,7 @@
 using System;
 using Microsoft.AspNetCore.Components;
 
-namespace MudBlazor.Dialog
+namespace MudBlazor
 {
     public class DialogService : IDialogService
     {


### PR DESCRIPTION
- As discussed with @henon 
- We feel for the developer it makes sense for all components to live in `MudBlazor`
- We are unlikely to encounter naming collisions and nearly all components are in `MudBlazor` already
- I have left 3 holding namespaces so it doesn't break `usings` in existing user code.
- Removed namespaces will show as unused (greyed out) in user code but will not break the compiler.
- We need to review PRs so that we don't get a proliferation of different namespaces in Components in the future.
