### PR TITLE
Fix textfield text label

### DIFF
--- a/src/MudBlazor/Styles/components/_inputcontrol.scss
+++ b/src/MudBlazor/Styles/components/_inputcontrol.scss
@@ -50,6 +50,7 @@
         line-height: 1;
         letter-spacing: 0.00938em;
         z-index: 0;
+        pointer-events:none;
 
         &.mud-disabled {
             color: var(--mud-palette-text-disabled);

--- a/src/MudBlazor/Styles/components/_inputcontrol.scss
+++ b/src/MudBlazor/Styles/components/_inputcontrol.scss
@@ -43,7 +43,7 @@
     }
 
     & > .mud-input-label-inputcontrol {
-        color: var(--mud-palette-text-primary);
+        color: var(--mud-palette-text-secondary);
         padding: 0;
         font-size: 1rem;
         font-weight: 400;


### PR DESCRIPTION
- First commit: when you try to click on a` MudTextField ` **Text variant**, in the label, the input should receive the focus and the label should shrink, but it won't, as the label will receive the click.
 This fixes it.
- Second commit: This is optional, but I think it should be considered. `MudTextField `label should be text-secondary. If not, you have the same color for the text entered as for the label, which is confusing, and you don't know if it's a `MudInput `with text or a `TextField `with no text and a label.

`MudInput `with text inside (no label)
![image](https://user-images.githubusercontent.com/13745954/102712726-198e3600-42bb-11eb-8b0b-dc5a7527bd26.png)

`MudTextField `with no text and with label. The user could think: _Is this field already filled?_ Imagine a large form...
![image](https://user-images.githubusercontent.com/13745954/102712731-2743bb80-42bb-11eb-83bf-d7fb13a3e1c7.png)

`MudTextField `with a label and no text. Could be also MudInput with placeholder and no text. But the point is "no text inside"
![image](https://user-images.githubusercontent.com/13745954/102712756-5bb77780-42bb-11eb-84c6-f1abdcafb6b4.png)


