### PR TITLE
Set readonly warning to none default BOM

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -289,13 +289,10 @@ dotnet_diagnostic.CS1591.severity = none
 # IDE0071 Require file header 
 dotnet_diagnostic.IDE0073.severity = none
 file_header_template = Not Used
-# Dont use BOM
-charset = utf
-
 # IDE0055: Fix formatting
 dotnet_diagnostic.IDE0055.severity = suggestion
 # IDE0044: Make field readonly
-dotnet_diagnostic.IDE0044.severity = suggestion
+dotnet_diagnostic.IDE0044.severity = none
 
 [*]
 end_of_line = lf


### PR DESCRIPTION
- Part of a pair
- In doing the refactoring I discovered Visual Studio will use UTF8 BOM even if not set so dont fight it
- readonly is just to prone to incorrect refactoring to set to none