### PR TITLE
Test coverage for MudBlazor only

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -65,7 +65,8 @@
             "args": [
                 "-reports:src/MudBlazor.UnitTests/TestResults/**/*.xml",
                 "-targetdir:src/MudBlazor.UnitTests/TestResults/Reports/",
-                "-historydir:src/MudBlazor.UnitTests/TestResults/"
+                "-historydir:src/MudBlazor.UnitTests/TestResults/",
+                "-assemblyfilters:+MudBlazor"
             ],
             "group": "build",
             "problemMatcher": "$msCompile"


### PR DESCRIPTION
- Hopefully this is it now
- Limit coverage to MudBlazor.dll only
- I know this is only for vscode users but it is also a good reference for command line build coverage analysis