### PR TITLE
Exit tests if taking too long

### DIFF
--- a/.azure/pipelines/jobs/default-test.yml
+++ b/.azure/pipelines/jobs/default-test.yml
@@ -17,5 +17,7 @@ steps:
   displayName: Test
   inputs:
     command: 'test'
+    # Timeout if we encounter never ending test and show current test
+    arguments: '--blame-hang --blame-hang-timeout 60s'
     projects: 'src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj'
     testRunTitle: 'UnitTest'

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -38,6 +38,9 @@
             "type": "shell",
             "args": [
                 "test",
+                "--blame-hang",
+                "--blame-hang-timeout",
+                "60s", 
                 "src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj",
                 "/property:GenerateFullPaths=true",
                 "/consoleloggerparameters:NoSummary"


### PR DESCRIPTION
- In #428 we discovered that the build system will try a test for an hour if it has an infinite loop.
- This change exits the individual test at 60s and enables quicker diagnosis.
- It also makes this change for vscode users.
- Please can we make the pipeline logs public as per #387 