### PR TITLE
Fix datepicker closing delay tests net5

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -115,15 +115,14 @@ namespace MudBlazor.UnitTests
         }
 
         [Test]
-        public async Task Open_CloseBySelectingADate_CheckClosed()
+        public void Open_CloseBySelectingADate_CheckClosed()
         {
             var comp = OpenPicker();
             // clicking a day button to select a date and close
             comp.FindAll("div.mud-picker-calendar-day > button")
                 .Where(x => x.TrimmedText().Equals("23")).First().Click();
-            await Task.Delay(comp.Instance.ClosingDelay + 50); // allow a delay
-            // should not be open any more
-            comp.FindAll("div.mud-picker-open").Count.Should().Be(0);
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0),
+                new TimeSpan(0, 0, comp.Instance.ClosingDelay + 5));
             comp.Instance.Date.Should().NotBeNull();
         }
 

--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests .cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests .cs
@@ -139,7 +139,7 @@ namespace MudBlazor.UnitTests
         }
 
         [Test]
-        public async Task Open_CloseBySelectingADateRange_CheckClosed()
+        public void Open_CloseBySelectingADateRange_CheckClosed()
         {
             var comp = OpenPicker();
             // clicking a day buttons to select a range and close
@@ -147,14 +147,13 @@ namespace MudBlazor.UnitTests
                 .Where(x => x.TrimmedText().Equals("10")).First().Click();
             comp.FindAll("div.mud-picker-calendar-day > button")
                 .Where(x => x.TrimmedText().Equals("23")).First().Click();
-            await Task.Delay(comp.Instance.ClosingDelay + 50); // allow a delay
-            // should not be open any more
-            comp.FindAll("div.mud-picker-open").Count.Should().Be(0);
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0),
+                new TimeSpan(0, 0, comp.Instance.ClosingDelay + 5));
             comp.Instance.DateRange.Should().NotBeNull();
         }
 
         [Test]
-        public async Task Open_SelectEndDateLowerThanStart_CheckNotClosed_SelectRange_CheckClosed()
+        public void Open_SelectEndDateLowerThanStart_CheckNotClosed_SelectRange_CheckClosed()
         {
             var comp = OpenPicker();
             // clicking a day buttons to select a range and close
@@ -162,16 +161,13 @@ namespace MudBlazor.UnitTests
                 .Where(x => x.TrimmedText().Equals("10")).First().Click();
             comp.FindAll("div.mud-picker-calendar-day > button")
                 .Where(x => x.TrimmedText().Equals("8")).First().Click();
-            await Task.Delay(comp.Instance.ClosingDelay + 50); // allow a delay
-            // should not be open any more
             comp.FindAll("div.mud-picker-open").Count.Should().Be(1);
             comp.Instance.DateRange.Should().BeNull();
 
             comp.FindAll("div.mud-picker-calendar-day > button")
                 .Where(x => x.TrimmedText().Equals("23")).First().Click();
-            await Task.Delay(comp.Instance.ClosingDelay + 50); // allow a delay
-            // should not be open any more
-            comp.FindAll("div.mud-picker-open").Count.Should().Be(0);
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0),
+                new TimeSpan(0, 0, comp.Instance.ClosingDelay + 5));
             comp.Instance.DateRange.Should().NotBeNull();
         }
 


### PR DESCRIPTION
- Even adding a delay the tests were still failing.  We now wait an extra 5 secs and succeed early.