### PR TITLE
Fixed crash when searching for icons with empty/null string

### DIFF
--- a/src/MudBlazor.Docs/Pages/Features/Icons/IconsPage.razor
+++ b/src/MudBlazor.Docs/Pages/Features/Icons/IconsPage.razor
@@ -56,7 +56,9 @@
 
     private string SelectedIconType { get; set; } = IconType.Filled;
     private string SearchText { get; set; } = string.Empty;
-    private List<MudIcons> SelectedIcons => MudIconsMaterial.Where(m => m.Name.Contains(SearchText, StringComparison.OrdinalIgnoreCase)).ToList();
+    private List<MudIcons> SelectedIcons => string.IsNullOrWhiteSpace(SearchText)
+        ? MudIconsMaterial
+        : MudIconsMaterial.Where(m => m.Name.Contains(SearchText, StringComparison.OrdinalIgnoreCase)).ToList();
     private readonly IDictionary<string, Type> IconTypes = new Dictionary<string, Type>()
 {
         { IconType.Filled, typeof(Icons.Material)},


### PR DESCRIPTION
Currently, when you search for an icon, then remove all the text in the search field, the web app crashes: https://mudblazor.com/features/icons

This is because `String.Contains` doesn't accept null, and the SearchText is null when the text field is made empty.
I simply added a `string.IsNullOrWhiteSpace` check before the contains.