### PR TITLE
Fix CS4014 Simple

### DIFF
--- a/src/MudBlazor/Components/Dialog/MudDialogInstance.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialogInstance.razor.cs
@@ -45,19 +45,19 @@ namespace MudBlazor
             Title = title;
             StateHasChanged();
         }
-        public async Task Close()
+        public void Close()
         {
-            await Close(DialogResult.Ok<object>(null));
+            Close(DialogResult.Ok<object>(null));
         }
 
-        public async Task Close(DialogResult dialogResult)
+        public void Close(DialogResult dialogResult)
         {
-            await Parent.DismissInstance(Id, dialogResult);
+            _ = Parent.DismissInstance(Id, dialogResult);
         }
 
-        public async Task Cancel()
+        public void Cancel()
         {
-            await Close(DialogResult.Cancel());
+            Close(DialogResult.Cancel());
         }
 
         private void ConfigureInstance()
@@ -159,11 +159,11 @@ namespace MudBlazor
             return false;
         }
 
-        private async Task HandleBackgroundClick()
+        private void HandleBackgroundClick()
         {
             if (DisableBackdropClick) return;
 
-            await Cancel();
+            Cancel();
         }
 
     }

--- a/src/MudBlazor/Services/ResizeListener/ResizeListenerService.cs
+++ b/src/MudBlazor/Services/ResizeListener/ResizeListenerService.cs
@@ -46,7 +46,7 @@ namespace MudBlazor.Services
             _onResized -= value;
             if (_onResized == null)
             {
-                Cancel().ConfigureAwait(false);
+                Cancel().RunSynchronously();
             }
         }
 
@@ -54,15 +54,15 @@ namespace MudBlazor.Services
         {
             if (_onResized == null)
             {
-                Task.Run(async () => await Start());
+                Start().RunSynchronously();
             }
             _onResized += value;
         }
 
-        private async ValueTask<bool> Start() =>
+        private async Task<bool> Start() =>
             await _jsRuntime.InvokeAsync<bool>($"resizeListener.listenForResize", DotNetObjectReference.Create(this), _options);
 
-        private async ValueTask Cancel()
+        private async Task Cancel()
         {
             try
             {
@@ -194,11 +194,11 @@ namespace MudBlazor.Services
         }
 
         bool disposed;
-        protected virtual void Dispose(bool disposing)
+        protected async virtual void Dispose(bool disposing)
         {
             if (!disposed)
             {
-                Cancel();
+                await Cancel();
                 if (disposing)
                 {
                     _onResized = null;


### PR DESCRIPTION
- Some easy ones.
- It was decided @henon @mikes-gh that it doesnt make sense to await `Dialog.Cancel()` or `Dialog.Close()` therefore we discard `_ =` the task at the component level.
- We wait for the event registration in the resize listener and also de-registration on dispose.