### PR TITLE
Remove depreciated CodeBase member

### DIFF
--- a/src/MudBlazor.Docs.Compiler/XmlDocumentation.cs
+++ b/src/MudBlazor.Docs.Compiler/XmlDocumentation.cs
@@ -181,7 +181,7 @@ namespace MudBlazor.Docs.Compiler
 		/// <returns>The file path of the assembly.</returns>
 		public static string GetDirectoryPath(this Assembly assembly)
 		{
-			string codeBase = assembly.CodeBase;
+			string codeBase = "file://" + assembly.Location;
 			UriBuilder uri = new UriBuilder(codeBase);
 			string path = Uri.UnescapeDataString(uri.Path);
 			return Path.GetDirectoryName(path);

--- a/src/MudBlazor.Docs/Models/XmlDocumentation.cs
+++ b/src/MudBlazor.Docs/Models/XmlDocumentation.cs
@@ -181,7 +181,7 @@ namespace MudBlazor.Docs.Models
 		/// <returns>The file path of the assembly.</returns>
 		public static string GetDirectoryPath(this Assembly assembly)
 		{
-			string codeBase = assembly.CodeBase;
+			string codeBase = "file://" + assembly.Location;
 			UriBuilder uri = new UriBuilder(codeBase);
 			string path = Uri.UnescapeDataString(uri.Path);
 			return Path.GetDirectoryName(path);


### PR DESCRIPTION
- Produces compiler warning in net5 so pre-empt in develop