### PR TITLE
Fix async calls in Alert

### DIFF
--- a/src/MudBlazor/Components/Alert/MudAlert.razor
+++ b/src/MudBlazor/Components/Alert/MudAlert.razor
@@ -2,7 +2,7 @@
 
 @inherits MudComponentBase
 
-<div @attributes="UserAttributes" class="@Classname" Style="@Style" @onclick="OnClicked" >
+<div @attributes="UserAttributes" class="@Classname" Style="@Style" @onclick="OnClick" >
     @if (!NoIcon)
     {
         <div class="mud-alert-icon">

--- a/src/MudBlazor/Components/Alert/MudAlert.razor.cs
+++ b/src/MudBlazor/Components/Alert/MudAlert.razor.cs
@@ -77,17 +77,12 @@ namespace MudBlazor
                     _ => throw new ArgumentOutOfRangeException(nameof(Severity)),
                 };
             }
-            }
+        }
 
         /// <summary>
         /// Raised when the alert is clicked
         /// </summary>
         [Parameter] public EventCallback<MouseEventArgs> OnClick { get; set; }
-
-        private void OnClicked(MouseEventArgs ev)
-        {
-            OnClick.InvokeAsync(ev);
-        }
     }
 }
    


### PR DESCRIPTION
Removed OnClicked since it was not really needed and contains no logic, so OnClick eventcallback is bound directly to the element (and task correctly awaited by Blazor)