### PR TITLE
Fix MudTextfield when placeholder and label are both set 

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -155,6 +155,28 @@ namespace MudBlazor.UnitTests
 
 
 
+        /// <summary>
+        /// Label and placeholder should not overlap.
+        /// When placeholder is set, label should shrink
+        /// </summary>
+        [Test]
+        public void LabelShouldShrinkWhenPlaceholderIsSet()
+        {
+            //Arrange
+            using var ctx = new Bunit.TestContext();
+            var label = Parameter(nameof(MudTextField<string>.Label), "label");
+            var placeholder = Parameter(nameof(MudTextField<string>.Placeholder), "placeholder");
+
+            //with no placeholder, label is not shrinked
+            var comp = ctx.RenderComponent<MudTextField<string>>( label);
+            comp.Markup.Should().NotContain("shrink");
+
+            //with placeholder label is shrinked
+            comp.SetParametersAndRender( placeholder);
+            comp.Markup.Should().Contain("shrink");
+            
+        }
+
 
     }
 }

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -42,16 +42,6 @@ namespace MudBlazor
         [Parameter] public bool DisableUnderLine { get; set; }
 
         /// <summary>
-        /// If string has value the label text will be displayed in the input, and scaled down at the top if the input has value.
-        /// </summary>
-        [Parameter] public string Label { get; set; }
-
-        /// <summary>
-        /// The short hint displayed in the input before the user enters a value.
-        /// </summary>
-        [Parameter] public string Placeholder { get; set; }
-
-        /// <summary>
         /// The HelperText will be displayed below the text field.
         /// </summary>
         [Parameter] public string HelperText { get; set; }

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -20,6 +20,16 @@ namespace MudBlazor
             .Build();
 
         /// <summary>
+        /// If string has value the label text will be displayed in the input, and scaled down at the top if the input has value.
+        /// </summary>
+        [Parameter] public string Label { get; set; }
+
+        /// <summary>
+        /// The short hint displayed in the input before the user enters a value.
+        /// </summary>
+        [Parameter] public string Placeholder { get; set; }
+
+        /// <summary>
         /// If true, compact vertical padding will be applied to all select items.
         /// </summary>
         [Parameter] public bool Dense { get; set; }

--- a/src/MudBlazor/Components/Field/MudField.razor.cs
+++ b/src/MudBlazor/Components/Field/MudField.razor.cs
@@ -5,6 +5,7 @@ using MudBlazor.Utilities;
 
 namespace MudBlazor
 {
+    //TODO Maybe can inherit from MudBaseInput?
     public partial class MudField : MudComponentBase
     {
         protected string Classname =>

--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -13,7 +13,7 @@ namespace MudBlazor
                 .AddClass($"mud-input-adorned-{Adornment.ToDescriptionString()}", Adornment != Adornment.None)
                 .AddClass($"mud-input-margin-{Margin.ToDescriptionString()}", when: () => Margin != Margin.None)
                 .AddClass("mud-input-underline", when: () => DisableUnderLine == false && Variant != Variant.Outlined)                
-                .AddClass("mud-shrink", when: () => !string.IsNullOrEmpty(Text) || Adornment == Adornment.Start)
+                .AddClass("mud-shrink", when: () => !string.IsNullOrEmpty(Text) || Adornment == Adornment.Start || !string.IsNullOrWhiteSpace(Placeholder))
                 .AddClass("mud-disabled", Disabled)
                 .AddClass("mud-input-error", HasErrors)
                 .AddClass(Class)
@@ -42,6 +42,11 @@ namespace MudBlazor
         /// ChildContent of the MudInput will only be displayed if InputType.Hidden and if its not null.
         /// </summary>
         [Parameter] public RenderFragment ChildContent { get; set; }
+
+        /// <summary>
+        /// The short hint displayed in the input before the user enters a value.
+        /// </summary>
+        [Parameter] public string Placeholder { get; set; }
     }
 
     public class MudInputString : MudInput<string> { }

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -8,7 +8,7 @@
         <MudInputControl Label="@Label" Variant="@Variant" HelperText="@HelperText" FullWidth="@FullWidth" Margin="@Margin" Class="@Classname" Style="@Style"
                          Error="@Error" ErrorText="@ErrorText" Disabled="@Disabled" @onclick="@ToggleMenu">
             <InputContent>
-                <MudInput Variant="@Variant" Value="@(Strict && !IsValueInList ? null : Text)" DisableUnderLine="@DisableUnderLine" Placeholder="@Placeholder" Disabled=@Disabled ReadOnly="true"
+                <MudInput Variant="@Variant" Value="@(Strict && !IsValueInList ? null : Text)" DisableUnderLine="@DisableUnderLine"  Disabled=@Disabled ReadOnly="true"
                           Class="mud-select-input" Error="@Error" AdornmentIcon="@CurrentIcon" Adornment="Adornment.End" IconSize="Size.Medium" Margin="@Margin"
                           InputType="@(CanRenderValue || (Strict && !IsValueInList) ? InputType.Hidden : InputType.Text)">
                     @if (CanRenderValue)

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -24,6 +24,11 @@ namespace MudBlazor
         [Parameter] public RenderFragment ChildContent { get; set; }
 
         /// <summary>
+        /// If string has value the label text will be displayed in the input, and scaled down at the top if the input has value.
+        /// </summary>
+        [Parameter] public string Label { get; set; }
+
+        /// <summary>
         /// If true, compact vertical padding will be applied to all select items.
         /// </summary>
         [Parameter] public bool Dense { get; set; }

--- a/src/MudBlazor/Components/TextField/MudTextField.razor.cs
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor.cs
@@ -1,4 +1,6 @@
-﻿using MudBlazor.Utilities;
+﻿using Microsoft.AspNetCore.Components;
+
+using MudBlazor.Utilities;
 
 namespace MudBlazor
 {
@@ -7,6 +9,18 @@ namespace MudBlazor
         protected string Classname =>
            new CssBuilder("mud-input-input-control").AddClass(Class)
            .Build();
+
+
+        /// <summary>
+        /// The short hint displayed in the input before the user enters a value.
+        /// </summary>
+        [Parameter] public string Placeholder { get; set; }
+
+        /// <summary>
+        /// If string has value the label text will be displayed in the input, and scaled down at the top if the input has value.
+        /// </summary>
+        [Parameter] public string Label { get; set; }
+
 
     }
 


### PR DESCRIPTION
This fixes #325

There was a bug when setting both placeholder and label, as they overlap. The expected is that when placeholder and label are both set, the label should shrink.
Also, MudBaseInput should not have nor Label nor Placeholder, because this allows descendants with no placeholder or no label to have one.
Some descendants should have only label, like MudSelect, others should have only placeholder, like MudInput.
I removed Label and Placeholder from MudBaseInput and reapplied only where were needed.
Before that was producing a bug on MudInput, because it allowed to have label overlapping placeholder, and MudInput should not have label.

Added tests to verify this doesn't occur any more.