### PR TITLE
Always close snackbar on click (resolves #362)

### DIFF
--- a/src/MudBlazor/Components/Snackbar/Snackbar.cs
+++ b/src/MudBlazor/Components/Snackbar/Snackbar.cs
@@ -28,10 +28,12 @@ namespace MudBlazor
         {
             if (!fromCloseIcon)
             {
-                // Execute the click action only if it's not from the close icon
-                State.Options.Onclick?.Invoke(this);
-                // If the close icon is show do not start the hiding transition
-                if (State.Options.ShowCloseIcon) return;
+                // Do not start the hiding transition if no click action
+                if (State.Options.Onclick == null)
+                    return;
+
+                // Click action is executed only if it's not from the close icon
+                State.Options.Onclick.Invoke(this);
             }
 
             State.UserHasInteracted = true;

--- a/src/MudBlazor/Components/Snackbar/State.cs
+++ b/src/MudBlazor/Components/Snackbar/State.cs
@@ -56,7 +56,7 @@ namespace MudBlazor
         {
             get
             {
-                var forceCursor = Options.ShowCloseIcon ? "" : " force-cursor";
+                var forceCursor = Options.Onclick == null ? "" : " force-cursor";
                 return $"mud-snackbar {Options.SnackbarTypeClass}{forceCursor}";
             }
         }


### PR DESCRIPTION
Following changes were made:

-The cursor pointer is used on snackbar as soon as an onclick handler is defined (previously, the cursor was shown only is there was not a close button, which is not correct, because we would want to have both a close button and an onclick handler)

-The Clicked method always close the snackbar, except if no onclick handler defined