### PR TITLE
Coverage reports vscode

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -41,7 +41,12 @@
                 "src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj",
                 "/property:GenerateFullPaths=true",
                 "/consoleloggerparameters:NoSummary",
-                "--collect:\"XPlat Code Coverage\"",
+                "/p:CollectCoverage=true",
+                "/p:CoverletOutputFormat=cobertura",
+                "/p:ExcludeByAttribute=\"ExcludeFromCodeCoverage\"",
+                "/p:Include=\"[MudBlazor]*\"",
+                "/p:SkipAutoProps=true",
+                "/p:CoverletOutput='./TestResults/'"
             ],
             "group": "build",
             "problemMatcher": "$msCompile"
@@ -58,38 +63,13 @@
             ]
         },
         {
-            
-            "label": "generate report",
-            "command": "reportgenerator",
-            "type": "shell",
-            "args": [
-                "-reports:src/MudBlazor.UnitTests/TestResults/**/*.xml",
-                "-targetdir:src/MudBlazor.UnitTests/TestResults/Reports/",
-                "-historydir:src/MudBlazor.UnitTests/TestResults/",
-                "-assemblyfilters:+MudBlazor"
-            ],
-            "group": "build",
-            "problemMatcher": "$msCompile"
-        },
-        {
-            "label": "open report",
+            "label": "coverage report",
             "command": "open",
             "type": "shell",
             "args": [
-                "src/MudBlazor.UnitTests/TestResults/Reports/Index.html",
+                "src/MudBlazor.UnitTests/TestResults/Report/Index.html",
             ],
             "problemMatcher": []
-        },
-        {
-            "label": "view coverage report",
-            "dependsOrder": "sequence",
-            "dependsOn": [
-                "generate report",
-                "open report"
-            ],
-            "problemMatcher": [
-                "$msCompile"
-            ]
         },
         {
             "label": "compile docs",

--- a/src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj
+++ b/src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="bunit" Version="1.0.0-preview-01" />
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.msbuild" Version="2.9.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -28,6 +28,7 @@
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="ReportGenerator" Version="4.8.4" />
   </ItemGroup>
 
   <ItemGroup>
@@ -36,5 +37,9 @@
     <ProjectReference Include="..\MudBlazor.UnitTests.Viewer\MudBlazor.UnitTests.Viewer.csproj" />
     <ProjectReference Include="..\MudBlazor\MudBlazor.csproj" />
   </ItemGroup>
+
+  <Target Name="GenerateHtmlCoverageReport" AfterTargets="GenerateCoverageResultAfterTest" Condition="Exists('./TestResults/coverage.cobertura.xml')" >
+    <ReportGenerator ReportFiles="./TestResults/coverage.cobertura.xml" TargetDirectory="./TestResults/Report" HistoryDirectory="./TestResults/ReportHistory" />
+  </Target>
 
 </Project>


### PR DESCRIPTION
- This is purely a devops PR
- This adds CLI code coverfage report generation using [coverlets](https://github.com/coverlet-coverage/coverlet) and [ReportGenerator](https://github.com/danielpalme/ReportGenerator)
- It adds a couple of dev only packages to the `MudBlazor.UnitTests` assembly for generating reports
- It does not slow down the build.
- It does not do anything without switches i.e. `dotnet test` behaves the same.
- It does not affect the API.
- I could add a powershell script to generate and open a coverage report if people think it would be useful.
- Otherwise you can examine the vscode task to see how to produce a report