### PR TITLE
Move Converter property to MudFormComponent and make it mandatory

### DIFF
--- a/src/MudBlazor.Docs.Compiler/DocStrings.cs
+++ b/src/MudBlazor.Docs.Compiler/DocStrings.cs
@@ -58,7 +58,7 @@ namespace MudBlazor.Docs.Compiler
             return success;
         }
 
-        private static string GetSaveTypename(Type t) => Regex.Replace(t.ConvertToCSharpSource(), @"[\.<>]", "_");
+        private static string GetSaveTypename(Type t) => Regex.Replace(t.ConvertToCSharpSource(), @"[\.,<>]", "_");
 
         private static string EscapeDescription(string doc)
         {

--- a/src/MudBlazor/Base/MudBooleanInput.cs
+++ b/src/MudBlazor/Base/MudBooleanInput.cs
@@ -1,23 +1,22 @@
-﻿using System.Collections.Generic;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Components;
+﻿using Microsoft.AspNetCore.Components;
+using System.Collections.Generic;
 
 namespace MudBlazor
 {
-    public class MudBooleanInput<T> : MudFormComponent<T>
+    public class MudBooleanInput<T> : MudFormComponent<T, bool?>
     {
+        public MudBooleanInput() : base(new BoolConverter<T>()) { }
+
         /// <summary>
         /// Fired when Checked changes.
         /// </summary>
         [Parameter]
         public EventCallback<T> CheckedChanged { get; set; }
 
-        private Converter<T, bool?> _boolConverter = new BoolConverter<T>();
-
         protected bool? BoolValue
         {
-            get => _boolConverter.Set(_value);
-            set => Checked = _boolConverter.Get(value);
+            get => Converter.Set(_value);
+            set => Checked = Converter.Get(value);
         }
 
         /// <summary>
@@ -37,26 +36,13 @@ namespace MudBlazor
             }
         }
 
-        [Parameter]
-        public Converter<T, bool?> Converter
+        protected override bool SetConverter(Converter<T, bool?> value)
         {
-            get => _boolConverter;
-            set
-            {
-                _boolConverter = value;
-                if (_boolConverter == null)
-                    return;
-                _boolConverter.OnError = OnConversionError;
+            var changed = base.SetConverter(value);
+            if (changed)
                 BoolValue = Converter.Set(Checked);
-            }
-        }
 
-
-        protected override Task OnInitializedAsync()
-        {
-            if (_boolConverter != null)
-                _boolConverter.OnError = OnConversionError;
-            return base.OnInitializedAsync();
+            return changed;
         }
 
         /// <summary>

--- a/src/MudBlazor/Base/MudComponentBase.cs
+++ b/src/MudBlazor/Base/MudComponentBase.cs
@@ -1,6 +1,5 @@
-﻿using System.Collections.Generic;
-using System.Globalization;
-using Microsoft.AspNetCore.Components;
+﻿using Microsoft.AspNetCore.Components;
+using System.Collections.Generic;
 
 namespace MudBlazor
 {
@@ -27,9 +26,5 @@ namespace MudBlazor
         /// </summary>
         [Parameter(CaptureUnmatchedValues = true)]
         public Dictionary<string, object> UserAttributes { get; set; } = new Dictionary<string, object>();
-
-        protected static string ToS(double value) => value.ToString(CultureInfo.InvariantCulture);
-        protected static string ToS(float value) => value.ToString(CultureInfo.InvariantCulture);
-        protected static string ToS(decimal value) => value.ToString(CultureInfo.InvariantCulture);
     }
 }

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -1,17 +1,27 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
 using MudBlazor.Interfaces;
+using static System.String;
 
 namespace MudBlazor
 {
-    public class MudFormComponent<T> : MudComponentBase, IFormComponent, IDisposable
-    {       
+    public abstract class MudFormComponent<T, U> : MudComponentBase, IFormComponent, IDisposable
+    {
+        private Converter<T, U> _converter;
+
+        protected MudFormComponent(Converter<T, U> converter)
+        {
+            _converter = converter ?? throw new ArgumentNullException(nameof(converter));
+            _converter.OnError = OnConversionError;
+        }
+
         [CascadingParameter] internal MudForm Form { get; set; }
 
         /// <summary>
@@ -34,34 +44,55 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public bool Error { get; set; }
 
+        [Parameter]
+        public Converter<T, U> Converter
+        {
+            get => _converter;
+            set => SetConverter(value);
+        }
+
+        protected virtual bool SetConverter(Converter<T, U> value)
+        {
+            var changed = (_converter != value);
+            if (changed)
+            {
+                _converter = value ?? throw new ArgumentNullException(nameof(value));   // converter is mandatory at all times
+                _converter.OnError = OnConversionError;
+            }
+            return changed;
+        }
+
+        [Parameter]
+        public CultureInfo Culture
+        {
+            get => _converter.Culture;
+            set => SetCulture(value);
+        }
+
+        protected virtual bool SetCulture(CultureInfo value)
+        {
+            var changed = (_converter.Culture != value);
+            if (changed)
+            {
+                _converter.Culture = value;
+            }
+            return changed;
+        }
+
         protected virtual void OnConversionError(string error)
         {
-            /* to be overridden */
+            /* Descendants can override this method to catch conversion errors */
         }
 
         /// <summary>
         /// True if the conversion from string to T failed
         /// </summary>
-        public virtual bool ConversionError
-        {
-            get
-            {
-                /* to be overridden */
-                return false;
-            }
-        }
+        public bool ConversionError => _converter.GetError;
 
         /// <summary>
         /// The error message of the conversion error from string to T. Null otherwise
         /// </summary>
-        public virtual string ConversionErrorMessage
-        {
-            get
-            {
-                /* to be overridden */
-                return null;
-            }
-        }
+        public string ConversionErrorMessage => _converter.GetErrorMessage;
 
         /// <summary>
         /// True if the input has any of the following errors: An error set from outside, a conversion error or
@@ -69,6 +100,17 @@ namespace MudBlazor
         /// </summary>
         public bool HasErrors => Error || ConversionError || ValidationErrors.Count > 0;
 
+        public string GetErrorText()
+        {
+            // ErrorText is either set from outside or the first validation error
+            if (!IsNullOrWhiteSpace(ErrorText))
+                return ErrorText;
+
+            if (!IsNullOrWhiteSpace(ConversionErrorMessage))
+                return ConversionErrorMessage;
+
+            return null;
+        }
 
         #region MudForm Validation
 
@@ -289,6 +331,7 @@ namespace MudBlazor
         {
             /* to be overridden */
             _value = default;
+            StateHasChanged();
         }
 
         public void ResetValidation()


### PR DESCRIPTION
I noticed that even if BaseInput had some null-handling for Converter property, it is widely used in other components assuming there is always a Converter. (In fact, a default Converter is always created, so the only way to NOT have a Converter would be to manually set it to null, which would make many components to throw errors)

I think it makes sense that an input component should **always** have a Converter. Also, I noticed some similarities between MudBaseInput and MudBooleanInput (each one is defining a Converter property, etc) so I wanted to define them once in a higher parent class.

In this PR:

-Converter property is guaranteed to never be null (so null checks no longer needed and have been removed)
-Converter property and other related properties (Culture, etc) have been moved to MudFormComponent, so BaseInput and BooleanInput no longer need to each define them
-Added some virtual methods (SetConverter, SetCulture, etc) so descendants can react when these properties change
-...and some dead code removed from MudComponentBase
