### PR TITLE
Bug fix: global snackbar ShowCloseIcon not working

### DIFF
--- a/src/MudBlazor/Components/Snackbar/CommonSnackbarOptions.cs
+++ b/src/MudBlazor/Components/Snackbar/CommonSnackbarOptions.cs
@@ -6,6 +6,7 @@ namespace MudBlazor
     public abstract class CommonSnackbarOptions
     {
         public int MaximumOpacity { get; set; } = 95;
+
         public int ShowTransitionDuration { get; set; } = 1000;
 
         public int VisibleStateDuration { get; set; } = 5000;
@@ -19,5 +20,19 @@ namespace MudBlazor
         public bool BackgroundBlurred { get; set; } = false;
 
         public Variant SnackbarVariant { get; set; } = Variant.Filled;
+
+        protected CommonSnackbarOptions() { }
+
+        protected CommonSnackbarOptions(CommonSnackbarOptions options)
+        {
+            MaximumOpacity = options.MaximumOpacity;
+            ShowTransitionDuration = options.ShowTransitionDuration;
+            VisibleStateDuration = options.VisibleStateDuration;
+            HideTransitionDuration = options.HideTransitionDuration;
+            ShowCloseIcon = options.ShowCloseIcon;
+            RequireInteraction = options.RequireInteraction;
+            BackgroundBlurred = options.BackgroundBlurred;
+            SnackbarVariant = options.SnackbarVariant;
+        }
     }
 }

--- a/src/MudBlazor/Components/Snackbar/SnackbarConfiguration.cs
+++ b/src/MudBlazor/Components/Snackbar/SnackbarConfiguration.cs
@@ -2,7 +2,6 @@
 //Changes and improvements Copyright (c) The MudBlazor Team.
 
 using System;
-using MudBlazor.Extensions;
 
 namespace MudBlazor
 {
@@ -62,22 +61,6 @@ namespace MudBlazor
             NewestOnTop = false;
             PreventDuplicates = true;
             MaxDisplayedSnackbars = 5;
-        }
-
-        internal string SnackbarTypeClass(Severity severity, Variant variant, bool blurred)
-        {
-            string backgroundClass = "";
-
-            if (blurred && variant != Variant.Filled)
-            {
-                backgroundClass = "mud-snackbar-blurred";
-            }
-            else if(!blurred && variant != Variant.Filled)
-            {
-                backgroundClass = "mud-snackbar-surface";
-            }
-
-            return $"mud-alert-{variant.ToDescriptionString()}-{severity.ToDescriptionString()} {backgroundClass}";
         }
     }
 }

--- a/src/MudBlazor/Components/Snackbar/SnackbarOptions.cs
+++ b/src/MudBlazor/Components/Snackbar/SnackbarOptions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using MudBlazor.Extensions;
 
 namespace MudBlazor
 {
@@ -14,20 +15,16 @@ namespace MudBlazor
 
         public string SnackbarTypeClass { get; set; }
 
-        public SnackbarOptions(Severity severity, SnackbarConfiguration configuration)
+        public SnackbarOptions(Severity severity, CommonSnackbarOptions options) : base(options)
         {
             Severity = severity;
-            SnackbarTypeClass = configuration.SnackbarTypeClass(severity, configuration.SnackbarVariant, configuration.BackgroundBlurred);
 
-            MaximumOpacity = configuration.MaximumOpacity;
+            SnackbarTypeClass = $"mud-alert-{SnackbarVariant.ToDescriptionString()}-{severity.ToDescriptionString()}";
 
-            ShowTransitionDuration = configuration.ShowTransitionDuration;
-
-            VisibleStateDuration = configuration.VisibleStateDuration;
-
-            HideTransitionDuration = configuration.HideTransitionDuration;
-
-            RequireInteraction = configuration.RequireInteraction;
+            if (SnackbarVariant != Variant.Filled)
+            {
+                SnackbarTypeClass += BackgroundBlurred ? " mud-snackbar-blurred" : " mud-snackbar-surface";
+            }
         }
     }
 }


### PR DESCRIPTION
Setting ShowCloseIcon to false on global snackbar settings did not hide the close icon on the snackbars with default options (but it was still possible to hide it on a one-by-one basis by using the Options object returned by Snackbar.Add, as demonstrated in the Doc)

The problem was that all properties from global settings object were copied when a new snackbar was initialized, except the ShowCloseIcon property.

What I did:
-Moved all the copy instructions on a copy constructor on CommonSnackbarOptions class
-Added the missing line to copy ShowCloseIcon
-Some refactoring on SnackbarOptions class
