### PR TITLE
Remove unused event in MudLayout

### DIFF
--- a/src/MudBlazor/Components/Layout/MudLayout.razor
+++ b/src/MudBlazor/Components/Layout/MudLayout.razor
@@ -64,8 +64,6 @@
         return _drawers.FirstOrDefault(d => d.Anchor == anchor)?.Clipped;
     }
 
-    public event Action DrawersChanged;
-
     public void FireDrawersChanged()
     {
         StateHasChanged();


### PR DESCRIPTION
- `FireDrawersChanged` is used to notify the parent (MudLayout) of a drawer state changed in the model.