### PR TITLE
Docs api

### DIFF
--- a/src/MudBlazor.Docs/Components/DocsApi.razor
+++ b/src/MudBlazor.Docs/Components/DocsApi.razor
@@ -1,6 +1,7 @@
 ﻿@using MudBlazor.Docs.Models
 @using System.Text.RegularExpressions
 @using System.Reflection
+@using System.Web
 @using Microsoft.Extensions.DependencyInjection
 @using System.Globalization
 @namespace MudBlazor.Docs.Components
@@ -28,7 +29,7 @@
                         <MudTd DataLabel="Name"><CodeInline>@context.Name</CodeInline></MudTd>
                         <MudTd DataLabel="Type">@context.Type</MudTd>
                         <MudTd DataLabel="Default">@PresentDefaultValue(context.Default)</MudTd>
-                        <MudTd DataLabel="Description">@context.Description</MudTd>
+                        <MudTd DataLabel="Description">@(HttpUtility.HtmlDecode(context.Description))</MudTd>
                     </RowTemplate>
                 </MudTable>
             </SectionContent>

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -121,7 +121,7 @@ namespace MudBlazor
         /// <para>Func&lt;T, bool&gt; ... will output the standard error message "Invalid" if false</para>
         /// <para>Func&lt;T, string&gt; ... outputs the result as error message, no error if null </para>
         /// <para>Func&lt;T, IEnumerable&lt; string &gt;&gt; ... outputs all the returned error messages, no error if empty</para>
-        /// <para>Func&lt;T, Task&lt; boo l&gt;&gt; ... will output the standard error message "Invalid" if false</para>
+        /// <para>Func&lt;T, Task&lt; bool &gt;&gt; ... will output the standard error message "Invalid" if false</para>
         /// <para>Func&lt;T, Task&lt; string &gt;&gt; ... outputs the result as error message, no error if null</para>
         /// <para>Func&lt;T, Task&lt;IEnumerable&lt; string &gt;&gt;&gt; ... outputs all the returned error messages, no error if empty</para>
         /// <para>System.ComponentModel.DataAnnotations.ValidationAttribute instances</para>


### PR DESCRIPTION
- Fix html encoded xml doc
- Still doesn't look great as it doesn't take into account `<para>` (paragraph formating) which is a long doc helps readability.

<img width="502" alt="Screenshot 2021-01-05 at 23 43 30" src="https://user-images.githubusercontent.com/16208742/103711701-e41e6380-4faf-11eb-9a81-cb471528e70d.png">

@Codinkat 