### PR TITLE
Backport focus and select

### DIFF
--- a/src/MudBlazor.Docs.Server/MudBlazor.Docs.Server.csproj
+++ b/src/MudBlazor.Docs.Server/MudBlazor.Docs.Server.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Toolbelt.Blazor.HeadElement" Version="5.0.0" />
     <PackageReference Include="Toolbelt.Blazor.HeadElement.ServerPrerendering" Version="1.2.3" />
-  </ItemGroup> 
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\MudBlazor.Docs\MudBlazor.Docs.csproj" />

--- a/src/MudBlazor.Docs/Pages/Components/TextField/Examples/TextFieldFocusExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TextField/Examples/TextFieldFocusExample.razor
@@ -1,0 +1,33 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+
+
+<MudGrid>
+    <MudItem xs="12" sm="12" md="12">
+        <MudTextField T="string" Label="Autofocus" Variant="Variant.Text" Text="@sampleText" AutoFocus="true" />
+    </MudItem>
+    <MudItem xs="12">
+        <MudTextField @ref="multilineReference" T="string" Label="Manual focus" Variant="Variant.Filled" Text="@sampleText" Lines="3" />
+    </MudItem>
+    <MudItem xs="12" Class="d-flex justify-end">
+        <MudButton @onclick="() => multilineReference.FocusAsync()">
+            Focus
+        </MudButton>
+    </MudItem>
+    <MudItem xs="12">
+        <MudTextField @ref="singleLineReference" T="string" Label="Manual focus" Variant="Variant.Filled" Text="@sampleText" />
+    </MudItem>
+    <MudItem xs="12" Class="d-flex justify-end">
+        <MudButton @onclick="() => singleLineReference.FocusAsync()">
+            Focus
+        </MudButton>
+    </MudItem>
+</MudGrid>
+
+@code
+{
+    private MudTextField<string> multilineReference;
+    private MudTextField<string> singleLineReference;
+
+    string sampleText = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
+}

--- a/src/MudBlazor.Docs/Pages/Components/TextField/Examples/TextFieldSelectExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TextField/Examples/TextFieldSelectExample.razor
@@ -1,0 +1,30 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+
+
+<MudGrid>
+    <MudItem xs="12" sm="12" md="12">
+        <MudTextField @ref="multilineReference" T="string" Label="Multiline Select" Lines="3" Variant="Variant.Text" Text="@sampleText" />
+    </MudItem>
+    <MudItem xs="12" Class="d-flex justify-end">
+        <MudButton @onclick="() => multilineReference.SelectAsnyc()">
+            Select
+        </MudButton>
+    </MudItem>
+    <MudItem xs="12">
+        <MudTextField @ref="singleLineReference" T="string" Label="Single Select" Variant="Variant.Filled" Text="@sampleText" />
+    </MudItem>
+    <MudItem xs="12" Class="d-flex justify-end">
+        <MudButton @onclick="() => singleLineReference.SelectAsnyc()">
+            Select
+        </MudButton>
+    </MudItem>
+</MudGrid>
+
+@code
+{
+    private MudTextField<string> multilineReference;
+    private MudTextField<string> singleLineReference;
+
+    string sampleText = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
+}

--- a/src/MudBlazor.Docs/Pages/Components/TextField/Examples/TextFieldSelectRangeExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TextField/Examples/TextFieldSelectRangeExample.razor
@@ -1,0 +1,28 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+
+
+<MudGrid>
+    <MudItem xs="12" sm="12" md="12">
+        <MudTextField @ref="multilineReference" T="string" Label="Multiline Select" Lines="3" Variant="Variant.Text" Text="@sampleText" />
+    </MudItem>
+    <MudItem xs="12" Class="d-flex justify-end">
+        <MudButton @onclick="() => multilineReference.SelectRangeAsync(5, 10)">
+            Select
+        </MudButton>
+    </MudItem>
+    <MudItem xs="12">
+        <MudTextField @ref="singleLineReference" T="string" Label="Single Select" Variant="Variant.Filled" Text="@sampleText" />
+    </MudItem>
+    <MudItem xs="12" Class="d-flex justify-end">
+        <MudButton @onclick="() => singleLineReference.SelectRangeAsync(5, 10)">
+            Select
+        </MudButton>
+    </MudItem>
+</MudGrid>
+
+@code
+{ private MudTextField<string> multilineReference;
+            private MudTextField<string> singleLineReference;
+
+            string sampleText = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."; }

--- a/src/MudBlazor.Docs/Pages/Components/TextField/TextFieldPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TextField/TextFieldPage.razor
@@ -100,6 +100,36 @@
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>
+                <Title>Focus</Title>
+                <Description></Description>
+            </SectionHeader>
+            <SectionContent Outlined="true">
+                <TextFieldFocusExample />
+            </SectionContent>
+            <SectionSource Code="TextFieldFocusExample" ShowCode="false" GitHubFolderName="TextField" />
+        </DocsPageSection>
+        <DocsPageSection>
+            <SectionHeader>
+                <Title>Select</Title>
+                <Description></Description>
+            </SectionHeader>
+            <SectionContent Outlined="true">
+                <TextFieldSelectExample />
+            </SectionContent>
+            <SectionSource Code="TextFieldSelectExample" ShowCode="false" GitHubFolderName="TextField" />
+        </DocsPageSection>
+        <DocsPageSection>
+            <SectionHeader>
+                <Title>Select Range</Title>
+                <Description></Description>
+            </SectionHeader>
+            <SectionContent Outlined="true">
+                <TextFieldSelectRangeExample />
+            </SectionContent>
+            <SectionSource Code="TextFieldSelectRangeExample" ShowCode="false" GitHubFolderName="TextField" />
+        </DocsPageSection>
+        <DocsPageSection>
+            <SectionHeader>
                 <Title>Inputs</Title>
                 <Description></Description>
             </SectionHeader>

--- a/src/MudBlazor/Base/MudBaseButton.cs
+++ b/src/MudBlazor/Base/MudBaseButton.cs
@@ -2,6 +2,7 @@
 using System.Windows.Input;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.JSInterop;
 using MudBlazor.Interfaces;
 using static System.String;
 
@@ -50,6 +51,8 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public EventCallback<MouseEventArgs> OnClick { get; set; }
 
+        [Inject] public IJSRuntime JSRuntime { get; set; }
+
         protected async Task OnClickHandler(MouseEventArgs ev)
         {
             await OnClick.InvokeAsync(ev);
@@ -78,5 +81,10 @@ namespace MudBlazor
         }
 
         protected ElementReference _elementReference;
+
+        public ValueTask FocusAsync()
+        {
+            return JSRuntime.InvokeVoidAsync("elementReference.focus", _elementReference);
+        }
     }
 }

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.JSInterop;
 
 namespace MudBlazor
 {
@@ -89,9 +90,16 @@ namespace MudBlazor
         [Parameter] public Margin Margin { get; set; } = Margin.None;
 
         /// <summary>
+        /// If true the input will focus automatically
+        /// </summary>
+        [Parameter] public bool AutoFocus { get; set; }
+
+        /// <summary>
         ///  A multiline input (textarea) will be shown, if set to more than one line.
         /// </summary>
         [Parameter] public int Lines { get; set; } = 1;
+
+        [Inject] public IJSRuntime JSRuntime { get; set; }
 
         protected string _text;
 
@@ -112,6 +120,16 @@ namespace MudBlazor
                 TextChanged.InvokeAsync(_text).AndForget();
             }
         }
+
+        /// <summary>
+        /// Focuses the element
+        /// </summary>
+        /// <returns>The ValueTask</returns>
+        public virtual ValueTask FocusAsync() { return new ValueTask(); }
+
+        public virtual ValueTask SelectAsnyc() { return new ValueTask(); }
+
+        public virtual ValueTask SelectRangeAsync(int pos1, int pos2) { return new ValueTask(); }
 
         /// <summary>
         /// Text change hook for descendants. Called when Text needs to be refreshed from current Value property.   
@@ -229,6 +247,15 @@ namespace MudBlazor
             // Because the way the Value setter is built, it won't cause an update if the incoming Value is
             // equal to the initial value. This is why we force an update to the Text property here.
             UpdateTextProperty(false);
+        }
+
+        protected override async Task OnAfterRenderAsync(bool firstRender)
+        {
+            //Only focus automatically after the first render cycle!
+            if (firstRender && AutoFocus)
+            {
+                await FocusAsync();
+            }
         }
 
         protected override void RegisterAsFormComponent()

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -339,5 +339,21 @@ namespace MudBlazor
             _timer?.Dispose();
             base.Dispose(disposing);
         }
+
+        public override ValueTask FocusAsync()
+        {
+            return _elementReference.FocusAsync();
+        }
+
+        public override ValueTask SelectAsnyc()
+        {
+            return _elementReference.SelectAsnyc();
+        }
+
+        public override ValueTask SelectRangeAsync(int pos1, int pos2)
+        {
+            return _elementReference.SelectRangeAsync(pos1, pos2);
+        }
+
     }
 }

--- a/src/MudBlazor/Components/Button/MudToggleIconButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudToggleIconButton.razor.cs
@@ -73,6 +73,5 @@ namespace MudBlazor
             _toggled = !_toggled;
             await ToggledChanged.InvokeAsync(_toggled);
         }
-
     }
 }

--- a/src/MudBlazor/Components/Input/MudDebouncedInput.cs
+++ b/src/MudBlazor/Components/Input/MudDebouncedInput.cs
@@ -7,6 +7,7 @@ namespace MudBlazor
 {
     public abstract class MudDebouncedInput<T> : MudBaseInput<T>, IDisposable
     {
+
         private Timer _timer;
 
         /// <summary>

--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
 using MudBlazor.Extensions;
 using MudBlazor.Utilities;
 
@@ -22,6 +24,21 @@ namespace MudBlazor
         [Parameter] public RenderFragment ChildContent { get; set; }
 
         private ElementReference _elementReference;
+
+        public override ValueTask FocusAsync()
+        {
+            return JSRuntime.InvokeVoidAsync("elementReference.focus", _elementReference);
+        }
+
+        public override ValueTask SelectAsnyc()
+        {
+            return JSRuntime.InvokeVoidAsync("mbSelectHelper.select", _elementReference);
+        }
+
+        public override ValueTask SelectRangeAsync(int pos1, int pos2)
+        {
+            return JSRuntime.InvokeVoidAsync("mbSelectHelper.selectRange", _elementReference, pos1, pos2);
+        }
 
         /// <summary>
         /// The short hint displayed in the input before the user enters a value.

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
 using MudBlazor.Utilities;
 using MudBlazor.Utilities.Exceptions;
 
@@ -277,6 +278,20 @@ namespace MudBlazor
                 throw new GenericTypeMismatchException("MudSelect", "MudSelectItem", typeof(T), itemT);
         }
 
+        public override ValueTask FocusAsync()
+        {
+            return _elementReference.FocusAsync();
+        }
+
+        public override ValueTask SelectAsnyc()
+        {
+            return _elementReference.SelectAsnyc();
+        }
+
+        public override ValueTask SelectRangeAsync(int pos1, int pos2)
+        {
+            return _elementReference.SelectRangeAsync(pos1, pos2);
+        }
     }
 
 }

--- a/src/MudBlazor/Components/TextField/MudTextField.razor.cs
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor.cs
@@ -1,5 +1,7 @@
-﻿using Microsoft.AspNetCore.Components;
-
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
@@ -12,6 +14,21 @@ namespace MudBlazor
 
         private MudInput<string> _elementReference;
 
+        public override ValueTask FocusAsync()
+        {
+            return _elementReference.FocusAsync();
+        }
+
+        public override ValueTask SelectAsnyc()
+        {
+            return _elementReference.SelectAsnyc();
+        }
+
+        public override ValueTask SelectRangeAsync(int pos1, int pos2)
+        {
+            return _elementReference.SelectRangeAsync(pos1, pos2);
+        }
+
         /// <summary>
         /// The short hint displayed in the input before the user enters a value.
         /// </summary>
@@ -21,7 +38,6 @@ namespace MudBlazor
         /// If string has value the label text will be displayed in the input, and scaled down at the top if the input has value.
         /// </summary>
         [Parameter] public string Label { get; set; }
-
 
     }
 

--- a/src/MudBlazor/TScripts/select.js
+++ b/src/MudBlazor/TScripts/select.js
@@ -1,0 +1,20 @@
+﻿window.mbSelectHelper = {
+    selectRange: (el, pos1, pos2) => {
+        if (el.createTextRange) {
+            var selRange = el.createTextRange();
+            selRange.collapse(true);
+            selRange.moveStart('character', pos1);
+            selRange.moveEnd('character', pos2);
+            selRange.select();
+        } else if (el.setSelectionRange) {
+            el.setSelectionRange(pos1, pos2);
+        } else if (el.selectionStart) {
+            el.selectionStart = pos1;
+            el.selectionEnd = pos2;
+        }
+        el.focus();
+    },
+    select: (el) => {
+        el.select();
+    }
+}


### PR DESCRIPTION
- Make focus and select work in net 3.1
- This is part of a pair.
- These changes are forward ported to net5 until we move.
- After that we can use JSRuntime the net5 way