### PR TITLE
Added FileUpload example

### DIFF
--- a/src/MudBlazor.Docs.Client/wwwroot/index.html
+++ b/src/MudBlazor.Docs.Client/wwwroot/index.html
@@ -22,6 +22,7 @@
     </div>
     <script src="_framework/blazor.webassembly.js"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
+    <script src="_content/BlazorInputFile/inputfile.js"></script>
 </body>
 
 </html>

--- a/src/MudBlazor.Docs.Server/Pages/_Host.cshtml
+++ b/src/MudBlazor.Docs.Server/Pages/_Host.cshtml
@@ -35,5 +35,6 @@
 
     <script src="_framework/blazor.server.js"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
+    <script src="_content/BlazorInputFile/inputfile.js"></script>
 </body>
 </html>

--- a/src/MudBlazor.Docs/MudBlazor.Docs.csproj
+++ b/src/MudBlazor.Docs/MudBlazor.Docs.csproj
@@ -30,11 +30,11 @@
   </Choose>
 
   <Target Name="CompileDocs" BeforeTargets="BeforeBuild;BeforeRebuild" DependsOnTargets="IncludeGeneratedFiles">
-    <Message Text="Generating Docs and Tests using $(RunCommand)" Importance="high"/>
-    <Exec Command='$(RunCommand)' />
+    <Message Text="Generating Docs and Tests using $(RunCommand)" Importance="high" />
+    <Exec Command="$(RunCommand)" />
   </Target>
 
-  <Target Name="IncludeGeneratedFiles" BeforeTargets="BeforeBuild;BeforeRebuild" >
+  <Target Name="IncludeGeneratedFiles" BeforeTargets="BeforeBuild;BeforeRebuild">
     <ItemGroup>
       <Compile Include="Models\Snippets.generated.cs" Condition="!Exists('Models\Snippets.generated.cs')" />
       <Compile Include="Models\DocStrings.generated.cs" Condition="!Exists('Models\DocStrings.generated.cs')" />
@@ -61,6 +61,7 @@
 
 
   <ItemGroup>
+    <PackageReference Include="BlazorInputFile" Version="0.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.10" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.10" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />

--- a/src/MudBlazor.Docs/Pages/Components/Button/Code/ButtonLinkExampleCode.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Button/Code/ButtonLinkExampleCode.razor
@@ -8,7 +8,7 @@ Visit our <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName
                       <span class="htmlAttributeName">EndIcon</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue"><span class="atSign">&#64;</span>Icons.Custom.GitHub</span><span class="quot">&quot;</span>
                       <span class="htmlAttributeName">IconColor</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="enum">Color</span><span class="enumValue">.Dark</span><span class="quot">&quot;</span>
                       <span class="htmlAttributeName">Color</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="enum">Color</span><span class="enumValue">.Secondary</span><span class="quot">&quot;</span>
-                      <span class="htmlAttributeName">Class</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">mx-2</span><span class="quot">&quot;</span>
+                      <span class="htmlAttributeName">Class</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">mx-0</span><span class="quot">&quot;</span>
                       <span class="htmlAttributeName">Style</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">text-transform:unset</span><span class="quot">&quot;</span><span class="htmlTagDelimiter">&gt;</span>
     GitHub page
 <span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">MudButton</span><span class="htmlTagDelimiter">&gt;</span>

--- a/src/MudBlazor.Docs/Pages/Components/FileUpload/Code/FileUploadButtonExampleCode.razor
+++ b/src/MudBlazor.Docs/Pages/Components/FileUpload/Code/FileUploadButtonExampleCode.razor
@@ -1,0 +1,55 @@
+@* Auto-generated markup. Any changes will be overwritten *@
+@namespace MudBlazor.Docs.Examples.Markup
+<div class="mud-codeblock">
+<div class="html"><pre>
+<span class="atSign">&#64;</span>using BlazorInputFile
+
+<span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">InputFile</span> <span class="htmlAttributeName">id</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">fileInput</span><span class="quot">&quot;</span> <span class="htmlAttributeName">OnChange</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">UploadFiles</span><span class="quot">&quot;</span> <span class="htmlAttributeName">hidden</span> <span class="htmlAttributeName">multiple</span> <span class="htmlTagDelimiter">/&gt;</span>
+
+<span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">MudButton</span> <span class="htmlAttributeName">HtmlTag</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">label</span><span class="quot">&quot;</span>
+           <span class="htmlAttributeName">Variant</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="enum">Variant</span><span class="enumValue">.Filled</span><span class="quot">&quot;</span>
+           <span class="htmlAttributeName">Color</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="enum">Color</span><span class="enumValue">.Primary</span><span class="quot">&quot;</span>
+           <span class="htmlAttributeName">StartIcon</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue"><span class="atSign">&#64;</span>Filled.CloudUpload</span><span class="quot">&quot;</span>
+           <span class="htmlAttributeName">for</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">fileInput</span><span class="quot">&quot;</span><span class="htmlTagDelimiter">&gt;</span>
+    Upload Files
+<span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">MudButton</span><span class="htmlTagDelimiter">&gt;</span>
+
+<span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">MudFab</span> <span class="htmlAttributeName">HtmlTag</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">label</span><span class="quot">&quot;</span>
+        <span class="htmlAttributeName">Color</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="enum">Color</span><span class="enumValue">.Secondary</span><span class="quot">&quot;</span>
+        <span class="htmlAttributeName">Icon</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue"><span class="atSign">&#64;</span>Filled.Image</span><span class="quot">&quot;</span>
+        <span class="htmlAttributeName">Label</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">Load picture</span><span class="quot">&quot;</span>
+        <span class="htmlAttributeName">for</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">fileInput</span><span class="quot">&quot;</span> <span class="htmlTagDelimiter">/&gt;</span>
+
+<span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">MudFab</span> <span class="htmlAttributeName">HtmlTag</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">label</span><span class="quot">&quot;</span>
+        <span class="htmlAttributeName">Color</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="enum">Color</span><span class="enumValue">.Success</span><span class="quot">&quot;</span>
+        <span class="htmlAttributeName">Icon</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue"><span class="atSign">&#64;</span>Filled.AttachFile</span><span class="quot">&quot;</span>
+        <span class="htmlAttributeName">for</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">fileInput</span><span class="quot">&quot;</span> <span class="htmlTagDelimiter">/&gt;</span>
+
+<span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">MudIconButton</span> <span class="htmlAttributeName">HtmlTag</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">label</span><span class="quot">&quot;</span>
+               <span class="htmlAttributeName">Color</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="enum">Color</span><span class="enumValue">.Info</span><span class="quot">&quot;</span>
+               <span class="htmlAttributeName">Icon</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue"><span class="atSign">&#64;</span>Filled.PhotoCamera</span><span class="quot">&quot;</span>
+               <span class="htmlAttributeName">for</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">fileInput</span><span class="quot">&quot;</span><span class="htmlTagDelimiter">&gt;</span>
+<span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">MudIconButton</span><span class="htmlTagDelimiter">&gt;</span>
+
+<span class="atSign">&#64;</span>if (files != null)
+ {
+    <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">MudText</span> <span class="htmlAttributeName">Typo</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue"><span class="atSign">&#64;</span>Typo.h6</span><span class="quot">&quot;</span><span class="htmlTagDelimiter">&gt;</span><span class="atSign">&#64;</span>files.Count() File<span class="atSign">&#64;</span>(files.Count()&gt;1?&quot;s&quot;:&quot;&quot;):<span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">MudText</span><span class="htmlTagDelimiter">&gt;</span>
+    <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">MudList</span><span class="htmlTagDelimiter">&gt;</span>
+    <span class="atSign">&#64;</span>foreach (var file in files)
+    {
+     <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">MudListItem</span> <span class="htmlAttributeName">Icon</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue"><span class="atSign">&#64;</span>Filled.AttachFile</span><span class="quot">&quot;</span> <span class="htmlAttributeName"><span class="atSign">&#64;</span>key</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="sharpVariable"><span class="atSign">&#64;</span>file</span><span class="quot">&quot;</span><span class="htmlTagDelimiter">&gt;</span>
+         <span class="atSign">&#64;</span>file.Name <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">code</span><span class="htmlTagDelimiter">&gt;</span><span class="atSign">&#64;</span>file.Size bytes<span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">code</span><span class="htmlTagDelimiter">&gt;</span>
+     <span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">MudListItem</span><span class="htmlTagDelimiter">&gt;</span>
+    }
+    <span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">MudList</span><span class="htmlTagDelimiter">&gt;</span>
+ }
+</pre></div>
+<div class="csharp"><pre>
+<span class="atSign">&#64;</span>code{ IEnumerable&lt;IFileListEntry&gt; files;
+    <span class="keyword">private</span> <span class="keyword">void</span> UploadFiles(IFileListEntry[] entries)
+    {
+        files = entries;
+        <span class="comment">//TODO upload the files to the server</span>
+    } }
+</pre></div>
+</div>

--- a/src/MudBlazor.Docs/Pages/Components/FileUpload/Code/FileUploadIconButtonExampleCode.razor
+++ b/src/MudBlazor.Docs/Pages/Components/FileUpload/Code/FileUploadIconButtonExampleCode.razor
@@ -1,0 +1,49 @@
+@* Auto-generated markup. Any changes will be overwritten *@
+@namespace MudBlazor.Docs.Examples.Markup
+<div class="mud-codeblock">
+<div class="html"><pre>
+<span class="atSign">&#64;</span>using BlazorInputFile
+
+&lt;label style=&quot;
+        box-shadow: 0 2px 7px #4caf50;
+        display: inline-flex;
+        width: 150px;
+        justify-content: space-around;
+        border-radius: 2em;
+        color: white;
+        border:2px solid;
+        cursor: pointer;
+        align-items: center;
+        padding:16px;
+        background-color: #4caf50;&quot;         
+       for=&quot;fileInput2&quot;&gt;
+    Upload <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">MudIcon</span> <span class="htmlAttributeName">Icon</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue"><span class="atSign">&#64;</span>Filled.CloudUpload</span><span class="quot">&quot;</span><span class="htmlTagDelimiter">/&gt;</span>
+<span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">label</span><span class="htmlTagDelimiter">&gt;</span>
+
+<span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">InputFile</span> <span class="htmlAttributeName">id</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">fileInput2</span><span class="quot">&quot;</span> <span class="htmlAttributeName">OnChange</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">UploadFiles</span><span class="quot">&quot;</span> <span class="htmlAttributeName">hidden</span> <span class="htmlAttributeName">multiple</span> <span class="htmlTagDelimiter">/&gt;</span>
+
+<span class="atSign">&#64;</span>if (files != null)
+{
+    <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">MudList</span><span class="htmlTagDelimiter">&gt;</span>
+        <span class="atSign">&#64;</span>foreach (var file in files)
+        {
+            <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">MudListItem</span> <span class="htmlAttributeName">Icon</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue"><span class="atSign">&#64;</span>Filled.AttachFile</span><span class="quot">&quot;</span><span class="htmlTagDelimiter">&gt;</span>
+                <span class="atSign">&#64;</span>file.Name <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">code</span><span class="htmlTagDelimiter">&gt;</span><span class="atSign">&#64;</span>file.Size bytes<span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">code</span><span class="htmlTagDelimiter">&gt;</span>
+            <span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">MudListItem</span><span class="htmlTagDelimiter">&gt;</span>
+        }
+    <span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">MudList</span><span class="htmlTagDelimiter">&gt;</span>
+}
+</pre></div>
+<div class="csharp"><pre>
+<span class="atSign">&#64;</span>code{
+
+    IEnumerable&lt;IFileListEntry&gt; files;
+    <span class="keyword">private</span> <span class="keyword">void</span> UploadFiles(IFileListEntry[] entries)
+    {
+        files = entries;
+        <span class="comment">//TODO upload the files to the server</span>
+    }
+
+}
+</pre></div>
+</div>

--- a/src/MudBlazor.Docs/Pages/Components/FileUpload/Examples/FileUploadButtonExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/FileUpload/Examples/FileUploadButtonExample.razor
@@ -1,0 +1,51 @@
+﻿@namespace MudBlazor.Docs.Examples
+@using BlazorInputFile
+
+<InputFile id="fileInput" OnChange="UploadFiles" hidden multiple />
+
+<MudButton HtmlTag="label"
+           Variant="Variant.Filled"
+           Color="Color.Primary"
+           StartIcon="@Filled.CloudUpload"
+           for="fileInput">
+    Upload Files
+</MudButton>
+
+<MudFab HtmlTag="label"
+        Color="Color.Secondary"
+        Icon="@Filled.Image"
+        Label="Load picture"
+        for="fileInput" />
+
+<MudFab HtmlTag="label"
+        Color="Color.Success"
+        Icon="@Filled.AttachFile"
+        for="fileInput" />
+
+<MudIconButton HtmlTag="label"
+               Color="Color.Info"
+               Icon="@Filled.PhotoCamera"
+               for="fileInput">
+</MudIconButton>
+
+@if (files != null)
+ {
+    <MudText Typo="@Typo.h6">@files.Count() File@(files.Count()>1?"s":""):</MudText>
+    <MudList>
+    @foreach (var file in files)
+    {
+     <MudListItem Icon="@Filled.AttachFile" @key="@file">
+         @file.Name <code>@file.Size bytes</code>
+     </MudListItem>
+    }
+    </MudList>
+ }
+
+
+
+@code{ IEnumerable<IFileListEntry> files;
+    private void UploadFiles(IFileListEntry[] entries)
+    {
+        files = entries;
+        //TODO upload the files to the server
+    } }

--- a/src/MudBlazor.Docs/Pages/Components/FileUpload/Examples/FileUploadIconButtonExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/FileUpload/Examples/FileUploadIconButtonExample.razor
@@ -1,0 +1,43 @@
+﻿@namespace MudBlazor.Docs.Examples
+@using BlazorInputFile
+
+<label style="
+        box-shadow: 0 2px 7px #4caf50;
+        display: inline-flex;
+        width: 150px;
+        justify-content: space-around;
+        border-radius: 2em;
+        color: white;
+        border:2px solid;
+        cursor: pointer;
+        align-items: center;
+        padding:16px;
+        background-color: #4caf50;"         
+       for="fileInput2">
+    Upload <MudIcon Icon="@Filled.CloudUpload"/>
+</label>
+
+<InputFile id="fileInput2" OnChange="UploadFiles" hidden multiple />
+
+@if (files != null)
+{
+    <MudList>
+        @foreach (var file in files)
+        {
+            <MudListItem Icon="@Filled.AttachFile">
+                @file.Name <code>@file.Size bytes</code>
+            </MudListItem>
+        }
+    </MudList>
+}
+
+@code{
+
+    IEnumerable<IFileListEntry> files;
+    private void UploadFiles(IFileListEntry[] entries)
+    {
+        files = entries;
+        //TODO upload the files to the server
+    }
+
+}

--- a/src/MudBlazor.Docs/Pages/Components/FileUpload/FileUploadPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/FileUpload/FileUploadPage.razor
@@ -1,0 +1,70 @@
+﻿@page "/components/fileupload"
+
+<DocsPage>
+    <DocsPageHeader Title="File Upload"
+                    SubTitle="Example on how to compose a file upload button"> 
+        <Description>
+           
+            <MudText Typo="@Typo.body1" Class="mt-4">
+                To create a file upload button, we must use two elements: a <CodeInline>label</CodeInline> and an <CodeInline>input</CodeInline>.
+            </MudText>
+            <br />
+            <MudText Typo="@Typo.body1">
+                When we set the <CodeInline>for</CodeInline> attribute to the same value as the <CodeInline>id</CodeInline> of the input, we enable the input to be triggered by clicking on the label. So the trick is to style the label to look like a button and hide the input.
+            </MudText>
+            <br />
+            <MudText Typo="@Typo.body1">
+                So, the styling part is solved. But to handle the files in Blazor without using javascript, we need an InputFile type component.
+            </MudText>
+            <br />
+            <MudText Typo="@Typo.body1">
+                If you are working with .Net Core 3.1 or earlier, you should install the
+                <MudButton Variant="Variant.Text"
+                           Color="Color.Primary"
+                           EndIcon="@Filled.Link"
+                           Link="https://www.nuget.org/packages/BlazorInputFile" target="_blank" rel="noopener noreferrer">
+                    nuget package InputFile
+                </MudButton>
+                , created by Steve Sanderson and reference it in your _host.cshtml or index.html (Server Side Blazor or Client Side Blazor).
+            </MudText>
+            <br />
+            <MudText Typo="@Typo.body1">
+                See
+                <MudButton Variant="Variant.Text"
+                           Color="Color.Primary"
+                           EndIcon="@Filled.Info"
+                           Link="https://blog.stevensanderson.com/2019/09/13/blazor-inputfile/" target="_blank" rel="noopener noreferrer">
+                    more info
+                </MudButton>
+                on how to install it.
+            </MudText>
+            <br />
+            <MudText Typo="@Typo.body1">
+                If your project is .Net 5.0, InputFile is a native component and you don't need to install it.
+            </MudText>
+        </Description>
+    </DocsPageHeader>
+    <DocsPageContent>
+        <DocsPageSection>
+            <SectionHeader>
+                <Title>Use any type of MudButton</Title>
+                <Description>Use a MudButton, a MudIconButton or a MudFab with the <CodeInline>HtmlTag</CodeInline> property set to "label" in combination with a hidden InputFile. That way, the MudButton will render a label element</Description>
+            </SectionHeader>
+            <SectionContent Outlined="true" DarkenBackground="true">
+                <FileUploadButtonExample />
+            </SectionContent>
+            <SectionSource Code="FileUploadButtonExample" GitHubFolderName="Button" />
+        </DocsPageSection>
+
+        <DocsPageSection >
+            <SectionHeader>
+                <Title>Use a standard label</Title>
+                <Description>Use an html label styled to your liking in combination with a hidden InputFile</Description>
+            </SectionHeader>
+            <SectionContent Outlined="true" FullWidth="true" DarkenBackground="true">
+                <FileUploadIconButtonExample />
+            </SectionContent>
+            <SectionSource Code="FileUploadIconButtonExample" GitHubFolderName="Button" />
+        </DocsPageSection>
+    </DocsPageContent>
+</DocsPage>

--- a/src/MudBlazor.Docs/Shared/NavMenu.razor
+++ b/src/MudBlazor.Docs/Shared/NavMenu.razor
@@ -125,7 +125,8 @@
                             .AddItem("Typography", typeof(MudText))
                             .AddItem("Overlay", typeof(MudOverlay))
                             .AddItem("Highlighter", typeof(MudHighlighter))
-                            .AddItem("Element", typeof(MudElement));
+                            .AddItem("Element", typeof(MudElement))
+                            .AddItem("FileUpload", typeof(MudElement));
 
         @foreach (var item in DocsComponents.ToList())
         {


### PR DESCRIPTION
This is of some interest, as it has been requested several times.
As discussed with @henon , this is a first step to have a real file upload component that encapsulates all the functionalities. But I think it is worth to show it in the documentation, because is easy to follow.
I installed a nuget package in the docs page, but it shouldn't be a problem, because the framework doesn't depend on it, just the docs page to illustrate the example.
It works both in 3.1 and in 5.0