### PR TITLE
Fix BL0005 RTL Support - Use cascading parameters instead

### DIFF
--- a/src/MudBlazor/Components/Drawer/MudDrawer.razor
+++ b/src/MudBlazor/Components/Drawer/MudDrawer.razor
@@ -14,8 +14,9 @@
 
 
 @code {
-
     [Inject] IJSRuntime JsRuntime { get; set; }
+
+    private bool _rtl;
 
     protected string Classname =>
     new CssBuilder("mud-drawer")
@@ -35,6 +36,24 @@
       .AddClass($"mud-drawer--open", !Open)
       .AddClass($"mud-drawer--initial", _initial)
     .Build();
+
+    [CascadingParameter] MudLayout Layout { get; set; }
+    
+    [CascadingParameter] bool RightToLeft
+    { 
+        get
+        {
+            return _rtl;
+        }
+        set
+        {
+            if (_rtl != value)
+            {
+                _rtl = value;
+                this.Anchor = this.Anchor == Anchor.Left ? Anchor.Right : Anchor.Left;
+            }
+        }
+    }
 
     /// <summary>
     /// The higher the number, the heavier the drop-shadow. 0 for no shadow.
@@ -97,9 +116,6 @@
             StateHasChanged();
         }
     }
-
-    [CascadingParameter] MudLayout Layout { get; set; }
-
 
     protected override void OnInitialized()
     {

--- a/src/MudBlazor/Components/Layout/MudLayout.razor
+++ b/src/MudBlazor/Components/Layout/MudLayout.razor
@@ -4,7 +4,9 @@
 
 <div @attributes="UserAttributes" class="@Classname" style="@Style">
     <CascadingValue IsFixed="true" Value="@this">
+        <CascadingValue Value="@RightToLeft">
             @ChildContent
+        </CascadingValue>
     </CascadingValue>
 </div>
 
@@ -32,11 +34,11 @@
         get => _rtl;
         set
         {
-            if (_rtl == value)
-                return;
-            _rtl = value;
-            SwapDrawerAnchors();
-            StateHasChanged();
+            if (_rtl != value)
+            {
+                _rtl = value;
+                StateHasChanged();
+            }
         }
     }
 
@@ -66,7 +68,6 @@
 
     public void FireDrawersChanged()
     {
-        //DrawersChanged?.Invoke();
         StateHasChanged();
     }
 
@@ -74,20 +75,4 @@
     {
         return _drawers.Any(d => d.Anchor == anchor);
     }
-
-    public void SwapDrawerAnchors()
-    {
-        foreach (var drawer in _drawers)
-        {
-            if(drawer.Anchor == Anchor.Left)
-            {
-                drawer.Anchor = Anchor.Right;
-            }
-            else if(drawer.Anchor == Anchor.Right)
-            {
-                drawer.Anchor = Anchor.Left;
-            }
-        }
-    }
-
 }


### PR DESCRIPTION
- Why? See this [reference](https://stackoverflow.com/questions/58852101/bl0005-external-parameter-usage-why-is-a-warning-for-that) that also links to aspnetcore repo.
- Microsoft really dont want you to set component parameters outside the component because it can break the render tree.
- In any case the changes in this PR are logical if we are going to have other components inside MudLayout that need to be notified of RTL.
- If you wanted to really optimise you can set the value once only (for example if your audience was RTL only.
- See [Chris Sainty's post](https://chrissainty.com/understanding-cascading-values-and-cascading-parameters/) for a good in depth guide to Cascading Parameters
- Built and tested on the docs site.