### PR TITLE
Fix include for non-existent file

### DIFF
--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -57,7 +57,6 @@
     <None Include="bundleconfig.json">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </None>
-    <None Include="compilerconfig.build.json" />
     <None Include="compilerconfig.json">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
- Follow up to removing dotnet tool webcompiler config