### PR TITLE
Add year monthpicker

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -104,11 +104,8 @@ namespace MudBlazor.UnitTests
             return comp;
         }
 
-        /// <summary>
-        /// Datepicker should open on input click and close on outside click
-        /// </summary>
         [Test]
-        public void Open_CloseByClickingOutsidePicker()
+        public void Open_CloseByClickingOutsidePicker_CheckClosed()
         {
             var comp = OpenPicker();
             // clicking outside to close
@@ -136,6 +133,44 @@ namespace MudBlazor.UnitTests
             var comp = OpenPicker(Parameter("OpenTo", OpenTo.Year));
             comp.Instance.Date.Should().BeNull();
             // should show years
+            comp.FindAll("div.mud-picker-year-container").Count.Should().Be(1);
+        }
+
+        [Test]
+        public void OpenToYear_ClickYear_CheckMonthsShown()
+        {
+            var comp = OpenPicker(Parameter("OpenTo", OpenTo.Year));
+            comp.Instance.Date.Should().BeNull();
+            // should show years
+            comp.FindAll("div.mud-picker-year-container").Count.Should().Be(1);
+            comp.FindAll("div.mud-picker-year").First().Click();
+            comp.FindAll("div.mud-picker-month-container").Count.Should().Be(1);
+        }
+
+        [Test]
+        public void OpenToMonth_CheckMonthsShown()
+        {
+            var comp = OpenPicker(Parameter("OpenTo", OpenTo.Month));
+            comp.Instance.Date.Should().BeNull();
+            // should show months
+            comp.FindAll("div.mud-picker-month-container").Count.Should().Be(1);
+        }
+
+        [Test]
+        public void Open_ClickCalendarHeader_CheckMonthsShown()
+        {
+            var comp = OpenPicker();
+            // should show months
+            comp.FindAll("div.mud-picker-calendar-header-transition").First().Click();
+            comp.FindAll("div.mud-picker-month-container").Count.Should().Be(1);
+        }
+
+        [Test]
+        public void Open_ClickYear_CheckYearsShown()
+        {
+            var comp = OpenPicker(Parameter("OpenTo", OpenTo.Month));
+            // should show years
+            comp.FindAll("div.mud-picker-calendar-header-transition").First().Click();
             comp.FindAll("div.mud-picker-year-container").Count.Should().Be(1);
         }
 
@@ -196,17 +231,19 @@ namespace MudBlazor.UnitTests
         }
      
         [Test]
-        public void Open_ClickYear_ClickCurrentYear_Click1_CheckDate()
+        public void Open_ClickYear_ClickCurrentYear_Click2ndMonth_Click1_CheckDate()
         {
             var comp = OpenPicker();
             comp.Find("div.mud-picker-datepicker-toolbar > button.mud-button-year").Click();
             comp.FindAll("div.mud-picker-content > div.mud-picker-year-container").Count.Should().Be(1);
             comp.FindAll("div.mud-picker-content > div.mud-picker-year-container > div.mud-picker-year")
                 .Where(x=>x.TrimmedText().Contains("2022")).First().Click();
+            comp.FindAll("div.mud-picker-month-container").Count.Should().Be(1);
+            comp.FindAll("div.mud-picker-content > div.mud-picker-month-container > div.mud-picker-month").Skip(1).First().Click();
             comp.FindAll("div.mud-picker-content > div.mud-picker-calendar-header").Count.Should().Be(1);
             comp.FindAll("div.mud-picker-calendar-day > button")
                 .Where(x=>x.TrimmedText().Equals("1")).First().Click();
-            comp.Instance.Date.Value.Date.Should().Be(new DateTime(2022, DateTime.Now.Month, 1));
+            comp.Instance.Date.Value.Date.Should().Be(new DateTime(2022, 2, 1));
         }
     }
 }

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.razor
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.razor
@@ -22,6 +22,15 @@
         }
         else if (OpenTo == OpenTo.Month)
         {
+            <div class="mud-picker-calendar-header">
+                <div class="mud-picker-calendar-header-switch">
+                    <MudIconButton Icon="@Icons.Material.ChevronLeft" OnClick="@OnPreviousYearClick"/>
+                    <div class="mud-picker-slide-transition mud-picker-calendar-header-transition" @onclick="OnYearClick"  @onclick:stopPropagation="true">
+                        <MudText Typo="Typo.body1" Align="Align.Center">@PickerMonth?.Year</MudText>
+                    </div>
+                    <MudIconButton Icon="@Icons.Material.ChevronRight" OnClick="@OnNextYearClick"/>
+                </div>
+            </div>
             <div class="mud-picker-month-container">
                 @foreach (var month in GetAllMonths())
                 {

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.razor.cs
@@ -237,6 +237,16 @@ namespace MudBlazor
             PickerMonth = GetMonthEnd().AddDays(1);
         }
 
+        private void OnPreviousYearClick()
+        {
+            PickerMonth = GetMonthStart().AddYears(-1);
+        }
+
+        private void OnNextYearClick()
+        {
+            PickerMonth = GetMonthStart().AddYears(1);
+        }
+
         private void OnYearClick()
         {
             OpenTo = OpenTo.Year;
@@ -296,7 +306,7 @@ namespace MudBlazor
 
         private void OnYearClicked(int year)
         {
-            OpenTo = OpenTo.Date;
+            OpenTo = OpenTo.Month;
             var current = GetMonthStart();
             PickerMonth = new DateTime(year, current.Month,  1);
         }
@@ -341,6 +351,12 @@ namespace MudBlazor
 
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
+            if (firstRender)
+            {
+                if(_picker_month == null)
+                    _picker_month = GetMonthStart();
+            }
+
             if (firstRender && OpenTo == OpenTo.Year)
             {
                 ScrollToYear();

--- a/src/MudBlazor/Styles/components/_pickerdate.scss
+++ b/src/MudBlazor/Styles/components/_pickerdate.scss
@@ -109,7 +109,7 @@
     .mud-picker-month {
         flex: 1 0 33.33%;
         cursor: pointer;
-        height: 75px;
+        height: 60px;
         display: flex;
         outline: none;
         transition: font-size 100ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;

--- a/src/MudBlazor/TScripts/scrollHelpers.js
+++ b/src/MudBlazor/TScripts/scrollHelpers.js
@@ -3,7 +3,7 @@ window.scrollHelpers = {
         var element = document.getElementById(elementId);
 
         if (element) {
-            element.scrollIntoView({ behavior: 'auto', block: 'center', inline: 'start' });
+            element.parentNode.scrollTop = element.offsetTop - element.parentNode.offsetTop;
         }
     },
     lockScroll: (selector) => {


### PR DESCRIPTION
- Add year to month picker closes https://github.com/Garderoben/MudBlazor/issues/209
- Gives the advantage of year selection in calendar only mode.
- Changes goto month instead of date after year selection
- Fixes https://github.com/Garderoben/MudBlazor/issues/505 jumpy scrollto
- Add tests