### PR TITLE
Adjustment & clarifications on async calls

### DIFF
--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -109,7 +109,7 @@ namespace MudBlazor
                 _text = text;
                 if (updateValue)
                     UpdateValueProperty(false);
-                TextChanged.InvokeAsync(_text).FireAndForget();
+                TextChanged.InvokeAsync(_text).AndForget();
             }
         }
 
@@ -132,15 +132,15 @@ namespace MudBlazor
 
         [Parameter] public EventCallback<KeyboardEventArgs> OnKeyDown { get; set; }
 
-        protected virtual void onKeyDown(KeyboardEventArgs obj) => OnKeyDown.InvokeAsync(obj).FireAndForget();
+        protected virtual void onKeyDown(KeyboardEventArgs obj) => OnKeyDown.InvokeAsync(obj).AndForget();
 
         [Parameter] public EventCallback<KeyboardEventArgs> OnKeyPress { get; set; }
 
-        protected virtual void onKeyPress(KeyboardEventArgs obj) => OnKeyPress.InvokeAsync(obj).FireAndForget();
+        protected virtual void onKeyPress(KeyboardEventArgs obj) => OnKeyPress.InvokeAsync(obj).AndForget();
 
         [Parameter] public EventCallback<KeyboardEventArgs> OnKeyUp { get; set; }
 
-        protected virtual void onKeyUp(KeyboardEventArgs obj) => OnKeyUp.InvokeAsync(obj).FireAndForget();
+        protected virtual void onKeyUp(KeyboardEventArgs obj) => OnKeyUp.InvokeAsync(obj).AndForget();
 
         /// <summary>
         /// Fired when the Value property changes. 

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -139,7 +139,7 @@ namespace MudBlazor
         // async code was executed to avoid race condition which could lead to incorrect validation results.
         protected void BeginValidateAfter(Task task)
         {
-            ((Func<Task>)(async () =>
+            Func<Task> execute = async () =>
             {
                 var value = _value;
 
@@ -149,13 +149,13 @@ namespace MudBlazor
                 {
                     BeginValidate();
                 }
-            }))
-            ().FireAndForget();
+            };
+            execute().AndForget();
         }
 
         protected void BeginValidate()
         {
-            ((Func<Task>)(async () =>
+            Func<Task> execute = async () =>
             {
                 var value = _value;
 
@@ -165,8 +165,8 @@ namespace MudBlazor
                 {
                     EditFormValidate();
                 }
-            }))
-            ().FireAndForget();
+            };
+            execute().AndForget();
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/FocusTrap/MudFocusTrap.razor.cs
+++ b/src/MudBlazor/Components/FocusTrap/MudFocusTrap.razor.cs
@@ -137,7 +137,7 @@ namespace MudBlazor
         public void Dispose()
         {
             if (!_disabled)
-                RestoreFocusAsync().FireAndForget();
+                RestoreFocusAsync().AndForget(TaskOption.Safe);
         }
     }
 }

--- a/src/MudBlazor/Extensions/TaskExtensions.cs
+++ b/src/MudBlazor/Extensions/TaskExtensions.cs
@@ -3,14 +3,26 @@ using System.Threading.Tasks;
 
 namespace MudBlazor
 {
-    internal static class TaskExtensions
+    public enum TaskOption
     {
-        public static void FireAndForget(this Task task)
+        None,
+        Safe
+    }
+
+    public static class TaskExtensions
+    {
+        /// <summary>
+        /// Task will be awaited and exceptions will be managed by the Blazor framework.
+        /// </summary>
+        public static async void AndForget(this Task task)
         {
-            task.FireAndForget(ex => Console.WriteLine(ex));
+            await task;
         }
 
-        public static async void FireAndForget(this Task task, Action<Exception> handler)
+        /// <summary>
+        /// Task will be awaited and exceptions will be logged to console (TaskOption.Safe) or managed by the Blazor framework (TaskOption.None).
+        /// </summary>
+        public static async void AndForget(this Task task, TaskOption option)
         {
             try
             {
@@ -18,16 +30,25 @@ namespace MudBlazor
             }
             catch(Exception ex)
             {
-                handler(ex);
+                if (option != TaskOption.Safe)
+                    throw;
+
+                Console.WriteLine(ex);
             }
         }
 
-        public static void FireAndForget(this ValueTask task)
+        /// <summary>
+        /// ValueTask will be awaited and exceptions will be managed by the Blazor framework.
+        /// </summary>
+        public static async void AndForget(this ValueTask task)
         {
-            task.FireAndForget(ex => Console.WriteLine(ex));
+            await task;
         }
 
-        public static async void FireAndForget(this ValueTask task, Action<Exception> handler)
+        /// <summary>
+        /// ValueTask will be awaited and exceptions will be logged to console (TaskOption.Safe) or managed by the Blazor framework (TaskOption.None).
+        /// </summary>
+        public static async void AndForget(this ValueTask task, TaskOption option)
         {
             try
             {
@@ -35,7 +56,10 @@ namespace MudBlazor
             }
             catch (Exception ex)
             {
-                handler(ex);
+                if (option != TaskOption.Safe)
+                    throw;
+
+                Console.WriteLine(ex);
             }
         }
     }


### PR DESCRIPTION
Here's an adjustment PR for small things I did previously about async calls.

But first, I realized that maybe I was misleading in previous discussions (#521), so I would like to clarify.

I said that uncaught exception will break the app. Well, not always. It depends if the task is awaited and how. In fact, the basic idea is that when an exception is thrown inside the async part of a task, it is stored in the Task object and then it's up to the caller to do whatever he wants with it.

So, to resume:

1-If a task is just invoked (ie, without await), the exception stored in the task will be ignored, so nothing will happen and execution of this task will just silently fail (not even shown in console!). So it is pretty bad and hard to debug :-(

2-If task is awaited, the IL code inserted by the compiler will check if the task contains an exception and then:

2a-...if the method returns a Task, it will contain the exception details so the caller can handle it (or ignore, haha)

2b-...if the method does not return a Task, the exception is thrown and becomes unhandled, so Blazor will catch it.

According to this, this PR brings some adjustments:

-I think that for now, the correct behavior is to redirect exceptions to the default Blazor handling, so it makes things very clear that something bad happened and should be fixed (and in future version, Blazor may offer some mechanisms for global exception handling)

-Adopted a more natural and "fluent" style (ex: InvokeAsync().AndForget())

-Added an option to specify that a specific forget call should be "safe", ie should not throw exception. For example, when disposing an object, it may not be critical to be successful or not.

-Added descriptions for methods.