### PR TITLE
Fix unresponsive flexbox in menu examples

### DIFF
--- a/src/MudBlazor.Docs/Style/Components/_DocsSection.scss
+++ b/src/MudBlazor.Docs/Style/Components/_DocsSection.scss
@@ -31,6 +31,7 @@
         & > .docs-section-content-inner {
             display: flex;
             flex-grow: 1;
+            flex-wrap:wrap;
         }
     }
 


### PR DESCRIPTION
### This fix unresponsive view in mobile for a flexbox in documentation page

- Changes this (notice the right button causing overflow)

![image](https://user-images.githubusercontent.com/13745954/102941735-5a4ca180-44ab-11eb-83b7-0ee525bf3c14.png)

- Into this

![image](https://user-images.githubusercontent.com/13745954/102941687-4608a480-44ab-11eb-98ac-d8477e15b280.png)

- By adding 

```
.docs-section-content-inner {      
          flex-wrap:wrap;
        }
```

I don't think we have an example that needs `flex-wrap:nowrap`

It doesn't affect to the framework, just to the documentation site