### PR TITLE
Allow dialog options to be set from dialog component itself

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Dialog/DialogPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/DialogPage.razor
@@ -47,7 +47,7 @@
             </SectionHeader>
             <MarkdownDialogParameters />
             <SectionHeader>
-                <SubTitle>2. Per Dialog</SubTitle>
+                <SubTitle>2. Per Dialog (on open)</SubTitle>
                 <Description>
                     Below we pass along the DialogOptions class when we open the dialog, this can be done per dialog or you can predefine a bunch of them that you use for specific cases in your system.<br />
                 </Description>
@@ -56,6 +56,24 @@
                 <DialogOptionsExample />
             </SectionContent>
             <SectionSource Code="DialogOptionsExample" GitHubFolderName="Dialog" ShowCode="false" />
+            <SectionHeader>
+                <SubTitle>3. Per Dialog (from dialog)</SubTitle>
+                <Description>
+                    The title and the options can also be modified from the dialog component itself by calling <CodeInline>SetTitle</CodeInline> and <CodeInline>SetOptions</CodeInline> on the <CodeInline>MudDialogInstance</CodeInline> object.
+                </Description>
+            </SectionHeader>
+            <SectionContent Outlined="true">
+                <DialogSetOptionsExample />
+            </SectionContent>
+            <MudTabs Rounded="true" Outlined="true" Class="mt-4">
+                <MudTabPanel Text="Hide Source" />
+                <MudTabPanel Text="Page.razor">
+                    <SectionSource Code="DialogSetOptionsExample" GitHubFolderName="Dialog" NoToolbar="true" Class="mt-8" />
+                </MudTabPanel>
+                <MudTabPanel Text="Dialog.razor">
+                    <SectionSource Code="DialogSetOptionsExample_Dialog" GitHubFolderName="Dialog" NoToolbar="true" Class="mt-8" />
+                </MudTabPanel>
+            </MudTabs>
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>

--- a/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogScrollableExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogScrollableExample.razor
@@ -2,22 +2,16 @@
 
 @inject IDialogService Dialog
 
-<MudButton Variant="Variant.Outlined" Color="Color.Primary" @onclick="OpenSimpleDialog">Scrollable Dialog</MudButton>
+<MudButton OnClick="OpenDialog" Variant="Variant.Filled" Color="Color.Primary">
+    Scrollable Dialog
+</MudButton>
 
 @code {
-    bool HideSourceSimpleDialog = true;
-
-    public void ShowSimpleDialogSource()
-    {
-        HideSourceSimpleDialog = !HideSourceSimpleDialog;
-    }
-
     bool license_accepted = false;
 
-    async Task OpenSimpleDialog()
+    async Task OpenDialog()
     {
-        var userSelect = Dialog.Show<DialogScrollableExample_Dialog>("MudBlazor License");
-        var result = await userSelect.Result;
+        var result = await Dialog.Show<DialogScrollableExample_Dialog>("MudBlazor License").Result;
 
         if (!result.Cancelled)
         {

--- a/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogSetOptionsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogSetOptionsExample.razor
@@ -1,0 +1,15 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+@inject IDialogService Dialog
+
+<MudButton OnClick="OpenDialog" Variant="Variant.Filled" Color="Color.Primary">
+    Options Dialog
+</MudButton>
+
+@code {
+
+    private void OpenDialog()
+    {
+       Dialog.Show<DialogSetOptionsExample_Dialog>("Options Dialog");
+    }
+}

--- a/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogSetOptionsExample_Dialog.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogSetOptionsExample_Dialog.razor
@@ -1,0 +1,44 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudDialog>
+    <DialogContent>
+        <div class="d-flex flex-column py-1">
+            <MudButton OnClick="ChangeTitle">Change Title</MudButton>
+            <MudButton OnClick="ToggleCloseButton">Toggle Close Button</MudButton>
+            <MudButton OnClick="ToggleFullWidth">Toggle Full Width</MudButton>
+            <MudButton OnClick="ToggleHeader">Toggle Header</MudButton>
+        </div>
+    </DialogContent>
+    <DialogActions>
+        <MudButton Color="Color.Primary" OnClick="Close">Ok</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] MudDialogInstance MudDialog { get; set; }
+
+    Task Close() => MudDialog.Close(DialogResult.Ok(true));
+
+    void ChangeTitle()
+    {
+        MudDialog.SetTitle("Current time is: " + DateTime.Now);
+    }
+
+    void ToggleCloseButton()
+    {
+        MudDialog.Options.CloseButton = !(MudDialog.Options.CloseButton ?? false);
+        MudDialog.SetOptions(MudDialog.Options);
+    }
+
+    void ToggleFullWidth()
+    {
+        MudDialog.Options.FullWidth = !(MudDialog.Options.FullWidth ?? true);
+        MudDialog.SetOptions(MudDialog.Options);
+    }
+
+    void ToggleHeader()
+    {
+        MudDialog.Options.NoHeader = !(MudDialog.Options.NoHeader ?? false);
+        MudDialog.SetOptions(MudDialog.Options);
+    }
+}

--- a/src/MudBlazor/Components/Dialog/MudDialogInstance.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialogInstance.razor.cs
@@ -40,11 +40,19 @@ namespace MudBlazor
             ConfigureInstance();
         }
 
+        public void SetOptions(DialogOptions options)
+        {
+            Options = options;
+            ConfigureInstance();
+            StateHasChanged();
+        }
+
         public void SetTitle(string title)
         {
             Title = title;
             StateHasChanged();
         }
+
         public async Task Close()
         {
             await Close(DialogResult.Ok<object>(null));
@@ -165,6 +173,5 @@ namespace MudBlazor
 
             await Cancel();
         }
-
     }
 }


### PR DESCRIPTION
Sometimes it is useful to let the dialog component decides itself some of its options. For example, if it should have a header, a close button, if it should be full width, etc.

The MudDialogInstance object received by the dialog component already had a SetTitle method, which can be used by the component to define its own title, but there was no SetOptions method to control the other options.

This PR adds a SetOptions method on the MudDialogInstance class and an usage example in the doc.

(also did a little cleanup on DialogScrollableExample to uniformize and remove some dead code)