### PR TITLE
Added a parameter in MudOverlay to block scroll

### DIFF
--- a/src/MudBlazor/Components/Drawer/MudDrawer.razor
+++ b/src/MudBlazor/Components/Drawer/MudDrawer.razor
@@ -10,7 +10,7 @@
         @ChildContent
     </CascadingValue>
 </aside>
-<MudOverlay Visible="true" OnClick="@DrawerClose" Class="@OverlayClass" DarkBackground="true" />
+<MudOverlay Visible="true" OnClick="@DrawerClose" Class="@OverlayClass" DarkBackground="true" LockScroll=false />
 
 
 @code {

--- a/src/MudBlazor/Styles/MudBlazor.scss
+++ b/src/MudBlazor/Styles/MudBlazor.scss
@@ -69,6 +69,8 @@
 @import 'utilities/_spacing';
 @import 'utilities/_borders';
 @import 'utilities/_display';
+@import 'utilities/scroll';
+
 
 @import 'layout/_appbar';
 @import 'layout/_drawer';

--- a/src/MudBlazor/Styles/core/_base.scss
+++ b/src/MudBlazor/Styles/core/_base.scss
@@ -6,7 +6,7 @@
     -moz-osx-font-smoothing: grayscale;
 }
 
-html, svg {
+ svg {
     height: 100%;
 }
 
@@ -15,7 +15,6 @@ strong, b {
 }
 
 body {
-    height: 100%;
     color: var(--mud-palette-text-primary);
     font-size: 0.875rem;
     font-family: "Roboto", "Helvetica", "Arial", sans-serif;

--- a/src/MudBlazor/Styles/utilities/_scroll.scss
+++ b/src/MudBlazor/Styles/utilities/_scroll.scss
@@ -1,0 +1,5 @@
+﻿.scroll-locked{
+    height:100%;
+    overflow-y:hidden;
+    padding-right:8px; //the width of scroll-bar
+}

--- a/src/MudBlazor/TScripts/scrollto.js
+++ b/src/MudBlazor/TScripts/scrollto.js
@@ -5,5 +5,17 @@ window.blazorHelpers = {
         if (element) {
             element.scrollIntoView({ behavior: 'auto', block: 'center', inline: 'start' });
         }
+    },
+    lockScroll: (selector) => {
+        let element = document.querySelector(selector);
+        if (element) {
+            element.classList.add('scroll-locked');
+        }
+    },
+    unlockScroll: (selector) => {
+        let element = document.querySelector(selector);
+        if (element) {
+            element.classList.remove('scroll-locked');
+        }
     }
 };


### PR DESCRIPTION
- Added a parameter `LockScroll` in MudOverlay to lock the scroll when showing the overlay
- Unset the body and html heights, so scroll works
- This solves several problems related to scroll
- To be solved: the navmenu drawer does not block the body in the mobile version