### PR TITLE
Change first page to 1 instead of 0

### DIFF
--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -13,7 +13,7 @@ namespace MudBlazor
     {
         internal object _editingItem = null;
         
-        private int _currentPage = 0;
+        private int _currentPage = 1;
         // note: the MudTable code is split. Everything that has nothing to do with the type parameter of MudTable<T> is here in MudTableBase
 
         protected string Classname =>
@@ -166,16 +166,16 @@ namespace MudBlazor
             switch (page)
             {
                 case Page.First:
-                    CurrentPage = 0;
+                    CurrentPage = 1;
                     break;
                 case Page.Last:
-                    CurrentPage = Math.Max(0, NumPages-1);
+                    CurrentPage = Math.Max(1, NumPages-1);
                     break;
                 case Page.Next:
                     CurrentPage = Math.Min(NumPages - 1, CurrentPage +1);
                     break;
                 case Page.Previous:
-                    CurrentPage = Math.Max(0, CurrentPage-1);
+                    CurrentPage = Math.Max(1, CurrentPage-1);
                     break;
             }
         }


### PR DESCRIPTION
I almost bang my head against the wall to understand why I didn't get any records from my API call. Eventuelly I figured out that the MudTable default page is 0 instead of a more seen 1 as default page. I want to propose to change this. What do you think?