### PR TITLE
Add test coverage xplat

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -38,12 +38,10 @@
             "type": "shell",
             "args": [
                 "test",
-                "--blame-hang",
-                "--blame-hang-timeout",
-                "60s", 
                 "src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj",
                 "/property:GenerateFullPaths=true",
-                "/consoleloggerparameters:NoSummary"
+                "/consoleloggerparameters:NoSummary",
+                "--collect:\"XPlat Code Coverage\"",
             ],
             "group": "build",
             "problemMatcher": "$msCompile"
@@ -54,6 +52,38 @@
             "dependsOn": [
                 "build",
                 "test"
+            ],
+            "problemMatcher": [
+                "$msCompile"
+            ]
+        },
+        {
+            
+            "label": "generate report",
+            "command": "reportgenerator",
+            "type": "shell",
+            "args": [
+                "-reports:src/MudBlazor.UnitTests/TestResults/**/*.xml",
+                "-targetdir:src/MudBlazor.UnitTests/TestResults/Reports/"
+            ],
+            "group": "build",
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "open report",
+            "command": "open",
+            "type": "shell",
+            "args": [
+                "src/MudBlazor.UnitTests/TestResults/Reports/Index.html",
+            ],
+            "problemMatcher": []
+        },
+        {
+            "label": "view coverage report",
+            "dependsOrder": "sequence",
+            "dependsOn": [
+                "generate report",
+                "open report"
             ],
             "problemMatcher": [
                 "$msCompile"

--- a/src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj
+++ b/src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj
@@ -18,6 +18,10 @@
 
   <ItemGroup>
     <PackageReference Include="bunit" Version="1.0.0-preview-01" />
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="FluentValidation" Version="9.3.0" />
     <PackageReference Include="Moq" Version="4.15.2" />


### PR DESCRIPTION
- Adds generate coverage data to the build.
- Adds a vscode task to build test coverage report
- FUTURE: Use the coverage data to post to coveralls.io for a coverage badge.
- FUTURE: Show coverage on PR.