### PR TITLE
Enhanced MudExpansionPanel component with max-height parameter

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/ExpansionPanel/Examples/ExpansionPanelSimpleExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ExpansionPanel/Examples/ExpansionPanelSimpleExample.razor
@@ -2,13 +2,13 @@
 
 
 <MudExpansionPanels>
-    <MudExpansionPanel Text="Panel One">
-        <LoremIpsum/>
-    </MudExpansionPanel>
-    <MudExpansionPanel Text="Panel Two">
+    <MudExpansionPanel Text="Panel One" MaxHeight="150">
         <LoremIpsum />
     </MudExpansionPanel>
-    <MudExpansionPanel Text="Panel Three">
+    <MudExpansionPanel Text="Panel Two" MaxHeight="500">
+        <LoremIpsum />
+    </MudExpansionPanel>
+    <MudExpansionPanel Text="Panel Three" MaxHeight="1000">
         <LoremIpsum />
     </MudExpansionPanel>
     <MudExpansionPanel Text="Panel Four">

--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableRelationalExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableRelationalExample.razor
@@ -1,0 +1,129 @@
+﻿@using MudBlazor.Docs.Data
+@namespace MudBlazor.Docs.Examples
+
+<MudTable Items="@People" Hover="true" Breakpoint="Breakpoint.Sm">
+    <ColGroup>
+        <col style="width:300px;" />
+        <col style="width:100px;" />
+        <col />
+        <col style="width:100px;" />
+    </ColGroup>
+    <HeaderContent>
+        <MudTh></MudTh>
+        <MudTh>Nr</MudTh>
+        <MudTh>Name</MudTh>
+        <MudTh>Age</MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd><MudButton Variant="Variant.Outlined" OnClick="@(() => ShowBtnPress(context.Number))">@((context.ShowDetails == true)? "Hide" : "Show") Address Details</MudButton></MudTd>
+        <MudTd DataLabel="Nr">@context.Number</MudTd>
+        <MudTd DataLabel="Name">@context.Name</MudTd>
+        <MudTd DataLabel="Age">@context.Age</MudTd>
+    </RowTemplate>
+    <ChildRowContent>
+        @if (context.ShowDetails)
+        {
+<MudTr>
+    <td colspan="4">
+        <MudCard Style="margin:15px">
+            <MudCardHeader>
+                <CardHeaderContent>
+                    <MudText Typo="Typo.body1">Address Details for <strong>@context.Name</strong></MudText>
+                </CardHeaderContent>
+            </MudCardHeader>
+            <MudCardContent>
+                <MudTable Items="@context.Addresses" Context="AddressContext" Hover="true" Breakpoint="Breakpoint.Sm">
+                    <ColGroup>
+                        <col />
+                        <col />
+                        <col style="width:200px;"/>
+                    </ColGroup>
+                    <HeaderContent>
+                        <MudTh>Address Line 1</MudTh>
+                        <MudTh>Address Line 2</MudTh>
+                        <MudTh>Postal Code</MudTh>
+                    </HeaderContent>
+                    <RowTemplate>
+                        <MudTd DataLabel="Address Line 1">@AddressContext.Address_Line_1</MudTd>
+                        <MudTd DataLabel="Address Line 2">@AddressContext.Address_Line_2</MudTd>
+                        <MudTd DataLabel="Postal Code">@AddressContext.Postal_Code</MudTd>
+                    </RowTemplate>
+                </MudTable>
+            </MudCardContent>
+        </MudCard>
+    </td>
+</MudTr>}
+    </ChildRowContent>
+</MudTable>
+
+@code
+{
+    protected override void OnInitialized()
+    {
+        FillPeople();
+    }
+
+    public class Address
+    {
+        public string Address_Line_1 { get; set; }
+        public string Address_Line_2 { get; set; }
+        public int Postal_Code { get; set; }
+    }
+    public class Person
+    {
+        public bool ShowDetails { get; set; }
+        public int Number { get; set; }
+        public string Name { get; set; }
+        public int Age { get; set; }
+        public IList<Address> Addresses { get; set; }
+    }
+    private void FillPeople()
+    {
+        IList<Person> people = new List<Person>();
+        IList<Address> addresses = new List<Address>();
+        addresses.Add(new Address { Address_Line_1 = "4 Privet Drive", Address_Line_2 = "Little Whinging", Postal_Code = 111 });
+        addresses.Add(new Address { Address_Line_1 = "12 Grimmauld Place", Address_Line_2 = "The Burrow", Postal_Code = 333 });
+        people.Add(new Person
+        {
+            ShowDetails = false,
+            Number = 1,
+            Name = "Harry Potter",
+            Age = 11,
+            Addresses = addresses
+        });
+
+        addresses = new List<Address>();
+        addresses.Add(new Address { Address_Line_1 = "123 Pikachu Lane", Address_Line_2 = "Pallet Town", Postal_Code = 777 });
+        addresses.Add(new Address { Address_Line_1 = "456 Mew Street", Address_Line_2 = "Pallet Town", Postal_Code = 999 });
+        people.Add(new Person
+        {
+            ShowDetails = false,
+            Number = 2,
+            Name = "Ash Ketchum",
+            Age = 18,
+            Addresses = addresses
+        });
+        People = people;
+
+        addresses = new List<Address>();
+        addresses.Add(new Address { Address_Line_1 = "123 Shire Lane", Address_Line_2 = "Bag End", Postal_Code = 223 });
+        addresses.Add(new Address { Address_Line_1 = "456 Shire Street", Address_Line_2 = "Bag End", Postal_Code = 445 });
+        addresses.Add(new Address { Address_Line_1 = "789 Shire Avenue", Address_Line_2 = "Bag End", Postal_Code = 667 });
+        people.Add(new Person
+        {
+            ShowDetails = true,
+            Number = 3,
+            Name = "Frodo Baggins",
+            Age = 24,
+            Addresses = addresses
+        });
+        People = people;
+    }
+    private static IEnumerable<Person> People { get; set; }
+
+    private void ShowBtnPress(int nr)
+    {
+        Person tmpPerson = People.First(f => f.Number == nr);
+        tmpPerson.ShowDetails = !tmpPerson.ShowDetails;
+    }
+}

--- a/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
@@ -7,14 +7,27 @@
             <SectionHeader>
                 <Title>Default Table</Title>
                 <Description>
-                   The default table displays your data in simple rows and is responsive, it breaks into mobile layout on <CodeInline>xs</CodeInline> unless changed.<br/>
-                   Add the <CodeInline>DataLabel</CodeInline> property to your <CodeInline>MudTd</CodeInline> cells to properly display the column label when the table has changed to mobile layout.
+                    The default table displays your data in simple rows and is responsive, it breaks into mobile layout on <CodeInline>xs</CodeInline> unless changed.<br />
+                    Add the <CodeInline>DataLabel</CodeInline> property to your <CodeInline>MudTd</CodeInline> cells to properly display the column label when the table has changed to mobile layout.
                 </Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" FullWidth="true">
                 <TableBasicExample />
             </SectionContent>
             <SectionSource Code="TableBasicExample" ShowCode="false" GitHubFolderName="Table" />
+        </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader>
+                <Title>Table With related data</Title>
+                <Description>
+                    Making use of the <CodeInline>&lt;ChildRowContent&gt;</CodeInline> allows more control over the layout for scenarios such as showing the related address data for each person below.
+                </Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" FullWidth="true">
+                <TableRelationalExample />                
+            </SectionContent>
+            <SectionSource Code="TableRelationalExample" ShowCode="false" GitHubFolderName="Table" />
         </DocsPageSection>
 
         <DocsPageSection>
@@ -104,7 +117,7 @@
             <SectionHeader>
                 <Title>Server Side Filtering, Sorting and Pagination</Title>
                 <Description>
-                    Set <CodeInline>ServerData</CodeInline> to load data from the backend that is filtered, sorted and paginated. Table will call this async function whenever the user navigates 
+                    Set <CodeInline>ServerData</CodeInline> to load data from the backend that is filtered, sorted and paginated. Table will call this async function whenever the user navigates
                     the pager or changes sorting by clicking on the sort header icons. In this example we also show how to force the table to update when the search textfield blurs, so that the table reloads server-filtered data.
                     <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">
                         Note: with a <CodeInline>ServerData</CodeInline> func you don't need <CodeInline>Items</CodeInline> and <CodeInline>Filter</CodeInline>.

--- a/src/MudBlazor/Components/Collapse/MudCollapse.razor
+++ b/src/MudBlazor/Components/Collapse/MudCollapse.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor
 @using MudBlazor.Utilities;
 
-<div class="@Classname">
+<div class="@Classname" style="@(MaxHeight.HasValue && Expanded ? $"max-height:{MaxHeight}px;transition-duration: {CalculatedTransitionDuration}s;" : "")">
     <div class="mud-collapse-wrapper">
         <div class="mud-collapse-wrapper-inner">
             @ChildContent
@@ -17,6 +17,11 @@
     [Parameter] public bool Expanded { get; set; }
 
     /// <summary>
+    /// Explicitly sets the height for the Collapse element to override the css default.
+    /// </summary>
+    [Parameter] public int? MaxHeight { get; set; }
+
+    /// <summary>
     /// User class names, separated by space
     /// </summary>
     [Parameter] public string Class { get; set; }
@@ -25,6 +30,25 @@
     /// Child content of component.
     /// </summary>
     [Parameter] public RenderFragment ChildContent { get; set; }
+
+    /// <summary>
+    /// Modified transition duration that scales with height parameter.
+    /// Basic implementation for now but should be a math formula to allow it to scale between 0.1s and 1s for the effect to be consistently smooth.
+    /// </summary>
+    private decimal CalculatedTransitionDuration
+    {
+        get
+        {
+            if (MaxHeight.HasValue && Expanded)
+            {
+                if (MaxHeight <= 200) { return 0.2m; }
+                else if (MaxHeight <= 600) { return 0.4m; }
+                else if (MaxHeight <= 1400) { return 0.6m; };
+            }
+            return 1;
+        }
+        set { }
+    }
 
     protected string Classname =>
         new CssBuilder("mud-collapse-container")

--- a/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor
+++ b/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor
@@ -13,12 +13,12 @@
                 @Text
             }
         </div>
-            @if (!HideIcon)
-            {
-                <MudIcon Icon="@Icons.Material.ExpandMore" class="@(IsExpanded? "mud-expand-panel-icon mud-transform" : "mud-expand-panel-icon")"/>
-            }
+        @if (!HideIcon)
+        {
+            <MudIcon Icon="@Icons.Material.ExpandMore" class="@(IsExpanded? "mud-expand-panel-icon mud-transform" : "mud-expand-panel-icon")" />
+        }
     </div>
-    <MudCollapse Expanded="@IsExpanded">
+    <MudCollapse Expanded="@IsExpanded" MaxHeight="@MaxHeight">
         <div class="mud-expand-panel-content">
             @ChildContent
         </div>

--- a/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor.cs
+++ b/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor.cs
@@ -20,6 +20,11 @@ namespace MudBlazor
         .Build();
 
         /// <summary>
+        /// Explicitly sets the height for the Collapse element to override the css default.
+        /// </summary>
+        [Parameter] public int? MaxHeight { get; set; }
+
+        /// <summary>
         /// RenderFragment to be displayed in the expansion panel which will override header text if defined.
         /// </summary>
         [Parameter] public RenderFragment TitleContent { get; set; }
@@ -51,7 +56,7 @@ namespace MudBlazor
                 if (_isExpanded == value)
                     return;
                 _isExpanded = value;
-                if (Parent?.MultiExpansion==true)
+                if (Parent?.MultiExpansion == true)
                     Parent?.UpdateAll();
                 else
                     Parent?.CloseAllExcept(this);
@@ -86,7 +91,7 @@ namespace MudBlazor
         {
             if (Disabled)
                 return;
-            if (Parent?.MultiExpansion==true)
+            if (Parent?.MultiExpansion == true)
             {
                 IsExpanded = !IsExpanded;
             }
@@ -96,7 +101,7 @@ namespace MudBlazor
             }
         }
 
-        public void Expand(bool update_parent=true)
+        public void Expand(bool update_parent = true)
         {
             if (update_parent)
                 IsExpanded = true;

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -50,6 +50,10 @@
                                 else
                                     @RowTemplate(item)
                             </MudTr>
+                            @if (ChildRowContent != null)
+                            {
+                                @ChildRowContent(item)
+                            }
 
                             @*@if(RowEditingTemplate != null && object.Equals(_editingItem, item))
                                 {

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -19,6 +19,11 @@ namespace MudBlazor
         [Parameter] public RenderFragment<T> RowTemplate { get; set; }
 
         /// <summary>
+        /// Row Child content of the component.
+        /// </summary>
+        [Parameter] public RenderFragment<T> ChildRowContent { get; set; }
+
+        /// <summary>
         /// Defines how a table row looks like in edit mode (for selected row). Use MudTd to define the table cells and their content.
         /// </summary>
         [Parameter] public RenderFragment<T> RowEditingTemplate { get; set; }


### PR DESCRIPTION
Added a parameter to explicitly set max-height for MudExpansionPanel and underlying MudCollapse.
The default css value might be too low currently set at 2000px.

The max-height parameter is required for the transition animation to work correctly. the animation is affected by the max-height parameter, so a scaling of the transition-duration was implemented as well to keep the animation smooth for different values of max-height.