### PR TITLE
Feature next previous on docs

### DIFF
--- a/src/MudBlazor.Docs/Components/NavigationFooter.razor
+++ b/src/MudBlazor.Docs/Components/NavigationFooter.razor
@@ -3,25 +3,24 @@
     <MudContainer MaxWidth=@(Section==NavigationSection.Components?MaxWidth.Medium:MaxWidth.Large)>
         <MudDivider />
         <br />
-       
-
             @if (!string.IsNullOrWhiteSpace(Previous))
-            {
-        <MudButton Color="Color.Primary"
-                   StartIcon="@Filled.NavigateBefore"
-                   Link="@($"/{Section.ToDescriptionString()}/{Previous}")">
-            @Previous
-        </MudButton>}
+             {
+                <MudButton Color="Color.Primary"
+                           StartIcon="@Filled.NavigateBefore"
+                           Link="@($"/{Section.ToDescriptionString()}/{Previous}")">
+                    @Previous
+                </MudButton>
+             }
             @if (!string.IsNullOrWhiteSpace(Next))
-            {
-        <MudButton Color="Color.Primary"
-                   Style="float:right;"
-                   EndIcon="@Filled.NavigateNext"
-                   Disabled="@(string.IsNullOrWhiteSpace(Next))"
-                   Link="@($"/{Section.ToDescriptionString()}/{Next}")">
-            @Next
-        </MudButton>}
-       
+             {
+                <MudButton Color="Color.Primary"
+                           Style="float:right;"
+                           EndIcon="@Filled.NavigateNext"
+                           Disabled="@(string.IsNullOrWhiteSpace(Next))"
+                           Link="@($"/{Section.ToDescriptionString()}/{Next}")">
+                    @Next
+                </MudButton>
+             }       
     </MudContainer>
  }
 
@@ -29,7 +28,4 @@
     [Parameter] public NavigationSection? Section { get; set; }
     [Parameter] public string Previous { get; set; }
     [Parameter] public  string Next { get; set; }
-
-       
-
 }

--- a/src/MudBlazor.Docs/Components/NavigationFooter.razor
+++ b/src/MudBlazor.Docs/Components/NavigationFooter.razor
@@ -1,0 +1,35 @@
+﻿@if (Section == NavigationSection.Components || Section == NavigationSection.Api)
+ {
+    <MudContainer MaxWidth=@(Section==NavigationSection.Components?MaxWidth.Medium:MaxWidth.Large)>
+        <MudDivider />
+        <br />
+       
+
+            @if (!string.IsNullOrWhiteSpace(Previous))
+            {
+        <MudButton Color="Color.Primary"
+                   StartIcon="@Filled.NavigateBefore"
+                   Link="@($"/{Section.ToDescriptionString()}/{Previous}")">
+            @Previous
+        </MudButton>}
+            @if (!string.IsNullOrWhiteSpace(Next))
+            {
+        <MudButton Color="Color.Primary"
+                   Style="float:right;"
+                   EndIcon="@Filled.NavigateNext"
+                   Disabled="@(string.IsNullOrWhiteSpace(Next))"
+                   Link="@($"/{Section.ToDescriptionString()}/{Next}")">
+            @Next
+        </MudButton>}
+       
+    </MudContainer>
+ }
+
+@code{
+    [Parameter] public NavigationSection? Section { get; set; }
+    [Parameter] public string Previous { get; set; }
+    [Parameter] public  string Next { get; set; }
+
+       
+
+}

--- a/src/MudBlazor.Docs/Components/NavigationFooter.razor
+++ b/src/MudBlazor.Docs/Components/NavigationFooter.razor
@@ -3,22 +3,22 @@
     <MudContainer MaxWidth=@(Section==NavigationSection.Components?MaxWidth.Medium:MaxWidth.Large)>
         <MudDivider />
         <br />
-            @if (!string.IsNullOrWhiteSpace(Previous))
+            @if (Previous!=null)
              {
                 <MudButton Color="Color.Primary"
+                           Style="text-transform:none;"
                            StartIcon="@Filled.NavigateBefore"
-                           Link="@($"/{Section.ToDescriptionString()}/{Previous}")">
-                    @Previous
+                           Link="@($"/{Section.ToDescriptionString()}/{Previous.Link}")">
+                    @Previous.Name
                 </MudButton>
              }
-            @if (!string.IsNullOrWhiteSpace(Next))
+            @if (Next!=null)
              {
                 <MudButton Color="Color.Primary"
-                           Style="float:right;"
-                           EndIcon="@Filled.NavigateNext"
-                           Disabled="@(string.IsNullOrWhiteSpace(Next))"
-                           Link="@($"/{Section.ToDescriptionString()}/{Next}")">
-                    @Next
+                           Style="float:right;text-transform:none;"
+                           EndIcon="@Filled.NavigateNext"                          
+                           Link="@($"/{Section.ToDescriptionString()}/{Next.Link}")">
+                    @Next.Name
                 </MudButton>
              }       
     </MudContainer>
@@ -26,6 +26,6 @@
 
 @code{
     [Parameter] public NavigationSection? Section { get; set; }
-    [Parameter] public string Previous { get; set; }
-    [Parameter] public  string Next { get; set; }
+    [Parameter] public NavigationFooterLink Previous { get; set; }
+    [Parameter] public NavigationFooterLink Next { get; set; }
 }

--- a/src/MudBlazor.Docs/Extensions/DocsViewExtension.cs
+++ b/src/MudBlazor.Docs/Extensions/DocsViewExtension.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 
-using MudBlazor.Docs.Models;
+using MudBlazor.Docs.Services;
 using MudBlazor.Services;
 
 namespace MudBlazor.Docs.Extensions

--- a/src/MudBlazor.Docs/Extensions/DocsViewExtension.cs
+++ b/src/MudBlazor.Docs/Extensions/DocsViewExtension.cs
@@ -1,4 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
+
+using MudBlazor.Docs.Models;
 using MudBlazor.Services;
 
 namespace MudBlazor.Docs.Extensions
@@ -21,6 +23,10 @@ namespace MudBlazor.Docs.Extensions
                 config.ShowTransitionDuration = 500;
                 config.SnackbarVariant = Variant.Filled;
             });
+
+            services.AddScoped<IDocsNavigationService,DocsNavigationService>();
+            services.AddScoped<IMenuService,MenuService>();
+            
         }
     }
 }

--- a/src/MudBlazor.Docs/Models/DocsComponents.cs
+++ b/src/MudBlazor.Docs/Models/DocsComponents.cs
@@ -6,12 +6,12 @@ namespace MudBlazor.Docs.Models
 {
     public class DocsComponents
     {
-        private List<MudComponent> _mudComponents;
+        private List<MudComponent> _mudComponents=new List<MudComponent>();
 
-        public DocsComponents()
-        {
-            _mudComponents = new List<MudComponent>();
-        }
+        /// <summary>
+        /// The elements of the list of mudcomponents
+        /// </summary>
+        internal IEnumerable<MudComponent> Elements => _mudComponents.OrderBy(e=>e.Name);       
 
         public DocsComponents AddItem(string name, Type component)
         {
@@ -43,6 +43,6 @@ namespace MudBlazor.Docs.Models
             return this;
         }
 
-        internal List<MudComponent> ToList() => _mudComponents;
+        
     }
 }

--- a/src/MudBlazor.Docs/Models/DocsNavigationService.cs
+++ b/src/MudBlazor.Docs/Models/DocsNavigationService.cs
@@ -1,0 +1,136 @@
+﻿using Microsoft.AspNetCore.Components;
+
+using System.Collections.Generic;
+using System.Linq;
+
+using MudBlazor.Docs.Extensions;
+using MudBlazor.Extensions;
+
+
+namespace MudBlazor.Docs.Models
+{
+    public interface IDocsNavigationService
+    {
+        string Next { get; }
+        string Previous { get; }
+        NavigationSection? Section { get; }
+    }
+
+    /// <summary>
+    /// The aim of this class is to provide the next and previous links for navigation footer
+    /// </summary>
+    public class DocsNavigationService : IDocsNavigationService
+    {
+        private readonly NavigationManager _navigationManager;
+        private readonly IMenuService _menuService;
+
+        //the last part of the url of the component;
+        //often is the name of the component, like in /components/button/
+        private string CurrentLink => _navigationManager.GetComponentLink();
+
+        /// <summary>
+        /// Previous link in the menu
+        /// </summary>
+        public string Previous=> GetNavigationLink( NavigationOrder.Previous);       
+       
+        /// <summary>
+        /// Next link in the menu
+        /// </summary>
+        public string Next=>GetNavigationLink( NavigationOrder.Next );          
+
+        
+        /// TODO add "get-started" and remaining sections
+        /// <summary>
+        /// The section of the menu: components or api
+        /// </summary>
+        public NavigationSection? Section
+        {
+            get
+            {
+                // return the enum corresponding to the section
+                return _navigationManager.GetSection() switch
+                {
+                    "components"=> NavigationSection.Components,
+                    "api" => NavigationSection.Api,
+                    _ => null,
+                };
+            }
+        }
+
+        //constructor for DI
+        public DocsNavigationService(NavigationManager navigationManager, IMenuService menuService)
+        {
+            _navigationManager = navigationManager;
+            _menuService = menuService;
+           
+
+        }
+
+        /// <summary>
+        /// Get the link (next or previous) for a given url and a given section
+        /// </summary>
+        /// <param name="order">next or previous</param>
+        /// <returns></returns>
+        private string GetNavigationLink( NavigationOrder order)
+        {          
+            List<string> orderedLinks =
+                Section == NavigationSection.Api
+                    ? GetOrderedMenuLinks( NavigationSection.Api)
+                    : GetOrderedMenuLinks( NavigationSection.Components);         
+
+            var index = orderedLinks.FindIndex(e => e == CurrentLink);
+            int increment =
+                order == NavigationOrder.Next
+                    ? 1
+                    : -1;
+
+            var position = index + increment;
+            //if out of index
+            if (position< 0 || position>= orderedLinks.Count)
+            {
+                return string.Empty;
+            }
+
+            var navigationLink = orderedLinks.ElementAt(position);
+            return navigationLink;
+        }
+
+        /// <summary>
+        /// Gets the last part of links from the menu in the same order as in the menu
+        /// This is the part with the name of the component
+        /// </summary>
+        /// <param name="section"> components or api </param>
+        /// <returns></returns>
+        private List<string> GetOrderedMenuLinks( NavigationSection? section)
+        {
+            var menuElements = 
+                section==NavigationSection.Components
+                    ? _menuService.DocsComponents.Elements
+                    : _menuService.DocsComponentsApi.Elements;
+
+            var links = new List<string>();
+            foreach (var menuElement in menuElements)
+            {
+                if (menuElement.Link != null)
+                {
+                    var link =
+                        section ==
+                        NavigationSection.Api
+                            ? ApiLink.GetApiLinkFor(menuElement.Component).Split("/").Last()
+                            : ApiLink.GetComponentLinkFor(menuElement.Component).Split("/").Last();
+                    links.Add(link);
+                }
+                if (menuElement.GroupItems != null)
+                    links.AddRange(menuElement.GroupItems.Elements.Select(i => i.Link).OrderBy(i => i));
+            };
+            return links;
+        }
+    }
+
+    #region ENUMS
+
+    public enum NavigationOrder { Previous, Next }
+
+    public enum NavigationSection { Api, Components }
+    #endregion
+}

--- a/src/MudBlazor.Docs/Models/FooterNavigationLink.cs
+++ b/src/MudBlazor.Docs/Models/FooterNavigationLink.cs
@@ -1,0 +1,19 @@
+﻿
+namespace MudBlazor.Docs.Models
+{
+    public class NavigationFooterLink
+    {
+        public string Name { get; set; }
+
+        public string Link { get; set; }
+
+        public NavigationFooterLink() {}
+
+        public NavigationFooterLink(string name, string link)
+        {
+            Name = name;
+            Link = link;
+        }
+        
+    }
+}

--- a/src/MudBlazor.Docs/Pages/Components/FileUpload/FileUploadPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/FileUpload/FileUploadPage.razor
@@ -1,10 +1,10 @@
 ﻿@page "/components/fileupload"
-
+@page "/components/fileuploader"
 <DocsPage>
     <DocsPageHeader Title="File Upload"
-                    SubTitle="Example on how to compose a file upload button"> 
+                    SubTitle="Example on how to compose a file upload button">
         <Description>
-           
+
             <MudText Typo="@Typo.body1" Class="mt-4">
                 To create a file upload button, we must use two elements: a <CodeInline>label</CodeInline> and an <CodeInline>input</CodeInline>.
             </MudText>
@@ -56,7 +56,7 @@
             <SectionSource Code="FileUploadButtonExample" GitHubFolderName="Button" />
         </DocsPageSection>
 
-        <DocsPageSection >
+        <DocsPageSection>
             <SectionHeader>
                 <Title>Use a standard label</Title>
                 <Description>Use an html label styled to your liking in combination with a hidden InputFile</Description>

--- a/src/MudBlazor.Docs/Services/MenuService.cs
+++ b/src/MudBlazor.Docs/Services/MenuService.cs
@@ -1,0 +1,130 @@
+﻿
+namespace MudBlazor.Docs.Models
+{
+    public interface IMenuService
+    {
+        DocsComponents DocsComponents { get; }
+        DocsComponents DocsComponentsApi { get; }
+    }
+        
+    /// <summary>
+    /// The aim of this class is to add new items to NavMenu
+    /// </summary>
+    public class MenuService : IMenuService
+    {
+        private DocsComponents _docsComponents;
+
+        //cached property
+        //`??=` means If _docsComponents is null, assign it. The next time gets cached value
+
+        /// <summary>
+        /// Here is where the links for the Components Menu in NavMenu are added
+        /// Add here the new menu elements without caring about the order.
+        /// They will be reordered automatically
+        /// </summary>
+        public DocsComponents DocsComponents => _docsComponents ??= new DocsComponents()
+            //Individual elements
+            .AddItem("Container", typeof(MudContainer))
+            .AddItem("Grid", typeof(MudGrid))
+            .AddItem("Hidden", typeof(MudHidden))
+            .AddItem("Chips", typeof(MudChip))
+            .AddItem("ChipSet", typeof(MudChipSet))
+            .AddItem("Badge", typeof(MudBadge))
+            .AddItem("AppBar", typeof(MudAppBar))
+            .AddItem("Drawer", typeof(MudDrawer))
+            .AddItem("Link", typeof(MudLink))
+            .AddItem("Menu", typeof(MudMenu))
+            .AddItem("Nav Menu", typeof(MudNavMenu))
+            .AddItem("Tabs", typeof(MudTabs))
+            .AddItem("Progress", typeof(MudProgressCircular))
+            .AddItem("Dialog", typeof(MudDialog))
+            .AddItem("Snackbar", typeof(MudSnackbarProvider))
+            .AddItem("Avatar", typeof(MudAvatar))
+            .AddItem("Alert", typeof(MudAlert))
+            .AddItem("Card", typeof(MudCard))
+            .AddItem("Divider", typeof(MudDivider))
+            .AddItem("Expansion Panel", typeof(MudExpansionPanel))
+            .AddItem("Icons", typeof(MudIcon))
+            .AddItem("List", typeof(MudList))
+            .AddItem("Paper", typeof(MudPaper))
+            .AddItem("Rating", typeof(MudRating))
+            .AddItem("Skeleton", typeof(MudSkeleton))
+            .AddItem("Table", typeof(MudTable<T>))
+            .AddItem("Simple Table", typeof(MudSimpleTable))
+            .AddItem("Tooltip", typeof(MudTooltip))
+            .AddItem("Typography", typeof(MudText))
+            .AddItem("Overlay", typeof(MudOverlay))
+            .AddItem("Highlighter", typeof(MudHighlighter))
+            .AddItem("Element", typeof(MudElement))
+            .AddItem("FileUpload", typeof(MudButton))
+
+            //GROUPS
+
+            //Inputs
+            .AddNavGroup("Form Inputs & controls", false, new DocsComponents()
+                .AddItem("Radio", typeof(MudRadio))
+                .AddItem("Checkbox", typeof(MudCheckBox<T>))
+                .AddItem("Select", typeof(MudSelect<T>))
+                .AddItem("Slider", typeof(MudSlider<T>))
+                .AddItem("Switch", typeof(MudSwitch<T>))
+                .AddItem("Text Field", typeof(MudTextField<T>))
+                .AddItem("Form", typeof(MudForm))
+                .AddItem("Autocomplete", typeof(MudAutocomplete<T>))
+                .AddItem("Field", typeof(MudField))
+            )
+
+            //Pickers
+            .AddNavGroup("Pickers", false, new DocsComponents()
+                .AddItem("Date Picker", typeof(MudDatePicker))
+                .AddItem("Time Picker", typeof(MudTimePicker))
+            )
+
+            //Buttons
+            .AddNavGroup("Buttons", false, new DocsComponents()
+                .AddItem("Button", typeof(MudButton))
+                .AddItem("IconButton", typeof(MudIconButton))
+                .AddItem("ToggleIconButton", typeof(MudToggleIconButton))
+                .AddItem("Button FAB", typeof(MudFab))
+            )
+
+            //Charts
+            .AddNavGroup("Charts", false, new DocsComponents()
+                .AddItem("Donut chart", typeof(MudChart))
+                .AddItem("Line chart", typeof(MudChart))
+                .AddItem("Pie chart", typeof(MudChart))
+            );
+
+        private DocsComponents _docsComponentsApi;
+
+        //cached property
+        /// <summary>
+        /// This autogenerates the Menu for the API
+        /// </summary>
+        public DocsComponents DocsComponentsApi
+        {
+            get
+            {
+                //caching property
+                if (_docsComponentsApi != null) return _docsComponentsApi;
+
+                _docsComponentsApi = new DocsComponents();
+                foreach (var item in DocsComponents.Elements)
+                {
+                    if (item.IsNavGroup)
+                    {
+                        foreach (var ApiItem in item.GroupItems.Elements)
+                        {
+                            _docsComponentsApi.AddItem(ApiItem.Name, ApiItem.Component);
+                        }
+                    }
+                    else
+                    {
+                        _docsComponentsApi.AddItem(item.Name, item.Component);
+                    }
+                }
+
+                return _docsComponentsApi;
+            }
+        }
+    }
+}

--- a/src/MudBlazor.Docs/Services/MenuService.cs
+++ b/src/MudBlazor.Docs/Services/MenuService.cs
@@ -1,5 +1,5 @@
-﻿
-namespace MudBlazor.Docs.Models
+﻿using MudBlazor.Docs.Models;
+namespace MudBlazor.Docs.Services
 {
     public interface IMenuService
     {
@@ -56,7 +56,7 @@ namespace MudBlazor.Docs.Models
             .AddItem("Overlay", typeof(MudOverlay))
             .AddItem("Highlighter", typeof(MudHighlighter))
             .AddItem("Element", typeof(MudElement))
-            .AddItem("FileUpload", typeof(MudButton))
+            .AddItem("FileUpload", typeof(MudFileUploader))
 
             //GROUPS
 

--- a/src/MudBlazor.Docs/Shared/MainLayout.razor
+++ b/src/MudBlazor.Docs/Shared/MainLayout.razor
@@ -1,5 +1,5 @@
 @inherits LayoutComponentBase
-@inject NavigationManager NavMan
+
 
 <MudThemeProvider Theme="currentTheme"/>
 <MudDialogProvider FullWidth="true" MaxWidth="MaxWidth.ExtraSmall" />
@@ -20,82 +20,18 @@
             <MudIconButton Icon="@Icons.Material.FormatTextdirectionRToL" Color="Color.Inherit" OnClick="@((e) => RightToLeftToggle())" />
         </MudTooltip>
     </MudAppBar>
-    <MudDrawer @bind-Open=_drawerOpen Elevation="25" Class="mudblazor-appbar-band">
-        <MudDrawerHeader Class="mudblazor-brand" LinkToIndex="true">
-            <MudBlazorLogo />
-        </MudDrawerHeader>
-        <NavMenu />
-    </MudDrawer>
-    <MudMainContent Class="mudblazor-main-content">
-        @Body
-    </MudMainContent>
+    
+        <MudDrawer @bind-Open=_drawerOpen Elevation="25" Class="mudblazor-appbar-band">
+            <MudDrawerHeader Class="mudblazor-brand" LinkToIndex="true">
+                <MudBlazorLogo />
+            </MudDrawerHeader>
+            <NavMenu @ref="@_navMenuRef"/>
+        </MudDrawer>
+        <MudMainContent Class="mudblazor-main-content">
+            @Body            
+            <NavigationFooter Section=_section Previous="@_previous" Next="@_next" />
+        </MudMainContent>
+    
 </MudLayout>
 
-@code {
-
-    bool _drawerOpen = false;
-    bool _rightToLeft = false;
-
-    void DrawerToggle()
-    {
-        _drawerOpen = !_drawerOpen;
-    }
-
-    void RightToLeftToggle()
-    {
-        _rightToLeft = !_rightToLeft;
-    }
-
-    protected override void OnInitialized()
-    {
-        currentTheme = defaultTheme;
-        //if not home page, the navbar starts open
-        if (!NavMan.IsHomePage())
-        {
-            _drawerOpen = true;
-        }
-    }
-
-    void DarkMode()
-    {
-        if (currentTheme == defaultTheme)
-        {
-            currentTheme = darkTheme;
-        }
-        else
-        {
-            currentTheme = defaultTheme;
-        }
-    }
-
-    MudTheme currentTheme = new MudTheme();
-    MudTheme defaultTheme = new MudTheme()
-    {
-        Palette = new Palette()
-        {
-            Black = "#272c34"
-        }
-    };
-
-    MudTheme darkTheme = new MudTheme()
-    {
-        Palette = new Palette()
-        {
-            Black = "#27272f",
-            Background = "#32333d",
-            BackgroundGrey = "#27272f",
-            Surface = "#373740",
-            DrawerBackground = "#27272f",
-            DrawerText = "rgba(255,255,255, 0.50)",
-            AppbarBackground = "#27272f",
-            AppbarText = "rgba(255,255,255, 0.70)",
-            TextPrimary = "rgba(255,255,255, 0.70)",
-            TextSecondary = "rgba(255,255,255, 0.50)",
-            ActionDefault = "#adadb1",
-            ActionDisabled = "rgba(255,255,255, 0.26)",
-            ActionDisabledBackground = "rgba(255,255,255, 0.12)",
-            DrawerIcon = "rgba(255,255,255, 0.50)"
-        }
-    };
-}
 

--- a/src/MudBlazor.Docs/Shared/MainLayout.razor.cs
+++ b/src/MudBlazor.Docs/Shared/MainLayout.razor.cs
@@ -2,7 +2,7 @@
 
 using MudBlazor.Docs.Extensions;
 using MudBlazor.Docs.Models;
-using MudBlazor.Extensions;
+using MudBlazor.Docs.Services;
 
 namespace MudBlazor.Docs.Shared
 {
@@ -11,8 +11,8 @@ namespace MudBlazor.Docs.Shared
 
         bool _drawerOpen = false;
         bool _rightToLeft = false;
-        string _previous;
-        string _next;
+        NavigationFooterLink _previous;
+        NavigationFooterLink _next;
         NavigationSection? _section =null;
         NavMenu _navMenuRef;
 

--- a/src/MudBlazor.Docs/Shared/MainLayout.razor.cs
+++ b/src/MudBlazor.Docs/Shared/MainLayout.razor.cs
@@ -1,0 +1,101 @@
+﻿using Microsoft.AspNetCore.Components;
+
+using MudBlazor.Docs.Extensions;
+using MudBlazor.Docs.Models;
+using MudBlazor.Extensions;
+
+namespace MudBlazor.Docs.Shared
+{
+    public partial class MainLayout:LayoutComponentBase
+    {
+
+        bool _drawerOpen = false;
+        bool _rightToLeft = false;
+        string _previous;
+        string _next;
+        NavigationSection? _section =null;
+        NavMenu _navMenuRef;
+
+        [Inject] IDocsNavigationService DocsService { get; set; }
+        [Inject]  NavigationManager NavigationManager { get; set; }
+        
+        void DrawerToggle()
+        {
+            _drawerOpen = !_drawerOpen;
+        }
+
+        void RightToLeftToggle()
+        {
+            _rightToLeft = !_rightToLeft;
+        }
+
+        protected override void OnInitialized()
+        {
+            currentTheme = defaultTheme;
+            //if not home page, the navbar starts open
+            if (!NavigationManager.IsHomePage())
+            {
+                _drawerOpen = true;
+            }
+        }
+
+        protected override void OnParametersSet()
+        {
+            _previous = DocsService.Previous;
+            _next = DocsService.Next;
+            _section = DocsService.Section;
+        }
+
+        protected override void OnAfterRender(bool firstRender)
+        {
+            //refresh nav menu because no parameters change in nav menu
+            //but internal data does
+            _navMenuRef.Refresh();
+        }
+
+        #region Theme        
+
+        void DarkMode()
+        {
+            if (currentTheme == defaultTheme)
+            {
+                currentTheme = darkTheme;
+            }
+            else
+            {
+                currentTheme = defaultTheme;
+            }
+        }
+
+        MudTheme currentTheme = new MudTheme();
+        readonly MudTheme defaultTheme = new MudTheme()
+        {
+            Palette = new Palette()
+            {
+                Black = "#272c34"
+            }
+        };
+        readonly MudTheme darkTheme = new MudTheme()
+        {
+            Palette = new Palette()
+            {
+                Black = "#27272f",
+                Background = "#32333d",
+                BackgroundGrey = "#27272f",
+                Surface = "#373740",
+                DrawerBackground = "#27272f",
+                DrawerText = "rgba(255,255,255, 0.50)",
+                AppbarBackground = "#27272f",
+                AppbarText = "rgba(255,255,255, 0.70)",
+                TextPrimary = "rgba(255,255,255, 0.70)",
+                TextSecondary = "rgba(255,255,255, 0.50)",
+                ActionDefault = "#adadb1",
+                ActionDisabled = "rgba(255,255,255, 0.26)",
+                ActionDisabledBackground = "rgba(255,255,255, 0.12)",
+                DrawerIcon = "rgba(255,255,255, 0.50)"
+            }
+        };
+
+        #endregion
+    }
+}

--- a/src/MudBlazor.Docs/Shared/NavMenu.razor
+++ b/src/MudBlazor.Docs/Shared/NavMenu.razor
@@ -1,6 +1,8 @@
 @using System.Linq
 @using MudBlazor.Docs.Extensions
 @inject NavigationManager NavMan
+@inject IMenuService _menuService
+
 <MudNavMenu Class="mudblazor-navmenu">
     <div class="docs-nav-fader"></div>
     
@@ -13,19 +15,20 @@
         <MudNavLink Href="getting-started/wireframes">Wireframes</MudNavLink>
     </MudNavGroup>
 
+    @*COMPONENTS*@
     <MudNavGroup Title="Components"
                  Icon="@Icons.Material.Dashboard"
                  Expanded="@(_section == "components")"
                  ExpandIcon="@Icons.Material.ExpandMore">
-        @foreach (var item in DocsComponents.ToList().OrderBy(i => i.Name))
+        @foreach (var item in _menuService.DocsComponents.Elements)
         {
             if (item.IsNavGroup)
             {
                 <MudNavGroup Title="@item.Name" Expanded="@(IsSubGroupExpanded(item))" ExpandIcon="@Icons.Material.ExpandMore">
-                    @foreach (var item in item.GroupItems.ToList().OrderBy(i => i.Name))
+                    @foreach (var subItem in item.GroupItems.Elements) 
                     {
-                        string href = $"components/{item.Link}";
-                        <MudNavLink Href="@href">@item.Name</MudNavLink>
+                        string href = $"components/{subItem.Link}";
+                        <MudNavLink Href="@href">@subItem.Name</MudNavLink>
                     }
                 </MudNavGroup>
             }
@@ -36,12 +39,13 @@
             }
         }
     </MudNavGroup>
-
+    
+    @*API*@
     <MudNavGroup Title="API"
                  Icon="@Icons.Material.Api"
                   Expanded="@(_section == "api")" 
                  ExpandIcon="@Icons.Material.ExpandMore">
-        @foreach (var item in DocsComponentsAPI.ToList().OrderBy(i => i.Name))
+        @foreach (var item in _menuService.DocsComponentsApi.Elements)
         {
             <MudNavLink Href="@ApiLink.GetApiLinkFor(item.Component)">@item.Name</MudNavLink>
         }
@@ -86,104 +90,22 @@
 <div class="docs-nav-filler"></div>
 
 @code {
-    DocsComponents DocsComponents = new DocsComponents();
-    DocsComponents DocsComponentsAPI = new DocsComponents();
-    
+
+
     //sections are "getting-started","components", "api", ...
     string _section;
+
     //component links are the part of the url that tells us what component is featured
     string _componentLink;
-    protected override void OnInitialized()
+
+    public void Refresh()
     {
         _section = NavMan.GetSection();
         _componentLink = NavMan.GetComponentLink();
-
-        AddDocsComponents();
-        AddDocsComponentsApi();
+        StateHasChanged();
     }
 
-    void AddDocsComponents()
-    {
-        DocsComponents.AddItem("Container", typeof(MudContainer))
-                                    .AddItem("Grid", typeof(MudGrid))
-                                    .AddItem("Hidden", typeof(MudHidden))
-                                    .AddNavGroup("Buttons", false, new DocsComponents()
-                                        .AddItem("Button", typeof(MudButton))
-                                        .AddItem("IconButton", typeof(MudIconButton))
-                                        .AddItem("ToggleIconButton", typeof(MudToggleIconButton))
-                                        .AddItem("Button FAB", typeof(MudFab)))
-                                    .AddNavGroup("Charts", false, new DocsComponents()
-                                            .AddItem("Donut chart", typeof(MudComponent))
-                                            .AddItem("Line chart", typeof(MudComponent))
-                                            .AddItem("Pie chart", typeof(MudComponent)))
-                                    .AddItem("Checkbox", typeof(MudCheckBox<T>))
-                                    .AddItem("Chips", typeof(MudChip))
-                                    .AddItem("ChipSet", typeof(MudChipSet))
-                                    .AddItem("Badge", typeof(MudBadge))
-                                        .AddNavGroup("Form Inputs & controls", false, new DocsComponents()
-                                            .AddItem("Radio", typeof(MudRadio))
-                                            .AddItem("Select", typeof(MudSelect<T>))
-                                            .AddItem("Slider", typeof(MudSlider<T>))
-                                            .AddItem("Switch", typeof(MudSwitch<T>))
-                                            .AddItem("Text Field", typeof(MudTextField<T>))
-                                            .AddItem("Form", typeof(MudForm))
-                                            .AddItem("Autocomplete", typeof(MudAutocomplete<T>))
-                                            .AddItem("Field", typeof(MudField))
-                                        )
-                                    .AddItem("AppBar", typeof(MudAppBar))
-                                    .AddItem("Drawer", typeof(MudDrawer))
-                                    .AddItem("Link", typeof(MudLink))
-                                    .AddItem("Menu", typeof(MudMenu))
-                                    .AddItem("Nav Menu", typeof(MudNavMenu))
-                                    .AddItem("Tabs", typeof(MudTabs))
-                                        .AddNavGroup("Pickers", false, new DocsComponents()
-                                            .AddItem("Date Picker", typeof(MudDatePicker))
-                                            .AddItem("Time Picker", typeof(MudTimePicker))
-                                        )
-                                    .AddItem("Progress", typeof(MudProgressCircular))
-                                    .AddItem("Dialog", typeof(MudDialog))
-                                    .AddItem("Snackbar", typeof(MudSnackbarProvider))
-                                    .AddItem("Avatar", typeof(MudAvatar))
-                                    .AddItem("Alert", typeof(MudAlert))
-                                    .AddItem("Card", typeof(MudCard))
-                                    .AddItem("Divider", typeof(MudDivider))
-                                    .AddItem("Expansion Panel", typeof(MudExpansionPanel))
-                                    .AddItem("Icons", typeof(MudIcon))
-                                    .AddItem("List", typeof(MudList))
-                                    .AddItem("Paper", typeof(MudPaper))
-                                    .AddItem("Rating", typeof(MudRating))
-                                    .AddItem("Skeleton", typeof(MudSkeleton))
-                                    .AddItem("Table", typeof(MudTable<T>))
-                                    .AddItem("Simple Table", typeof(MudSimpleTable))
-                                    .AddItem("Tooltip", typeof(MudTooltip))
-                                    .AddItem("Typography", typeof(MudText))
-                                    .AddItem("Overlay", typeof(MudOverlay))
-                                    .AddItem("Highlighter", typeof(MudHighlighter))
-                                    .AddItem("Element", typeof(MudElement))
-                                    .AddItem("FileUpload", typeof(MudElement));
-
-
-    }
-
-    void AddDocsComponentsApi()
-    {
-        foreach (var item in DocsComponents.ToList())
-        {
-            if (item.IsNavGroup)
-            {
-                foreach (var ApiItem in item.GroupItems.ToList())
-                {
-                    DocsComponentsAPI.AddItem(ApiItem.Name, ApiItem.Component);
-                }
-            }
-            else
-            {
-                DocsComponentsAPI.AddItem(item.Name, item.Component);
-            }
-        }
-    }
-
-    bool IsSubGroupExpanded(MudComponent item)
+        bool IsSubGroupExpanded(MudComponent item)
     {
         #region comment about is subgroup expanded
         //if the route contains any of the links of the subgroup, then the subgroup
@@ -195,6 +117,6 @@
         //radio, select...
         //this route `/components/autocomplete` should open the subgroup "form inputs..."
         #endregion
-        return item.GroupItems.ToList().Any(i => i.Link ==_componentLink);
+        return item.GroupItems.Elements.Any(i => i.Link ==_componentLink);
     }
 }

--- a/src/MudBlazor.Docs/Shared/NavMenu.razor
+++ b/src/MudBlazor.Docs/Shared/NavMenu.razor
@@ -1,5 +1,6 @@
 @using System.Linq
 @using MudBlazor.Docs.Extensions
+
 @inject NavigationManager NavMan
 @inject IMenuService _menuService
 

--- a/src/MudBlazor.Docs/_Imports.razor
+++ b/src/MudBlazor.Docs/_Imports.razor
@@ -12,4 +12,5 @@
 @using MudBlazor.Docs.Models
 @using MudBlazor.Docs.Components
 @using MudBlazor.Docs.Examples
-@using MudBlazor.Docs.Extensions
+@using MudBlazor.Docs.Models
+@using MudBlazor.Docs.Services

--- a/src/MudBlazor.Docs/_Imports.razor
+++ b/src/MudBlazor.Docs/_Imports.razor
@@ -5,9 +5,11 @@
 @using Microsoft.JSInterop
 
 @using MudBlazor
+@using MudBlazor.Extensions
+
 @using MudBlazor.Docs.Pages
 @using MudBlazor.Docs.Shared
 @using MudBlazor.Docs.Models
 @using MudBlazor.Docs.Components
 @using MudBlazor.Docs.Examples
-@using MudBlazor.Docs.Extensions 
+@using MudBlazor.Docs.Extensions

--- a/src/MudBlazor/Components/FileUploader/MudFileUploader.razor
+++ b/src/MudBlazor/Components/FileUploader/MudFileUploader.razor
@@ -1,0 +1,4 @@
+﻿@namespace MudBlazor
+@inherits MudBaseButton
+
+@*TODO*@ 


### PR DESCRIPTION
- This is a enhancement for the docs site
- It does not affect the framework API
- Components and Api sections can be navigated through a footer with `next >`  `< previous` links
- Will be later improved with the remaining sections
- The components menu items must be added now in a new service, MenuService, instead of the NavMenu component


![image](https://user-images.githubusercontent.com/13745954/103150962-4c2fa700-4771-11eb-8842-4b95048b40e9.png)

