### PR TITLE
Implementing ReadOnly for CheckBox & Switch

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Checkbox/CheckboxPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Checkbox/CheckboxPage.razor
@@ -51,5 +51,15 @@
             <SectionSource Code="CheckboxConversionExample" GitHubFolderName="Switch" />
         </DocsPageSection>
 
+        <DocsPageSection>
+            <SectionHeader>
+                <Title>ReadOnly mode</Title>
+                <Description>Set <CodeInline>ReadOnly="true"</CodeInline> will make the checkbox control stop listening to user inputs.</Description>
+            </SectionHeader>
+            <SectionContent Outlined="true">
+                <CheckboxReadOnlyExample/>
+            </SectionContent>
+            <SectionSource Code="CheckboxReadOnlyExample" GitHubFolderName="Checkbox" />
+        </DocsPageSection>
     </DocsPageContent>
 </DocsPage>

--- a/src/MudBlazor.Docs/Pages/Components/Checkbox/Examples/CheckboxReadOnlyExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Checkbox/Examples/CheckboxReadOnlyExample.razor
@@ -1,0 +1,21 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudCheckBox ReadOnly="@ReadOnly" @bind-Checked="@Label_Checkbox1" Label="@(ReadOnly ? "ReadOnly Checkbox 1" : "EditMode Checkbox 1")"/>
+<MudCheckBox ReadOnly="@ReadOnly" @bind-Checked="@Label_Checkbox2" Label="@(ReadOnly ? "ReadOnly Checkbox 2" : "EditMode Checkbox 2")"/>
+
+<MudSelect  @bind-Value="@Label_Checkbox1" Label="Checkbox 1">
+    <MudSelectItem Value="@(false)">False</MudSelectItem>
+    <MudSelectItem Value="@(true)">True</MudSelectItem>
+</MudSelect>
+<MudSelect @bind-Value="@Label_Checkbox2" Label="Checkbox 2">
+    <MudSelectItem Value="@(false)">False</MudSelectItem>
+    <MudSelectItem Value="@(true)">True</MudSelectItem>
+</MudSelect>
+
+<MudSwitch @bind-Checked="@ReadOnly" Label="@(ReadOnly ? "ReadOnly Mode" : "Edit Mode")"/>
+
+@code {
+    public bool Label_Checkbox1 { get; set; } = true;
+    public bool Label_Checkbox2 { get; set; } = false;
+    public bool ReadOnly { get; set; } = true;
+}

--- a/src/MudBlazor.Docs/Pages/Components/Switch/Examples/SwitchReadOnlyExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Switch/Examples/SwitchReadOnlyExample.razor
@@ -1,0 +1,14 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudSwitch ReadOnly="@ReadOnly" @bind-Checked="@SwitchValue" Label="@(SwitchValue ? "On" : "Off")"/>
+
+<MudSelect  @bind-Value="@SwitchValue" Label="Change Switch value">
+    <MudSelectItem Value="@(false)">False</MudSelectItem>
+    <MudSelectItem Value="@(true)">True</MudSelectItem>
+</MudSelect>
+
+<MudSwitch @bind-Checked="@ReadOnly" Label="@(ReadOnly ? "ReadOnly Mode" : "Edit Mode")"/>
+@code {
+    public bool SwitchValue { get; set; } = true;
+    public bool ReadOnly { get; set; } = true;
+}

--- a/src/MudBlazor.Docs/Pages/Components/Switch/SwitchPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Switch/SwitchPage.razor
@@ -36,6 +36,16 @@
             <SectionSource Code="SwitchConversionExample" GitHubFolderName="Switch"  />
         </DocsPageSection>
 
+        <DocsPageSection>
+            <SectionHeader>
+                <Title>ReadOnly mode</Title>
+                <Description>Set <CodeInline>ReadOnly="true"</CodeInline> will make the switch control stop listening to user inputs.</Description>
+            </SectionHeader>
+            <SectionContent Outlined="true">
+                <SwitchReadOnlyExample/>
+            </SectionContent>
+            <SectionSource Code="SwitchReadOnlyExample" GitHubFolderName="Switch" />
+        </DocsPageSection>
     </DocsPageContent>
 </DocsPage>
 

--- a/src/MudBlazor/Base/MudBooleanInput.cs
+++ b/src/MudBlazor/Base/MudBooleanInput.cs
@@ -6,6 +6,11 @@ namespace MudBlazor
     public class MudBooleanInput<T> : MudFormComponent<T, bool?>
     {
         public MudBooleanInput() : base(new BoolConverter<T>()) { }
+        
+        /// <summary>
+        /// If true, the input will be read only.
+        /// </summary>
+        [Parameter] public bool ReadOnly { get; set; }
 
         /// <summary>
         /// Fired when Checked changes.

--- a/src/MudBlazor/Components/CheckBox/MudCheckBox.razor
+++ b/src/MudBlazor/Components/CheckBox/MudCheckBox.razor
@@ -5,7 +5,7 @@
 <label class="@Classname" style="@Style">
     <span class="@CheckBoxClassname">
         @*note: stopping the click propagation is important here. otherwise checking the checkbox results in click events on its parent (i.e. table row), which is generally not what you would want*@
-        <input @attributes="UserAttributes" type="checkbox" class="mud-checkbox-input" @bind="@BoolValue" disabled="@Disabled" @onclick:stopPropagation="true" />
+        <input @attributes="UserAttributes" type="checkbox" class="mud-checkbox-input" @bind="@BoolValue" disabled="@Disabled" @onclick:stopPropagation="true" @onclick:preventDefault="@ReadOnly"/>
         @if (BoolValue == true)
         {
             <svg class="mud-svg-icon-root" focusable="false" viewBox="0 0 24 24" role="presentation" aria-hidden="true">

--- a/src/MudBlazor/Components/Switch/MudSwitch.razor
+++ b/src/MudBlazor/Components/Switch/MudSwitch.razor
@@ -6,7 +6,7 @@
     <span class="mud-switch-span">
         <span class="@SwitchClassname">
             <span class="mud-switch-button">
-                <input @attributes="UserAttributes" type="checkbox" class="mud-switch-input" @bind="@BoolValue" disabled="@Disabled" />
+                <input @attributes="UserAttributes" type="checkbox" class="mud-switch-input" @bind="@BoolValue" disabled="@Disabled" @onclick:preventDefault="@ReadOnly"/>
                 <span class="mud-switch-thumb"></span>
             </span>
         </span>


### PR DESCRIPTION
Issue #528 

I think that MudRadioGroup and MudSlider should be discussed if they needs to obtain ReadOnly mode, because the implementation can be bit trickier and probably contain javascript. I am pretty new to Blazor and there is clearly a knowledge gap. 
Propably the disable state is enough.