### PR TITLE
Custom viewbox for MudIcon

### DIFF
--- a/src/MudBlazor/Components/Icon/MudIcon.razor
+++ b/src/MudBlazor/Components/Icon/MudIcon.razor
@@ -3,7 +3,7 @@
 
 @if (!string.IsNullOrEmpty(Icon))
 {
-    <svg @attributes="UserAttributes" class="@Classname" style="@Style" focusable="false" viewBox="0 0 24 24" aria-hidden="true">
+    <svg @attributes="UserAttributes" class="@Classname" style="@Style" focusable="false" viewBox="@ViewBox" aria-hidden="true">
         <path d="@Icon" />
     </svg>
 }

--- a/src/MudBlazor/Components/Icon/MudIcon.razor.cs
+++ b/src/MudBlazor/Components/Icon/MudIcon.razor.cs
@@ -44,6 +44,11 @@ namespace MudBlazor
         [Parameter] public Color Color { get; set; } = Color.Inherit;
 
         /// <summary>
+        /// The viewbox size of an svg element. Default: '0 0 24 24'
+        /// </summary>
+        [Parameter] public string ViewBox { get; set; } = "0 0 24 24";
+
+        /// <summary>
         /// Child content of component.
         /// </summary>
         [Parameter] public RenderFragment ChildContent { get; set; }


### PR DESCRIPTION
Adding custom content to MudIcon with a viewbox different than the current default, it results an invalid html. This PR make it possible to specify the viewbox for the svg html tag.