### PR TITLE
Fixes #499 OpenTo for pickers

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -148,6 +148,25 @@ namespace MudBlazor.UnitTests
         }
 
         [Test]
+        public void OpenToYear_ClickYear_CheckMonthsShown_Close_Reopen_CheckYearsShown()
+        {
+            var comp = OpenPicker(Parameter("OpenTo", OpenTo.Year));
+            comp.Instance.Date.Should().BeNull();
+            // should show years
+            comp.FindAll("div.mud-picker-year-container").Count.Should().Be(1);
+            comp.FindAll("div.mud-picker-year").First().Click();
+            comp.FindAll("div.mud-picker-month-container").Count.Should().Be(1);
+            // clicking outside to close
+            comp.Find("div.mud-overlay").Click();
+            // should not be open any more
+            comp.FindAll("div.mud-picker-open").Count.Should().Be(0);
+            comp.Find("input").Click();
+            // should show years
+            comp.FindAll("div.mud-picker-year-container").Count.Should().Be(1);            
+        }
+
+
+        [Test]
         public void OpenToMonth_CheckMonthsShown()
         {
             var comp = OpenPicker(Parameter("OpenTo", OpenTo.Month));

--- a/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
@@ -168,44 +168,41 @@ namespace MudBlazor.UnitTests
         [Test]
         public void OpenToHours_CheckMinutesHidden() 
         {
-            // Use bare component
-            var comp = ctx.RenderComponent<MudTimePicker>(("OpenTo", OpenTo.Hours));
-            // should not be open
-            comp.FindAll("div.mud-picker-open").Count.Should().Be(0);
-            // click to to open menu
-            comp.Find("input").Click();
-            // now its open
-            comp.FindAll("div.mud-picker-open").Count.Should().Be(1);
+            var comp = OpenPicker(Parameter("OpenTo", OpenTo.Hours));
             // Are hours displayed
             comp.FindAll("div.mud-time-picker-minute.mud-time-picker-dial-hidden").Count.Should().Be(1);
         }
 
         [Test]
-        public void OpenToMinutes_CheckHoursHidden() 
+        public void OpenToHours_ChangeTo_Minutes_ReOpen_CheckStillHours() 
         {
-            // Use bare component
-            var comp = ctx.RenderComponent<MudTimePicker>(("OpenTo", OpenTo.Minutes));
+            var comp = OpenPicker(Parameter("OpenTo", OpenTo.Hours));
+            // Are minutes hidden
+            comp.FindAll("div.mud-time-picker-minute.mud-time-picker-dial-hidden").Count.Should().Be(1);
+            // click on the minutes input
+            comp.FindAll("button.mud-timepicker-button").Skip(1).First().Click();
+            // clicking outside to close
+            comp.Find("div.mud-overlay").Click();
             // should not be open
             comp.FindAll("div.mud-picker-open").Count.Should().Be(0);
-            // click to to open menu
-            comp.Find("input").Click();
-            // now its open
-            comp.FindAll("div.mud-picker-open").Count.Should().Be(1);
-            // Any hours displayed
+            comp.FindAll("input").First().Click();
+            // Are hours displayed
+            comp.FindAll("div.mud-time-picker-minute.mud-time-picker-dial-hidden").Count.Should().Be(1);
+        }
+
+
+        [Test]
+        public void OpenToMinutes_CheckHoursHidden()
+        {
+            var comp = OpenPicker(Parameter("OpenTo", OpenTo.Minutes));
+            // Are Hours hidden
             comp.FindAll("div.mud-time-picker-hour.mud-time-picker-dial-hidden").Count.Should().Be(1);
         }
 
         [Test]
         public void ChangeToMinutes_FromHours_CheckHoursHidden() 
         {
-            // Use bare component
-            var comp = ctx.RenderComponent<MudTimePicker>();
-            // should not be open
-            comp.FindAll("div.mud-picker-open").Count.Should().Be(0);
-            // click to to open menu
-            comp.Find("input").Click();
-            // now its open
-            comp.FindAll("div.mud-picker-open").Count.Should().Be(1);
+            var comp = OpenPicker();
             // click on the minutes input
             comp.FindAll("button.mud-timepicker-button").Skip(1).First().Click();
             // Are minutes displayed

--- a/src/MudBlazor/Base/MudBasePicker.cs
+++ b/src/MudBlazor/Base/MudBasePicker.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Components;
+﻿using System;
+using Microsoft.AspNetCore.Components;
 
 namespace MudBlazor
 {
@@ -130,24 +131,22 @@ namespace MudBlazor
             /* to be overridden by descendants */
         }
 
-        internal bool isOpen { get; set; }
+        internal bool IsOpen { get; set; }
 
-        public void ToggleOpen()
+        public virtual void ToggleOpen()
         {
-            isOpen = !isOpen;
-            StateHasChanged();
+            IsOpen = !IsOpen;
         }
 
         public void Close()
         {
-            isOpen = false;
+            IsOpen = false;
             StateHasChanged();
         }
 
-        public void Open()
+        public virtual void Open()
         {
-            isOpen = true;
-            StateHasChanged();
+            IsOpen = true;
         }
     }
 }

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.razor
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.razor
@@ -2,13 +2,15 @@
 @inherits MudBasePicker
 
 
-<MudPicker @ref="Picker" Class="@Class" PickerVariant="@PickerVariant" Orientation="@Orientation" Label="@Label" @bind-Value="@Value" HelperText="@HelperText" Editable="@Editable" InputVariant="@InputVariant" Disabled="@Disabled" Adornment="@Adornment" IconSize="@IconSize" InputIcon="@InputIcon" Elevation="@Elevation" Square="@Square" Rounded="@Rounded">
+<MudPicker @ref="Picker" Class="@Class" PickerVariant="@PickerVariant" Orientation="@Orientation" Label="@Label" @bind-Value="@Value"
+        HelperText="@HelperText" Editable="@Editable" InputVariant="@InputVariant" Disabled="@Disabled" Adornment="@Adornment"
+        IconSize="@IconSize" InputIcon="@InputIcon" Elevation="@Elevation" Square="@Square" Rounded="@Rounded" PickerOpened="OnPickerOpened">
     <MudPickerToolbar Class="mud-picker-datepicker-toolbar" DisableToolbar="@DisableToolbar" Orientation="@Orientation" Color="@Color">
         <MudButton Variant="Variant.Text" Color="Color.Inherit" Class="mud-button-year" OnClick="@OnYearClick">@GetFormattedYearString()</MudButton>
         <MudButton Variant="Variant.Text" Color="Color.Inherit" Class="mud-button-date" OnClick="@OnFormattedDateClick">@GetFormattedDateString()</MudButton>
     </MudPickerToolbar>
     <MudPickerContent>
-        @if (OpenTo == OpenTo.Year)
+        @if (_currentView == OpenTo.Year)
         {
             <div id="pickerYears" class="mud-picker-year-container">
                 @for (int i = GetMinYear(); i <= GetMaxYear(); i++)
@@ -20,7 +22,7 @@
                 }
             </div>
         }
-        else if (OpenTo == OpenTo.Month)
+        else if (_currentView == OpenTo.Month)
         {
             <div class="mud-picker-calendar-header">
                 <div class="mud-picker-calendar-header-switch">

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.razor.cs
@@ -126,6 +126,8 @@ namespace MudBlazor
         private void OnPickerOpened()
         {
             _currentView = OpenTo;
+            if(_currentView == OpenTo.Year)
+                _scrollToYearAfterRender=true;
         }
 
         protected override void StringValueChanged(string value)
@@ -275,7 +277,7 @@ namespace MudBlazor
         {
             _scrollToYearAfterRender = false;
             string id = $"{_componentId}{GetMonthStart().Year.ToString()}";
-            await JsRuntime.InvokeVoidAsync("scrollHelpers.scrollToFragment", id);
+            await JsRuntime.InvokeVoidAsync("scrollHelpers.scrollToYear", id);
             StateHasChanged();
         }
 
@@ -369,6 +371,7 @@ namespace MudBlazor
                 ScrollToYear();
                 return;
             }
+
             if (_scrollToYearAfterRender)
                 ScrollToYear();
             await base.OnAfterRenderAsync(firstRender);

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.razor.cs
@@ -121,6 +121,13 @@ namespace MudBlazor
         /// </summary>
         private MudPicker Picker;
 
+        private OpenTo _currentView;
+        
+        private void OnPickerOpened()
+        {
+            _currentView = OpenTo;
+        }
+
         protected override void StringValueChanged(string value)
         {
             // update the date property
@@ -249,7 +256,7 @@ namespace MudBlazor
 
         private void OnYearClick()
         {
-            OpenTo = OpenTo.Year;
+            _currentView = OpenTo.Year;
             StateHasChanged();
             _scrollToYearAfterRender = true;
         }
@@ -306,7 +313,7 @@ namespace MudBlazor
 
         private void OnYearClicked(int year)
         {
-            OpenTo = OpenTo.Month;
+            _currentView = OpenTo.Month;
             var current = GetMonthStart();
             PickerMonth = new DateTime(year, current.Month,  1);
         }
@@ -339,13 +346,13 @@ namespace MudBlazor
 
         private void OnMonthClicked()
         {
-            OpenTo = OpenTo.Month;
+            _currentView = OpenTo.Month;
             StateHasChanged();
         }
 
         private void OnMonthSelected(in DateTime month)
         {
-            OpenTo = OpenTo.Date;
+            _currentView = OpenTo.Date;
             PickerMonth = month;
         }
 
@@ -357,7 +364,7 @@ namespace MudBlazor
                     _picker_month = GetMonthStart();
             }
 
-            if (firstRender && OpenTo == OpenTo.Year)
+            if (firstRender && _currentView == OpenTo.Year)
             {
                 ScrollToYear();
                 return;

--- a/src/MudBlazor/Components/Picker/MudPicker.razor
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor
@@ -9,7 +9,7 @@
                       @onclick="@(() => { if (!Editable) ToggleOpen(); })" OnAdornmentClick="ToggleOpen" Disabled="@Disabled" Adornment="@Adornment" AdornmentIcon="@InputIcon" IconSize="@IconSize" />
     }
     <CascadingValue Value="@this" IsFixed="true">
-        @if (isOpen && PickerVariant != PickerVariant.Dialog)
+        @if (IsOpen && PickerVariant != PickerVariant.Dialog)
         {
             <MudPaper @attributes="UserAttributes" Class="@PickerPaperClass" Elevation="@PickerElevation" Square="@PickerSquare">
                 <div class="@PickerContainerClass">
@@ -17,9 +17,9 @@
                 </div>
             </MudPaper>
         }
-        else if(isOpen && PickerVariant == PickerVariant.Dialog)
+        else if(IsOpen && PickerVariant == PickerVariant.Dialog)
         {
-            <MudOverlay Visible="isOpen" OnClick="@Close" DarkBackground="true" Class="mud-overlay-dialog">
+            <MudOverlay Visible="IsOpen" OnClick="@Close" DarkBackground="true" Class="mud-overlay-dialog">
                 <MudPaper @attributes="UserAttributes" Class="@PickerPaperClass" Elevation="@PickerElevation" Square="@PickerSquare">
                     <div class="@PickerContainerClass">
                         @ChildContent
@@ -31,66 +31,5 @@
 </div>
 @if (PickerVariant == PickerVariant.Inline)
 {
-    <MudOverlay Visible="isOpen" OnClick="@Close" LockScroll="false" />
-}
-
-@code {
-
-    protected string PickerClass =>
-        new CssBuilder("mud-picker")
-           .AddClass($"mud-picker-inline", PickerVariant != PickerVariant.Static)
-           .AddClass($"mud-picker-static", PickerVariant == PickerVariant.Static)
-           .AddClass($"mud-rounded", PickerVariant == PickerVariant.Static && !PickerSquare)
-           .AddClass($"mud-elevation-{PickerElevation.ToString()}", PickerVariant == PickerVariant.Static)
-           .AddClass($"mud-picker-input-button", !AllowKeyboardInput && PickerVariant != PickerVariant.Static)
-           .AddClass($"mud-picker-input-text", AllowKeyboardInput && PickerVariant != PickerVariant.Static)
-           .AddClass($"mud-disabled", Disabled && PickerVariant != PickerVariant.Static)
-           .AddClass(Class)
-        .Build();
-
-    protected string PickerPaperClass =>
-    new CssBuilder("mud-picker-paper")
-      .AddClass("mud-picker-view", PickerVariant == PickerVariant.Inline)
-      .AddClass("mud-picker-open", isOpen && PickerVariant == PickerVariant.Inline)
-      .AddClass("mud-picker-popover-paper", PickerVariant == PickerVariant.Inline)
-      .AddClass("mud-dialog", PickerVariant == PickerVariant.Dialog)
-    .Build();
-
-    protected string PickerContainerClass =>
-    new CssBuilder("mud-picker-container")
-      .AddClass("mud-paper-square", PickerSquare)
-      .AddClass("mud-picker-container-landscape", Orientation == Orientation.Landscape && PickerVariant == PickerVariant.Static)
-    .Build();
-
-    [Parameter] public string InputIcon { get; set; }
-    [Parameter] public RenderFragment ChildContent { get; set; }
-
-    private bool PickerSquare { get; set; }
-    private int PickerElevation { get; set; }
-
-    protected override void OnInitialized()
-    {
-        if (PickerVariant == PickerVariant.Static)
-        {
-            isOpen = true;
-            if (Elevation == 8)
-            {
-                PickerElevation = 0;
-            }
-            else
-            {
-                PickerElevation = Elevation;
-            }
-
-            if (!Rounded)
-            {
-                PickerSquare = true;
-            }
-        }
-        else
-        {
-            PickerSquare = Square;
-            PickerElevation = Elevation;
-        }
-    }
+    <MudOverlay Visible="IsOpen" OnClick="@Close" LockScroll="false" />
 }

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -1,0 +1,90 @@
+using System;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using MudBlazor.Utilities;
+
+namespace MudBlazor
+{
+    public partial class MudPicker : MudBasePicker
+    {
+        protected string PickerClass =>
+            new CssBuilder("mud-picker")
+            .AddClass($"mud-picker-inline", PickerVariant != PickerVariant.Static)
+            .AddClass($"mud-picker-static", PickerVariant == PickerVariant.Static)
+            .AddClass($"mud-rounded", PickerVariant == PickerVariant.Static && !PickerSquare)
+            .AddClass($"mud-elevation-{PickerElevation.ToString()}", PickerVariant == PickerVariant.Static)
+            .AddClass($"mud-picker-input-button", !AllowKeyboardInput && PickerVariant != PickerVariant.Static)
+            .AddClass($"mud-picker-input-text", AllowKeyboardInput && PickerVariant != PickerVariant.Static)
+            .AddClass($"mud-disabled", Disabled && PickerVariant != PickerVariant.Static)
+            .AddClass(Class)
+            .Build();
+
+        protected string PickerPaperClass =>
+        new CssBuilder("mud-picker-paper")
+        .AddClass("mud-picker-view", PickerVariant == PickerVariant.Inline)
+        .AddClass("mud-picker-open", IsOpen && PickerVariant == PickerVariant.Inline)
+        .AddClass("mud-picker-popover-paper", PickerVariant == PickerVariant.Inline)
+        .AddClass("mud-dialog", PickerVariant == PickerVariant.Dialog)
+        .Build();
+
+        protected string PickerContainerClass =>
+        new CssBuilder("mud-picker-container")
+        .AddClass("mud-paper-square", PickerSquare)
+        .AddClass("mud-picker-container-landscape", Orientation == Orientation.Landscape && PickerVariant == PickerVariant.Static)
+        .Build();
+
+        [Parameter] public string InputIcon { get; set; }
+        [Parameter] public RenderFragment ChildContent { get; set; }
+
+        [Parameter] public EventCallback PickerOpened { get; set; }
+
+        private bool PickerSquare { get; set; }
+        private int PickerElevation { get; set; }
+
+        protected override void OnInitialized()
+        {
+            if (PickerVariant == PickerVariant.Static)
+            {
+                IsOpen = true;
+                if (Elevation == 8)
+                {
+                    PickerElevation = 0;
+                }
+                else
+                {
+                    PickerElevation = Elevation;
+                }
+
+                if (!Rounded)
+                {
+                    PickerSquare = true;
+                }
+            }
+            else
+            {
+                PickerSquare = Square;
+                PickerElevation = Elevation;
+            }
+        }
+
+        public override void ToggleOpen()
+        {
+            base.ToggleOpen();
+            if(IsOpen)
+                OnPickerOpened();
+            else
+                StateHasChanged();
+        }
+
+        public override void Open()
+        {
+            base.Open();
+            OnPickerOpened();
+        }
+
+        protected virtual void OnPickerOpened()
+        {
+            PickerOpened.InvokeAsync(this);
+        }
+    }
+}

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor
@@ -2,7 +2,10 @@
 @inherits MudBasePicker
 
 
-<MudPicker @ref="Picker" Class="@Class" PickerVariant="@PickerVariant" Orientation="@Orientation" Label="@Label" @bind-Value="@Value" HelperText="@HelperText" InputVariant="@InputVariant" Editable="@Editable" Disabled="@Disabled" Adornment="@Adornment" IconSize="@IconSize" InputIcon="@InputIcon" Elevation="@Elevation" Square="@Square" Rounded="@Rounded">
+<MudPicker @ref="Picker" Class="@Class" PickerVariant="@PickerVariant" 
+        Orientation="@Orientation" Label="@Label" @bind-Value="@Value" HelperText="@HelperText" InputVariant="@InputVariant" 
+        Editable="@Editable" Disabled="@Disabled" Adornment="@Adornment" IconSize="@IconSize" InputIcon="@InputIcon" 
+        Elevation="@Elevation" Square="@Square" Rounded="@Rounded" PickerOpened="OnPickerOpened">
     <MudPickerToolbar Class="@ToolbarClass" DisableToolbar="@DisableToolbar" Orientation="@Orientation" Color="@Color">
         <div class="mud-timepicker-hourminute">
             <MudButton Variant="Variant.Text" Color="Color.Inherit" Class="@HoursButtonClass" OnClick="@OnHourClick">@GetHourString()</MudButton>

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -16,7 +16,7 @@ namespace MudBlazor
         /// </summary>
         private MudPicker Picker;
 
-        private OpenTo _currentMode = OpenTo.Hours;
+        private OpenTo _currentView;
 
         /// <summary>
         /// First view to show in the MudDatePicker.
@@ -76,6 +76,11 @@ namespace MudBlazor
             Time = ParseTimeValue(value);
         }
 
+        private void OnPickerOpened()
+        {
+            _currentView = OpenTo;
+        }
+
         private TimeSpan? ParseTimeValue(string value)
         {
             if (string.IsNullOrWhiteSpace(value))
@@ -122,13 +127,13 @@ namespace MudBlazor
 
         private void OnHourClick()
         {
-            _currentMode = OpenTo.Hours;
+            _currentView = OpenTo.Hours;
             StateHasChanged();
         }
 
         private void OnMinutesClick()
         {
-            _currentMode = OpenTo.Minutes;
+            _currentView = OpenTo.Minutes;
             StateHasChanged();
         }
 
@@ -155,12 +160,12 @@ namespace MudBlazor
 
         protected string HoursButtonClass =>
         new CssBuilder("mud-timepicker-button")
-          .AddClass($"mud-timepicker-toolbar-text", _currentMode == OpenTo.Minutes)
+          .AddClass($"mud-timepicker-toolbar-text", _currentView == OpenTo.Minutes)
         .Build();
 
         protected string MinuteButtonClass =>
         new CssBuilder("mud-timepicker-button")
-          .AddClass($"mud-timepicker-toolbar-text", _currentMode == OpenTo.Hours)
+          .AddClass($"mud-timepicker-toolbar-text", _currentView == OpenTo.Hours)
         .Build();
 
         protected string AmButtonClass =>
@@ -176,15 +181,15 @@ namespace MudBlazor
         private string HourDialClass =>
         new CssBuilder("mud-time-picker-hour")
           .AddClass($"mud-time-picker-dial")
-          .AddClass($"mud-time-picker-dial-out", _currentMode != OpenTo.Hours)
-          .AddClass($"mud-time-picker-dial-hidden", _currentMode != OpenTo.Hours)
+          .AddClass($"mud-time-picker-dial-out", _currentView != OpenTo.Hours)
+          .AddClass($"mud-time-picker-dial-hidden", _currentView != OpenTo.Hours)
         .Build();
 
         private string MinuteDialClass =>
         new CssBuilder("mud-time-picker-minute")
           .AddClass($"mud-time-picker-dial")
-          .AddClass($"mud-time-picker-dial-out", _currentMode != OpenTo.Minutes)
-          .AddClass($"mud-time-picker-dial-hidden", _currentMode != OpenTo.Minutes)
+          .AddClass($"mud-time-picker-dial-out", _currentView != OpenTo.Minutes)
+          .AddClass($"mud-time-picker-dial-hidden", _currentView != OpenTo.Minutes)
         .Build();
 
         private bool IsAm => _timeSet.Hour >= 00 && _timeSet.Hour < 12; // am is 00:00 to 11:59 
@@ -222,7 +227,7 @@ namespace MudBlazor
 
         private string GetNumberColor(int value)
         {
-            if(_currentMode == OpenTo.Hours)
+            if(_currentView == OpenTo.Hours)
             {
                 var h = _timeSet.Hour;
                 if (AmPm)
@@ -234,7 +239,7 @@ namespace MudBlazor
                 if (h==value)
                     return $"mud-clock-number mud-theme-{Color.ToDescriptionString()}";
             }
-            else if (_currentMode == OpenTo.Minutes && _timeSet.Minute == value)
+            else if (_currentView == OpenTo.Minutes && _timeSet.Minute == value)
             {
                 return $"mud-clock-number mud-theme-{Color.ToDescriptionString()}";
             }
@@ -244,9 +249,9 @@ namespace MudBlazor
         private double GetDeg()
         {
             double deg = 0;
-            if (_currentMode == OpenTo.Hours)
+            if (_currentView == OpenTo.Hours)
                 deg = (_timeSet.Hour * 30) % 360;
-            if (_currentMode == OpenTo.Minutes)
+            if (_currentView == OpenTo.Minutes)
                 deg = (_timeSet.Minute * 6) % 360;
             return deg;
         }
@@ -254,9 +259,9 @@ namespace MudBlazor
         private string GetPointerRotation()
         {
             double deg = 0;
-            if (_currentMode == OpenTo.Hours)
+            if (_currentView == OpenTo.Hours)
                 deg = (_timeSet.Hour * 30) % 360;
-            if (_currentMode == OpenTo.Minutes)
+            if (_currentView == OpenTo.Minutes)
                 deg = (_timeSet.Minute * 6) % 360;
             return $"rotateZ({deg}deg);";
         }
@@ -264,9 +269,9 @@ namespace MudBlazor
         private string GetPointerHeight()
         {
             int height = 40;
-            if (_currentMode == OpenTo.Minutes)
+            if (_currentView == OpenTo.Minutes)
                 height = 40;
-            if (_currentMode == OpenTo.Hours)
+            if (_currentView == OpenTo.Hours)
             {
                 if (!AmPm && _timeSet.Hour > 0 && _timeSet.Hour < 13)
                     height = 26;
@@ -282,7 +287,7 @@ namespace MudBlazor
         protected override void OnInitialized()
         {
             UpdateTimeSetFromTime();
-            _currentMode = OpenTo;
+            _currentView = OpenTo;
             _initialHour = _timeSet.Hour;
         }
 
@@ -315,9 +320,9 @@ namespace MudBlazor
         private void OnMouseUp(MouseEventArgs e)
         {
             MouseDown = false;
-            if(_currentMode == OpenTo.Hours && _timeSet.Hour != _initialHour)
+            if(_currentView == OpenTo.Hours && _timeSet.Hour != _initialHour)
             {
-                _currentMode = OpenTo.Minutes;
+                _currentView = OpenTo.Minutes;
             }
         }
 
@@ -348,7 +353,7 @@ namespace MudBlazor
             }
             _timeSet.Hour = h;
             UpdateTime();
-            _currentMode = OpenTo.Minutes;
+            _currentView = OpenTo.Minutes;
         }
 
         /// <summary>

--- a/src/MudBlazor/TScripts/scrollHelpers.js
+++ b/src/MudBlazor/TScripts/scrollHelpers.js
@@ -3,7 +3,14 @@ window.scrollHelpers = {
         var element = document.getElementById(elementId);
 
         if (element) {
-            element.parentNode.scrollTop = element.offsetTop - element.parentNode.offsetTop;
+            element.scrollIntoView({ behavior: 'auto', block: 'center', inline: 'start' });
+        }
+    },
+    scrollToYear: (elementId) => {
+        var element = document.getElementById(elementId);
+
+        if (element) {
+            element.parentNode.scrollTop = element.offsetTop - element.parentNode.offsetTop - element.scrollHeight * 3;
         }
     },
     lockScroll: (selector) => {


### PR DESCRIPTION
- OpenTo is supposed to not change state. ie If you set a picker to open to year it should always do so.
- The current code reused the OpenTo state in its rendering logic so its initial state was lost.
- I fixed this by loading OpenTo to a private variable when opening of the picker.
- Moved MudPicker code to separate `razor.cs` file.
- Actually took a lot longer than I thought.
- Added tests.
