### PR TITLE
Bug fix & Read only ratings

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Rating/Examples/RatingReadonlyExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Rating/Examples/RatingReadonlyExample.razor
@@ -1,0 +1,3 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudRating ReadOnly="true" SelectedValue="2" />

--- a/src/MudBlazor.Docs/Pages/Components/Rating/RatingPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Rating/RatingPage.razor
@@ -40,6 +40,17 @@
 
         <DocsPageSection>
             <SectionHeader>
+                <Title>Read only</Title>
+                <Description>A read only component doesn't allow interactions. Use the <CodeInline>ReadOnly</CodeInline> parameter to mark a component as read only.</Description>
+            </SectionHeader>
+            <SectionContent Outlined="true">
+                <RatingReadonlyExample />
+            </SectionContent>
+            <SectionSource Code="RatingReadonlyExample" GitHubFolderName="Rating" SnippetId="todo" />
+        </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader>
                 <Title>Sizes</Title>
                 <Description></Description>
             </SectionHeader>

--- a/src/MudBlazor.UnitTests/Components/RatingTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RatingTests.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using Bunit;
 using FluentAssertions;
 using NUnit.Framework;
-
+using static Bunit.ComponentParameterFactory;
 
 namespace MudBlazor.UnitTests
 {
@@ -14,7 +14,8 @@ namespace MudBlazor.UnitTests
     public class RatingTests
     {
         [Test]
-        public void RatingTest1() {
+        public void RatingTest1()
+        {
             // click should change selected value
             // setup
             using var ctx = new Bunit.TestContext();
@@ -165,5 +166,13 @@ namespace MudBlazor.UnitTests
         }
 
 
+        [Test]
+        public void ReadOnlyRating_ShouldNotRenderInputs()
+        {
+            using var ctx = new Bunit.TestContext();
+            var comp = ctx.RenderComponent<MudRating>(Parameter("ReadOnly", true));
+
+            comp.FindAll("input").Should().BeEmpty();
+        }
     }
 }

--- a/src/MudBlazor/Components/Rating/MudRating.razor
+++ b/src/MudBlazor/Components/Rating/MudRating.razor
@@ -6,7 +6,9 @@
     <CascadingValue Value="this" >
         @for (int i = 1; i <= MaxValue; i++)
         {
-            <MudRatingItem Class="@RatingItemsClass" Style="@RatingItemsStyle" ItemValue="@i" DisableRipple="DisableRipple" Disabled="Disabled" Color="Color" Size="Size" ItemClicked="HandleItemClicked" ItemHovered="HandleItemHovered"/>
+            <MudRatingItem Class="@RatingItemsClass" Style="@RatingItemsStyle" ItemValue="@i"
+                           DisableRipple="DisableRipple" Disabled="Disabled" ReadOnly="ReadOnly" Color="Color"
+                           Size="Size" ItemClicked="HandleItemClicked" ItemHovered="HandleItemHovered"/>
         }
     </CascadingValue>
 </span>

--- a/src/MudBlazor/Components/Rating/MudRating.razor.cs
+++ b/src/MudBlazor/Components/Rating/MudRating.razor.cs
@@ -61,6 +61,10 @@ namespace MudBlazor
         /// If true, the controls will be disabled.
         /// </summary>
         [Parameter] public bool Disabled { get; set; }
+        /// <summary>
+        /// If true, the ratings will show without interactions.
+        /// </summary>
+        [Parameter] public bool ReadOnly { get; set; }
 
         /// <summary>
         /// Fires when SelectedValue changes.

--- a/src/MudBlazor/Components/Rating/MudRatingItem.razor
+++ b/src/MudBlazor/Components/Rating/MudRatingItem.razor
@@ -1,10 +1,20 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
 
-
-<span class="@ClassName" style="@Style" @onmouseover="HandleMouseOver" @onclick="HandleClick" @onmouseout="HandleMouseOut ">
-    <svg viewBox="0 0 24 24" aria-hidden="true" >
-        <path d="@ItemIcon" />
-    </svg>
-    <input class="mud-rating-input" type="radio" value="@ItemValue" name="@Rating?.Name" disabled="@Disabled" checked="@(IsChecked)" @attributes="UserAttributes" />
-</span>
+@if (ReadOnly)
+{
+    <span class="@ClassName" style="@Style">
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="@ItemIcon" />
+        </svg>
+    </span>
+}
+else
+{
+    <span class="@ClassName" style="@Style" @onmouseover="HandleMouseOver" @onclick="HandleClick" @onmouseout="HandleMouseOut ">
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="@ItemIcon" />
+        </svg>
+        <input class="mud-rating-input" type="radio" value="@ItemValue" name="@Rating?.Name" disabled="@Disabled" checked="@(IsChecked)" @attributes="UserAttributes" />
+    </span>
+}

--- a/src/MudBlazor/Components/Rating/MudRatingItem.razor.cs
+++ b/src/MudBlazor/Components/Rating/MudRatingItem.razor.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Extensions;
@@ -77,7 +78,7 @@ namespace MudBlazor
 
         private string SelectIcon()
         {
-            if (Rating==null)
+            if (Rating == null)
                 return null;
             if (Rating.HoveredValue.HasValue && Rating.HoveredValue.Value >= ItemValue)
             {
@@ -110,18 +111,15 @@ namespace MudBlazor
             if (Disabled) return;
             if (Rating == null)
                 return;
-            // onmouseout from current item will always fire before onmouseover, if we don't wait here for potential onmouseover from another item there will be a flicker issue
-            await Task.Delay(10);
-            if (Rating.HoveredValue.HasValue && Rating.HoveredValue.Value == ItemValue)
-            {
-                IsActive = false;
-                await ItemHovered.InvokeAsync(null);
-            }
+
+            IsActive = false;
+            await ItemHovered.InvokeAsync(null);
         }
 
         private void HandleMouseOver(MouseEventArgs e)
         {
             if (Disabled) return;
+
             IsActive = true;
             ItemHovered.InvokeAsync(ItemValue);
         }
@@ -129,7 +127,7 @@ namespace MudBlazor
         private void HandleClick(MouseEventArgs e)
         {
             if (Disabled) return;
-            IsActive = false;            
+            IsActive = false;
             if (Rating?.SelectedValue == ItemValue)
             {
                 ItemClicked.InvokeAsync(0);

--- a/src/MudBlazor/Components/Rating/MudRatingItem.razor.cs
+++ b/src/MudBlazor/Components/Rating/MudRatingItem.razor.cs
@@ -22,6 +22,7 @@ namespace MudBlazor
           .AddClass($"mud-icon-size-{Size.ToDescriptionString()}")
           .AddClass($"mud-rating-item-active", IsActive)
           .AddClass($"mud-disabled", Disabled)
+          .AddClass($"mud-readonly", ReadOnly)
           .AddClass(Class)
         .Build();
 
@@ -59,6 +60,11 @@ namespace MudBlazor
         /// If true, the controls will be disabled.
         /// </summary>
         [Parameter] public bool Disabled { get; set; }
+
+        /// <summary>
+        /// If true, the item will be readonly.
+        /// </summary>
+        [Parameter] public bool ReadOnly { get; set; }
 
         /// <summary>
         /// Fires when element clicked.

--- a/src/MudBlazor/Styles/components/_rating.scss
+++ b/src/MudBlazor/Styles/components/_rating.scss
@@ -21,6 +21,10 @@
         }
     }
 
+    &.mud-readonly {
+        cursor: default;
+    }
+
     & .mud-rating-input {
         clip: rect(0,0,0,0);
         margin: 0;


### PR DESCRIPTION
Fixes #398 

- Rating items should become inactive the moment the mouse is out no matter what.
- Read only ratings show the ratings without allowing interactions. Inputs aren't rendered and events aren't even registered to save resources.