### PR TITLE
Cleanup async dialog methods

### DIFF
--- a/src/MudBlazor/Components/Dialog/DialogReference.cs
+++ b/src/MudBlazor/Components/Dialog/DialogReference.cs
@@ -6,7 +6,6 @@
 // License: MIT
 // See https://github.com/Blazored
 
-
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
@@ -17,15 +16,12 @@ namespace MudBlazor
     {
         private readonly TaskCompletionSource<DialogResult> _resultCompletion = new TaskCompletionSource<DialogResult>();
 
-        private readonly Action<DialogResult> _closed;
-
         private readonly DialogService _dialogService;
 
         public DialogReference(Guid dialogInstanceId, RenderFragment dialogInstance, DialogService dialogService)
         {
             Id = dialogInstanceId;
             DialogInstance = dialogInstance;
-            _closed = HandleClosed;
             _dialogService = dialogService;
         }
 
@@ -39,19 +35,15 @@ namespace MudBlazor
             _dialogService.Close(this, result);
         }
 
-        private void HandleClosed(DialogResult obj)
+        internal void Dismiss(DialogResult result)
         {
-            _ = _resultCompletion.TrySetResult(obj);
+            _resultCompletion.TrySetResult(result);
         }
 
         internal Guid Id { get; }
+
         internal RenderFragment DialogInstance { get; }
 
         public Task<DialogResult> Result => _resultCompletion.Task;
-
-        internal void Dismiss(DialogResult result)
-        {
-            _closed.Invoke(result);
-        }
     }
 }

--- a/src/MudBlazor/Components/Dialog/MudDialogInstance.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialogInstance.razor.cs
@@ -54,7 +54,7 @@ namespace MudBlazor
 
         public void Close(DialogResult dialogResult)
         {
-            _ = Parent.DismissInstance(Id, dialogResult);
+            Parent.DismissInstance(Id, dialogResult);
         }
 
         public void Cancel()

--- a/src/MudBlazor/Components/Dialog/MudDialogProvider.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialogProvider.razor.cs
@@ -10,10 +10,11 @@ using System;
 using System.Collections.ObjectModel;
 using System.Linq;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Routing;
 
 namespace MudBlazor
 {
-    public partial class MudDialogProvider
+    public partial class MudDialogProvider : IDisposable
     {
         [Inject] private IDialogService DialogService { get; set; }
         [Inject] private NavigationManager NavigationManager { get; set; }
@@ -32,7 +33,7 @@ namespace MudBlazor
         {
             ((DialogService)DialogService).OnDialogInstanceAdded += AddInstance;
             ((DialogService)DialogService).OnDialogCloseRequested += DismissInstance;
-            NavigationManager.LocationChanged += (s, e) => DismissAll();
+            NavigationManager.LocationChanged += LocationChanged;
 
             GlobalDialogOptions.DisableBackdropClick = DisableBackdropClick;
             GlobalDialogOptions.CloseButton = CloseButton;
@@ -72,6 +73,17 @@ namespace MudBlazor
         private DialogReference GetDialogReference(Guid Id)
         {
             return Dialogs.SingleOrDefault(x => x.Id == Id);
+        }
+
+        private void LocationChanged(object sender, LocationChangedEventArgs args)
+        {
+            DismissAll();
+        }
+
+        public void Dispose()
+        {
+            if (NavigationManager != null)
+                NavigationManager.LocationChanged -= LocationChanged;
         }
     }
 }


### PR DESCRIPTION
As discussed in PR #390, here's some code fixes to cleanup async methods. Dismiss is now sync in this version. Some dead code removed also.