### PR TITLE
Forwardport net 3.1 focus and select

### DIFF
--- a/src/MudBlazor/Base/MudBaseButton.cs
+++ b/src/MudBlazor/Base/MudBaseButton.cs
@@ -2,6 +2,7 @@
 using System.Windows.Input;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.JSInterop;
 using MudBlazor.Interfaces;
 using static System.String;
 
@@ -50,6 +51,8 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public EventCallback<MouseEventArgs> OnClick { get; set; }
 
+        [Inject] public IJSRuntime JSRuntime { get; set; }
+
         protected async Task OnClickHandler(MouseEventArgs ev)
         {
             await OnClick.InvokeAsync(ev);
@@ -81,7 +84,7 @@ namespace MudBlazor
 
         public ValueTask FocusAsync()
         {
-            return _elementReference.Context is WebElementReferenceContext ? _elementReference.FocusAsync() : ValueTask.CompletedTask;
+            return JSRuntime.InvokeVoidAsync("elementReference.focus", _elementReference);
         }
     }
 }

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -126,11 +126,11 @@ namespace MudBlazor
         /// Focuses the element
         /// </summary>
         /// <returns>The ValueTask</returns>
-        public virtual ValueTask FocusAsync() { return ValueTask.CompletedTask; }
+        public virtual ValueTask FocusAsync() { return new ValueTask(); }
 
-        public virtual ValueTask SelectAsnyc() { return ValueTask.CompletedTask; }
+        public virtual ValueTask SelectAsnyc() { return new ValueTask(); }
 
-        public virtual ValueTask SelectRangeAsync(int pos1, int pos2) { return ValueTask.CompletedTask; }
+        public virtual ValueTask SelectRangeAsync(int pos1, int pos2) { return new ValueTask(); }
 
         /// <summary>
         /// Text change hook for descendants. Called when Text needs to be refreshed from current Value property.   

--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -27,18 +27,17 @@ namespace MudBlazor
 
         public override ValueTask FocusAsync()
         {
-            //The context must be a WebElementReferenceContext otherwise the JSRuntime is not available otherwise we just return a completed task and pretend everything is ok
-            return _elementReference.Context is WebElementReferenceContext ? _elementReference.FocusAsync() : ValueTask.CompletedTask;
+            return JSRuntime.InvokeVoidAsync("elementReference.focus", _elementReference);
         }
 
         public override ValueTask SelectAsnyc()
         {
-            return _elementReference.Context is WebElementReferenceContext ? JSRuntime.InvokeVoidAsync("mbSelectHelper.select", _elementReference) : ValueTask.CompletedTask;
+            return JSRuntime.InvokeVoidAsync("mbSelectHelper.select", _elementReference);
         }
 
         public override ValueTask SelectRangeAsync(int pos1, int pos2)
         {
-            return _elementReference.Context is WebElementReferenceContext ? JSRuntime.InvokeVoidAsync("mbSelectHelper.selectRange", _elementReference, pos1, pos2) : ValueTask.CompletedTask;
+            return JSRuntime.InvokeVoidAsync("mbSelectHelper.selectRange", _elementReference, pos1, pos2);
         }
 
         /// <summary>


### PR DESCRIPTION
- Use the old way until we switch to net5 for development.
- This will ease the transition