### PR TITLE
Added MudElement reference two-way binding

### DIFF
--- a/src/MudBlazor.Docs.Client/wwwroot/index.html
+++ b/src/MudBlazor.Docs.Client/wwwroot/index.html
@@ -22,6 +22,7 @@
     </div>
     <script src="_framework/blazor.webassembly.js"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
+    <script src="_content/MudBlazor.Docs/JS/examples.js"></script>
 </body>
 
 </html>

--- a/src/MudBlazor.Docs.Server/Pages/_Host.cshtml
+++ b/src/MudBlazor.Docs.Server/Pages/_Host.cshtml
@@ -35,5 +35,6 @@
 
     <script src="_framework/blazor.server.js"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
+    <script src="_content/MudBlazor.Docs/JS/examples.js"></script>
 </body>
 </html>

--- a/src/MudBlazor.Docs/Pages/Components/Element/Code/MudElementRefExampleCode.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Element/Code/MudElementRefExampleCode.razor
@@ -1,0 +1,41 @@
+@* Auto-generated markup. Any changes will be overwritten *@
+@namespace MudBlazor.Docs.Examples.Markup
+<div class="mud-codeblock">
+<div class="html"><pre>
+<span class="atSign">&#64;</span>inject Microsoft.JSInterop.IJSRuntime Js
+
+
+&lt;MudElement HtmlTag=&quot;button&quot;
+            <span class="atSign">&#64;</span>onclick=&quot;Focus&quot;
+            Style=&quot;padding: 16px 32px;
+                   background-color: var(--mud-palette-tertiary-darken);
+                   color: white;
+                   font-size: 18px;
+                   font-weight: bold;
+                   border-radius: 8px;
+                   box-shadow: 0 2px 7px var(--mud-palette-tertiary-darken);&quot;&gt;
+    Click to focus
+<span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">MudElement</span><span class="htmlTagDelimiter">&gt;</span>
+
+<span class="atSign">&#64;</span>*this element is going to be focused through JS and its reference*<span class="atSign">&#64;</span>
+
+&lt;MudElement <span class="atSign">&#64;</span>bind-Ref=&quot;myRef&quot;
+            HtmlTag=&quot;input&quot;
+            Style=&quot;border: 1px solid lightgray;
+                   border-radius:8px;
+                   padding: 16px 32px;
+                   outline-color: var(--mud-palette-tertiary-darken);
+                   outline-width:5px;&quot;/&gt;
+</pre></div>
+<div class="csharp"><pre>
+<span class="atSign">&#64;</span>code{
+    ElementReference myRef = <span class="keyword">new</span> ElementReference();
+
+    <span class="keyword">async</span> Task Focus()
+    {
+        <span class="comment">//this js snippet does `document.querySelector(myRef).focus();`</span>
+       <span class="keyword">await</span> Js.InvokeVoidAsync(<span class="string">&quot;mudBlazorExamples.focusElement&quot;</span>, myRef);
+    }
+}
+</pre></div>
+</div>

--- a/src/MudBlazor.Docs/Pages/Components/Element/ElementPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Element/ElementPage.razor
@@ -18,14 +18,37 @@
                 <Title>Interactive example</Title>
                 <Description>Change the rendered html element in an interactive way</Description>
             </SectionHeader>
-            <SectionContent Outlined="true"  
-                            Style="height:150px; 
+            <SectionContent Outlined="true"
+                            Style="height:150px;
                                    display:flex;
                                    justify-content:flex-start;
                                    align-items:flex-end;">
                 <MudElementChangingExample />
             </SectionContent>
             <SectionSource Code="MudElementChangingExample" GitHubFolderName="Element" />
+        </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader>
+                <Title>Passing a ref</Title>
+                <Description>
+                    You can pass an ElementReference to the root element that MudElement is going to render
+                    <br />
+                    Just make sure that you bind this reference to the 
+                    <CodeInline>
+                        Ref 
+                    </CodeInline>
+                    property of the MudElement
+                </Description>
+            </SectionHeader>
+            <SectionContent Outlined="true"
+                            Style="height:150px;
+                                   display:flex;
+                                   justify-content:flex-start;
+                                   align-items:flex-end;">
+                <MudElementRefExample />
+            </SectionContent>
+            <SectionSource Code="MudElementRefExample" GitHubFolderName="Element" />
         </DocsPageSection>
     </DocsPageContent>
 </DocsPage>

--- a/src/MudBlazor.Docs/Pages/Components/Element/Examples/MudElementRefExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Element/Examples/MudElementRefExample.razor
@@ -1,0 +1,35 @@
+﻿@namespace MudBlazor.Docs.Examples
+@inject Microsoft.JSInterop.IJSRuntime Js
+
+
+<MudElement HtmlTag="button"
+            @onclick="Focus"
+            Style="padding: 16px 32px;
+                   background-color: var(--mud-palette-tertiary-darken);
+                   color: white;
+                   font-size: 18px;
+                   font-weight: bold;
+                   border-radius: 8px;
+                   box-shadow: 0 2px 7px var(--mud-palette-tertiary-darken);">
+    Click to focus
+</MudElement>
+
+@*this element is going to be focused through JS and its reference*@
+
+<MudElement @bind-Ref="myRef"
+            HtmlTag="input"
+            Style="border: 1px solid lightgray;
+                   border-radius:8px;
+                   padding: 16px 32px;
+                   outline-color: var(--mud-palette-tertiary-darken);
+                   outline-width:5px;"/>
+
+@code{
+    ElementReference myRef = new ElementReference();
+
+    async Task Focus()
+    {
+        //this js snippet does `document.querySelector(myRef).focus();`
+       await Js.InvokeVoidAsync("mudBlazorExamples.focusElement", myRef);
+    }
+}

--- a/src/MudBlazor.Docs/wwwroot/JS/examples.js
+++ b/src/MudBlazor.Docs/wwwroot/JS/examples.js
@@ -1,0 +1,11 @@
+﻿var mudBlazorExamples = {
+    focusElement: function (el) {
+        console.log(el, " focused");
+        el.focus();
+    },
+    clickElement: function (el) {
+        console.log(el.innerHtml, " clicked");
+        el.click();
+    }
+}
+

--- a/src/MudBlazor.UnitTests/Components/ButtonsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ButtonsTests.cs
@@ -30,7 +30,7 @@ namespace MudBlazor.UnitTests
                 .Should()
                 .StartWith("<button")
                 .And
-                .Contain("__internal_stopPropagation_onclick");
+                .Contain("stopPropagation");
 
         }
 

--- a/src/MudBlazor/Components/Element/MudElement.cs
+++ b/src/MudBlazor/Components/Element/MudElement.cs
@@ -2,6 +2,9 @@
 using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.AspNetCore.Components.Web;
 
+using System;
+using System.Threading.Tasks;
+
 namespace MudBlazor
 {
     /// <summary>
@@ -19,22 +22,47 @@ namespace MudBlazor
         /// The HTML element that will be rendered in the root by the component
         /// </summary>
         [Parameter] public string HtmlTag { get; set; }
+        /// <summary>
+        /// The ElementReference to bind to.
+        /// Use like @bind-Ref="myRef"
+        /// </summary>
+        [Parameter] public ElementReference? Ref { get; set; } 
 
-        protected  override void BuildRenderTree(RenderTreeBuilder builder)
+        [Parameter] public EventCallback<ElementReference> RefChanged { get; set; } 
+       
+        
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
         {
             base.BuildRenderTree(builder);
+            //Open
             builder.OpenElement(0, HtmlTag);
+
+            //splatted attributes
             builder.AddMultipleAttributes(1, UserAttributes);
+            //Class
             builder.AddAttribute(2, "class", Class);
+            //Style
             builder.AddAttribute(3, "style", Style);
            
+            // StopPropagation
             //the order matters. This has to be before content is added
             if (HtmlTag == "button")
-             builder.AddEventStopPropagationAttribute(5, "onclick", true); 
-            
+             builder.AddEventStopPropagationAttribute(5, "onclick", true);
+
+            //Reference capture
+            if (Ref != null)
+            {
+                builder.AddElementReferenceCapture(6, async capturedRef =>
+                {
+                    Ref = capturedRef;
+                    await RefChanged.InvokeAsync(Ref.Value);
+                });
+            }
+
+            //Content
             builder.AddContent(10, ChildContent);
 
-
+            //Close
             builder.CloseElement();
         }
     }


### PR DESCRIPTION
MudElement is now able to receive a reference (needed in buttons for ripple).
You just has to pass it like

`<MudElement @bind-Ref="myRef"/>`

The examples serve as tests and documentation