### PR TITLE
Fix autocomplete jumping on keyboard

### DIFF
--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -21,8 +21,7 @@
                     @foreach (T item in _items)
                     {
                         bool is_selected = i == _selectedListItemIndex;
-                        //TODO Should this have a @key? because is inside a loop
-                        <MudListItem id="@GetListItemId(i)" OnClick="@(() => SelectOption(item))" Class="@(is_selected ? "mud-selected-item" : "")">
+                        <MudListItem @key="@item" id="@GetListItemId(i)" OnClick="@(() => SelectOption(item))" Class="@(is_selected ? "mud-selected-item" : "")">
                             @if (ItemTemplate == null)
                             {
                                 @GetItemString(item)

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -13,13 +13,15 @@
             </InputContent>
         </MudInputControl>
         <MudPopover Open="@IsOpen" MaxHeight="@MaxHeight" OffsetY="true">
-            <MudList Clickable="true" Dense="@Dense">
+            @*this must be the real scroll container, not the Popover, hence the maxheight*@
+            <MudList Clickable="true" Dense="@Dense" Style=@($"max-height: {MaxHeight}px; overflow-y:auto;")>
                 @if (_items != null && _items.Any())
                 {
                     int i = 0;
                     @foreach (T item in _items)
                     {
                         bool is_selected = i == _selectedListItemIndex;
+                        //TODO Should this have a @key? because is inside a loop
                         <MudListItem id="@GetListItemId(i)" OnClick="@(() => SelectOption(item))" Class="@(is_selected ? "mud-selected-item" : "")">
                             @if (ItemTemplate == null)
                             {

--- a/src/MudBlazor/Styles/components/_list.scss
+++ b/src/MudBlazor/Styles/components/_list.scss
@@ -40,10 +40,10 @@
     background-color: transparent;
     -webkit-appearance: none;
     -webkit-tap-highlight-color: transparent;
-    transition: background-color 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 
     &:hover {
         background-color: var(--mud-palette-action-default-hover);
+        transition: background-color 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
     }
 
     &:focus {

--- a/src/MudBlazor/TScripts/scrollHelpers.js
+++ b/src/MudBlazor/TScripts/scrollHelpers.js
@@ -1,18 +1,55 @@
 window.scrollHelpers = {
-    scrollToFragment: (elementId) => {
+    scrollToFragment: (elementId, behavior) => {
         var element = document.getElementById(elementId);
 
         if (element) {
-            element.scrollIntoView({ behavior: 'auto', block: 'center', inline: 'start' });
+            element.scrollIntoView({ behavior, block: 'center', inline: 'start' });
         }
     },
-    scrollToYear: (elementId) => {
+    //scrolls to year in MudDatePicker
+    scrollToYear: (elementId, offset) => {
         var element = document.getElementById(elementId);
 
         if (element) {
-            element.parentNode.scrollTop = element.offsetTop - element.parentNode.offsetTop - element.scrollHeight * 3;
+            element.parentNode.scrollTop = element.offsetTop - element.parentNode.offsetTop - element.scrollHeight * offset;
         }
     },
+
+    // scrolls down or up in a select input
+    //increment is 1 if moving dow and -1 if moving up
+    //onEdges is a boolean. If true, it waits to reach the bottom or the top
+    //of the container to scroll.   
+    scrollToListItem: (elementId, increment, onEdges) => {
+        let element = document.getElementById(elementId);        
+        if (element) {
+
+            //this is the scroll container
+            let parent = element.parentElement;
+            //reset the scroll position when close the menu
+            if (increment == 0) {
+                parent.scrollTop = 0;
+                return;
+            }
+
+            //position of the elements relative to the screen, so we can compare
+            //one with the other
+            //e:element; p:parent of the element; For example:eBottom is the element bottom
+            let { bottom: eBottom, height:eHeight, top:eTop } = element.getBoundingClientRect();
+            let { bottom: pBottom, top: pTop} = parent.getBoundingClientRect();
+
+            if (
+                //if element reached bottom and direction is down
+                ((pBottom - eBottom <= 0) && increment > 0)
+                //or element reached top and direction is up
+                || ((eTop - pTop <= 0) && increment < 0)
+                // or scroll is not constrained to the Edges
+                || !onEdges
+            ) {
+                parent.scrollTop += eHeight* increment;                
+            }
+        }
+    },
+
     lockScroll: (selector) => {
         let element = document.querySelector(selector);
         if (element) {


### PR DESCRIPTION
### Fix scroll jumping on MudAutoComplete.

- When scrolls down, the autocomplete must wait until reach the end of the container until to start to scroll
- The opposite when scrolls up
- After close the menu, the scroll position must be restored to top of the container
- The scroll container must be the MudList, not the MudPopover, in order to let the items scroll alongside the parent. That's why I applied the MaxHeight of the popover to the list.