### PR TITLE
Don't check in compiler errors

### DIFF
--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -18,4 +18,4 @@ steps:
   inputs:
     command: 'build'
     projects: 'src/MudBlazor.sln'
-    arguments: '--configuration Release'
+    arguments: '--configuration Release /p:TreatWarningsAsErrors=true'


### PR DESCRIPTION
- This does not affect the local dev cycle.
- This is only CI builds
- Since some considerable effort was made to eliminate the compiler warnings with some good benefits this change will prevent any more warnings. (Although failing builds can still be checked in like normal)
- The warnings had built up over a long period and you have to try quite hard to get a compiler warning now.  If you do its likely because something really does need fixing.
- Please only use #pragma as a last resort.