### PR TITLE
Fixed: Scrollable dialog example in doc not working in wasm

### DIFF
--- a/src/MudBlazor.Docs.Compiler/TestsForApiPages.cs
+++ b/src/MudBlazor.Docs.Compiler/TestsForApiPages.cs
@@ -34,6 +34,7 @@ namespace MudBlazor.Docs.Compiler
                 cb.AddLine("using MudBlazor.Docs.Components;");
                 cb.AddLine("using Bunit.Rendering;");
                 cb.AddLine("using System;");
+                cb.AddLine("using System.Net.Http;");
                 cb.AddLine("using Toolbelt.Blazor.HeadElement;");
                 cb.AddLine("using MudBlazor.UnitTests;");
                 cb.AddLine("using MudBlazor.Charts;");
@@ -64,6 +65,7 @@ namespace MudBlazor.Docs.Compiler
                 cb.AddLine("ctx.Services.AddSingleton<ISnackbar>(new MockSnackbar());");
                 cb.AddLine("ctx.Services.AddSingleton<IResizeListenerService>(new MockResizeListenerService());");
                 cb.AddLine("ctx.Services.AddSingleton<IHeadElementHelper>(new MockHeadElementHelper());");
+                cb.AddLine("ctx.Services.AddScoped(sp => new HttpClient());");
                 cb.IndentLevel--;
                 cb.AddLine("}");
                 cb.AddLine();

--- a/src/MudBlazor.Docs.Compiler/TestsForExamples.cs
+++ b/src/MudBlazor.Docs.Compiler/TestsForExamples.cs
@@ -32,6 +32,7 @@ namespace MudBlazor.Docs.Compiler
                 cb.AddLine("using MudBlazor.Docs.Examples;");
                 cb.AddLine("using MudBlazor.Docs.Wireframes;");
                 cb.AddLine("using MudBlazor.Services;");
+                cb.AddLine("using System.Net.Http;");
                 cb.AddLine();
                 cb.AddLine("namespace MudBlazor.UnitTests.Components");
                 cb.AddLine("{");
@@ -53,6 +54,7 @@ namespace MudBlazor.Docs.Compiler
                 cb.AddLine("ctx.Services.AddSingleton<IDialogService>(new DialogService());");
                 cb.AddLine("ctx.Services.AddSingleton<ISnackbar>(new MockSnackbar());");
                 cb.AddLine("ctx.Services.AddSingleton<IResizeListenerService>(new MockResizeListenerService());");
+                cb.AddLine("ctx.Services.AddScoped(sp => new HttpClient());");
                 cb.IndentLevel--;
                 cb.AddLine("}");
                 cb.AddLine();

--- a/src/MudBlazor.Docs.Server/Startup.cs
+++ b/src/MudBlazor.Docs.Server/Startup.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using MudBlazor.Docs.Extensions;
+using System.Net.Http;
 using Toolbelt.Blazor.Extensions.DependencyInjection;
 
 namespace MudBlazor.Docs.Server
@@ -21,6 +22,9 @@ namespace MudBlazor.Docs.Server
         // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddHttpClient("Default");
+            services.AddTransient(sp => sp.GetRequiredService<IHttpClientFactory>().CreateClient("Default"));
+
             services.AddHeadElementHelper();
             services.AddRazorPages();
             services.AddServerSideBlazor();

--- a/src/MudBlazor.Docs/Pages/Components/Dialog/Code/DialogScrollableExample_DialogCode.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/Code/DialogScrollableExample_DialogCode.razor
@@ -27,21 +27,23 @@
 <span class="atSign">&#64;</span>code {
     [CascadingParameter] MudDialogInstance MudDialog { <span class="keyword">get</span>; <span class="keyword">set</span>; }
 
+    [Inject] HttpClient HttpClient { <span class="keyword">get</span>; <span class="keyword">set</span>; }
+
     <span class="keyword">protected</span> <span class="keyword">override</span> <span class="keyword">async</span> Task OnInitializedAsync()
     {
-        Loading = <span class="keyword">true</span>;
-        <span class="keyword">var</span> bytes = <span class="keyword">await</span> <span class="keyword">new</span> WebClient().DownloadDataTaskAsync(<span class="keyword">new</span> Uri(<span class="string">&quot;https://raw.githubusercontent.com/Garderoben/MudBlazor/master/LICENSE&quot;</span>));
-        LicenseText = Encoding.UTF8.GetString(bytes);
-        Loading = <span class="keyword">false</span>;
         <span class="keyword">await</span> <span class="keyword">base</span>.OnInitializedAsync();
+        Loading = <span class="keyword">true</span>;
+        <span class="keyword">var</span> response = <span class="keyword">await</span> HttpClient.GetAsync(<span class="string">&quot;https://raw.githubusercontent.com/Garderoben/MudBlazor/master/LICENSE&quot;</span>);
+        LicenseText = <span class="keyword">await</span> response.Content.ReadAsStringAsync();
+        Loading = <span class="keyword">false</span>;
     }
 
     <span class="keyword">private</span> <span class="keyword">string</span> LicenseText;
     <span class="keyword">private</span> <span class="keyword">bool</span> Loading = <span class="keyword">false</span>;
 
-    <span class="keyword">private</span> <span class="keyword">void</span> Ok()
+    <span class="keyword">private</span> Task Ok()
     {
-        MudDialog.Close(DialogResult.Ok(<span class="keyword">true</span>));
+        <span class="keyword">return</span> MudDialog.Close(DialogResult.Ok(<span class="keyword">true</span>));
     }
 }
 </pre></div>

--- a/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogScrollableExample_Dialog.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogScrollableExample_Dialog.razor
@@ -24,20 +24,22 @@
 @code {
     [CascadingParameter] MudDialogInstance MudDialog { get; set; }
 
+    [Inject] HttpClient HttpClient { get; set; }
+
     protected override async Task OnInitializedAsync()
     {
-        Loading = true;
-        var bytes = await new WebClient().DownloadDataTaskAsync(new Uri("https://raw.githubusercontent.com/Garderoben/MudBlazor/master/LICENSE"));
-        LicenseText = Encoding.UTF8.GetString(bytes);
-        Loading = false;
         await base.OnInitializedAsync();
+        Loading = true;
+        var response = await HttpClient.GetAsync("https://raw.githubusercontent.com/Garderoben/MudBlazor/master/LICENSE");
+        LicenseText = await response.Content.ReadAsStringAsync();
+        Loading = false;
     }
 
     private string LicenseText;
     private bool Loading = false;
 
-    private void Ok()
+    private Task Ok()
     {
-        MudDialog.Close(DialogResult.Ok(true));
+        return MudDialog.Close(DialogResult.Ok(true));
     }
 }


### PR DESCRIPTION
Javascript console was reporting an error when trying to open the scrollable dialog example in docs in Blazor WebAssembly (Docs.Client)

This was due to the usage of WebClient, which is not supported on wasm platform. Code was refactored to use HttpClient.