### PR TITLE
Fix incorrect async MenuClose() MenuOpen()

### DIFF
--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -30,13 +30,13 @@ namespace MudBlazor
         [Parameter] public bool DisableRipple { get; set; }
         [Parameter] public RenderFragment ChildContent { get; set; }
 
-        public async Task CloseMenu()
+        public void CloseMenu()
         {
             isOpen = false;
             StateHasChanged();
         }
 
-        public async Task OpenMenu()
+        public void OpenMenu()
         {
             if (Disabled)
                 return;


### PR DESCRIPTION
- These functions are obviously synchronous.
- While this technically changes the public api surface even the examples don't await a task.  It just doesn't make sense.
- i.e. I don't imagine anyone is doing `var task = await MudMenu.MenuClose();`
- What this PR will do is correct the async and return type and stop giving users CS4014 - Because this call is not awaited, execution of the current method continues before the call is completed