### PR TITLE
Fix CS1998 Autocomplete Example and tests

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompleteUsageExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompleteUsageExample.razor
@@ -36,6 +36,9 @@
 
     private async Task<IEnumerable<string>> Search1(string value)
     {
+        // In real life use an asynchronous function for fetching data from an api.
+        await Task.Delay(5);
+
         // if text is null or empty, show complete list
         if (string.IsNullOrEmpty(value))
             return states;
@@ -44,6 +47,9 @@
 
     private async Task<IEnumerable<string>> Search2(string value)
     {
+        // In real life use an asynchronous function for fetching data from an api.
+        await Task.Delay(5);
+
         // if text is null or empty, don't return values (drop-down will not open)
         if (string.IsNullOrEmpty(value))
             return new string[0];

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTest1.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTest1.razor
@@ -28,6 +28,9 @@
 
     private async Task<IEnumerable<string>> Search1(string value)
     {
+        // In real life use an asynchronous function for fetching data from an api.
+        await Task.Delay(5);
+
         // if text is null or empty, show complete list
         if (string.IsNullOrEmpty(value))
             return states;

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTest2.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTest2.razor
@@ -28,6 +28,9 @@
 
     private async Task<IEnumerable<string>> Search1(string value)
     {
+        // In real life use an asynchronous function for fetching data from an api.
+        await Task.Delay(5);
+
         // if text is null or empty, show complete list
         if (string.IsNullOrEmpty(value))
             return states;

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTest3.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTest3.razor
@@ -69,6 +69,9 @@
 
     public async Task<IEnumerable<State>> SearchStateAsync(string value)
     {
+        // In real life use an asynchronous function for fetching data from an api.
+        await Task.Delay(5);
+
         IEnumerable<State> list;
         if (string.IsNullOrEmpty(value)) list = StateList;
         else list = StateList.Where(e => e.StateName.Contains(value, StringComparison.InvariantCultureIgnoreCase));

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTest4.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTest4.razor
@@ -12,6 +12,9 @@
 
     public async Task<IEnumerable<State>> SearchStateAsync(string value)
     {
+        // In real life use an asynchronous function for fetching data from an api.
+        await Task.Delay(5);
+
         return new State[0];
     }
 


### PR DESCRIPTION
- One example fixed NOTE it might be better to provide web api for the `PeriodicTable` and `States` datasets at mudblazor.com.
- Four tests fixed -  It is common to use Task.FromResult when mocking to avoid having to test async.
- There are no more examples of async without await now.
- I have not checked in the generated code as that is disappearing soon.