### PR TITLE
MudTabs: Render active tab by CSS (Keep Panels Alive mode)

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsPlacementExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsPlacementExample.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudText Typo="@Typo.h6">Default</MudText>
-<MudTabs Elevation="1">
+<MudTabs Elevation="1" KeepPanelsAlive>
     <MudTabPanel Text="Item One" ToolTip="Item One">
         <MudText>Item One</MudText>
     </MudTabPanel>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/KeepTabsAliveComponents/TabsKeepAliveTabTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/KeepTabsAliveComponents/TabsKeepAliveTabTest.razor
@@ -1,0 +1,14 @@
+﻿<h3>TabsKeepAliveTab01</h3>
+
+@code {
+
+    [Parameter] public string ComponentName { get; set; }
+    public int Counter { get; set; } = 0;
+
+    protected override Task OnAfterRenderAsync(bool firstRender)
+    {
+        Console.WriteLine($"Component {ComponentName} is rendered. First render: {firstRender}");
+        return base.OnAfterRenderAsync(firstRender);
+    }
+
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/KeepTabsAliveComponents/TabsKeepAliveTabTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/KeepTabsAliveComponents/TabsKeepAliveTabTest.razor
@@ -1,4 +1,4 @@
-﻿<h3>TabsKeepAliveTab01</h3>
+﻿<h3>@($"{ComponentName} : {Counter}")</h3>
 
 @code {
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/TabsKeepAliveTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/TabsKeepAliveTest.razor
@@ -17,7 +17,7 @@
     public KeepTabsAliveComponents.TabsKeepAliveTabTest content2;
     public KeepTabsAliveComponents.TabsKeepAliveTabTest content3;
 
-    public void Increase(int index)
+    public void IncrementCountOfTab(int index)
     {
         switch (index)
         {
@@ -32,6 +32,6 @@
                 break;
 
         }
+        InvokeAsync(() => StateHasChanged());
     }
-
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/TabsKeepAliveTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/TabsKeepAliveTest.razor
@@ -1,0 +1,37 @@
+﻿<MudTabs KeepPanelsAlive @ref="tabs">
+    <MudTabPanel Text="Item One">
+        <MudBlazor.UnitTests.TestComponents.Tabs.KeepTabsAliveComponents.TabsKeepAliveTabTest @ref="content1" ComponentName="Item One" />
+    </MudTabPanel>
+    <MudTabPanel Text="Item Two">
+        <MudBlazor.UnitTests.TestComponents.Tabs.KeepTabsAliveComponents.TabsKeepAliveTabTest @ref="content2" ComponentName="Item Two" />
+    </MudTabPanel>
+    <MudTabPanel Text="Item Three">
+        <MudBlazor.UnitTests.TestComponents.Tabs.KeepTabsAliveComponents.TabsKeepAliveTabTest @ref="content3" ComponentName="Item Three" />
+    </MudTabPanel>
+</MudTabs>
+
+@code{
+
+    public MudTabs tabs;
+    public KeepTabsAliveComponents.TabsKeepAliveTabTest content1;
+    public KeepTabsAliveComponents.TabsKeepAliveTabTest content2;
+    public KeepTabsAliveComponents.TabsKeepAliveTabTest content3;
+
+    public void Increase(int index)
+    {
+        switch (index)
+        {
+            case 1:
+                content1.Counter += 1;
+                break;
+            case 2:
+                content2.Counter += 1;
+                break;
+            case 3:
+                content3.Counter += 1;
+                break;
+
+        }
+    }
+
+}

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -79,7 +79,7 @@ namespace MudBlazor.UnitTests
             Console.WriteLine($"{comp.Instance.content3.ComponentName} Counter : {comp.Instance.content3.Counter}");
             Console.WriteLine("=======================");
 
-            comp.Instance.Increase(1);
+            comp.Instance.IncrementCountOfTab(1);
             comp.Instance.content1.Counter.Should().Be(1);
             comp.Instance.tabs.ActivatePanel(1);
             comp.Instance.content1.Counter.Should().Be(1);
@@ -90,11 +90,10 @@ namespace MudBlazor.UnitTests
             Console.WriteLine($"{comp.Instance.content3.ComponentName} Counter : {comp.Instance.content3.Counter}");
             Console.WriteLine("=======================");
 
-            comp.Instance.Increase(2);
-            comp.Instance.Increase(2);
+            comp.Instance.IncrementCountOfTab(2);
+            comp.Instance.IncrementCountOfTab(2);
             comp.Instance.content1.Counter.Should().Be(1);
             comp.Instance.content2.Counter.Should().Be(2);
-
             comp.Instance.tabs.ActivatePanel(2);
             comp.Instance.content1.Counter.Should().Be(1);
             comp.Instance.content2.Counter.Should().Be(2);
@@ -106,16 +105,14 @@ namespace MudBlazor.UnitTests
             Console.WriteLine($"{comp.Instance.content3.ComponentName} Counter : {comp.Instance.content3.Counter}");
             Console.WriteLine("=======================");
 
-            comp.Instance.Increase(3);
+            comp.Instance.IncrementCountOfTab(3);
             comp.Instance.content1.Counter.Should().Be(1);
             comp.Instance.content2.Counter.Should().Be(2);
             comp.Instance.content3.Counter.Should().Be(1);
-
             comp.Instance.tabs.ActivatePanel(0);
             comp.Instance.content1.Counter.Should().Be(1);
             comp.Instance.content2.Counter.Should().Be(2);
             comp.Instance.content3.Counter.Should().Be(1);
-
             Console.WriteLine(comp.Markup);
             Console.WriteLine($"Active Panel index: {comp.Instance.tabs.ActivePanelIndex}");
             Console.WriteLine($"{comp.Instance.content1.ComponentName} Counter : {comp.Instance.content1.Counter}");

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -84,6 +84,7 @@ namespace MudBlazor.UnitTests
             comp.Instance.tabs.ActivatePanel(1);
             comp.Instance.content1.Counter.Should().Be(1);
             Console.WriteLine(comp.Markup);
+            Console.WriteLine($"Active Panel index: {comp.Instance.tabs.ActivePanelIndex}");
             Console.WriteLine($"{comp.Instance.content1.ComponentName} Counter : {comp.Instance.content1.Counter}");
             Console.WriteLine($"{comp.Instance.content2.ComponentName} Counter : {comp.Instance.content2.Counter}");
             Console.WriteLine($"{comp.Instance.content3.ComponentName} Counter : {comp.Instance.content3.Counter}");
@@ -99,6 +100,7 @@ namespace MudBlazor.UnitTests
             comp.Instance.content2.Counter.Should().Be(2);
             comp.Instance.content3.Counter.Should().Be(0);
             Console.WriteLine(comp.Markup);
+            Console.WriteLine($"Active Panel index: {comp.Instance.tabs.ActivePanelIndex}");
             Console.WriteLine($"{comp.Instance.content1.ComponentName} Counter : {comp.Instance.content1.Counter}");
             Console.WriteLine($"{comp.Instance.content2.ComponentName} Counter : {comp.Instance.content2.Counter}");
             Console.WriteLine($"{comp.Instance.content3.ComponentName} Counter : {comp.Instance.content3.Counter}");
@@ -115,6 +117,7 @@ namespace MudBlazor.UnitTests
             comp.Instance.content3.Counter.Should().Be(1);
 
             Console.WriteLine(comp.Markup);
+            Console.WriteLine($"Active Panel index: {comp.Instance.tabs.ActivePanelIndex}");
             Console.WriteLine($"{comp.Instance.content1.ComponentName} Counter : {comp.Instance.content1.Counter}");
             Console.WriteLine($"{comp.Instance.content2.ComponentName} Counter : {comp.Instance.content2.Counter}");
             Console.WriteLine($"{comp.Instance.content3.ComponentName} Counter : {comp.Instance.content3.Counter}");

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -69,6 +69,58 @@ namespace MudBlazor.UnitTests
             comp.FindAll("div.mud-tab").Should().BeEmpty();
         }
 
+        [Test]
+        public async Task KeepTabsAliveTest()
+        {
+            var comp = ctx.RenderComponent<TabsKeepAliveTest>();
+            Console.WriteLine(comp.Markup);
+            Console.WriteLine($"{comp.Instance.content1.ComponentName} Counter : {comp.Instance.content1.Counter}");
+            Console.WriteLine($"{comp.Instance.content2.ComponentName} Counter : {comp.Instance.content2.Counter}");
+            Console.WriteLine($"{comp.Instance.content3.ComponentName} Counter : {comp.Instance.content3.Counter}");
+            Console.WriteLine("=======================");
+
+            comp.Instance.Increase(1);
+            comp.Instance.content1.Counter.Should().Be(1);
+            comp.Instance.tabs.ActivatePanel(1);
+            comp.Instance.content1.Counter.Should().Be(1);
+            Console.WriteLine(comp.Markup);
+            Console.WriteLine($"{comp.Instance.content1.ComponentName} Counter : {comp.Instance.content1.Counter}");
+            Console.WriteLine($"{comp.Instance.content2.ComponentName} Counter : {comp.Instance.content2.Counter}");
+            Console.WriteLine($"{comp.Instance.content3.ComponentName} Counter : {comp.Instance.content3.Counter}");
+            Console.WriteLine("=======================");
+
+            comp.Instance.Increase(2);
+            comp.Instance.Increase(2);
+            comp.Instance.content1.Counter.Should().Be(1);
+            comp.Instance.content2.Counter.Should().Be(2);
+
+            comp.Instance.tabs.ActivatePanel(2);
+            comp.Instance.content1.Counter.Should().Be(1);
+            comp.Instance.content2.Counter.Should().Be(2);
+            comp.Instance.content3.Counter.Should().Be(0);
+            Console.WriteLine(comp.Markup);
+            Console.WriteLine($"{comp.Instance.content1.ComponentName} Counter : {comp.Instance.content1.Counter}");
+            Console.WriteLine($"{comp.Instance.content2.ComponentName} Counter : {comp.Instance.content2.Counter}");
+            Console.WriteLine($"{comp.Instance.content3.ComponentName} Counter : {comp.Instance.content3.Counter}");
+            Console.WriteLine("=======================");
+
+            comp.Instance.Increase(3);
+            comp.Instance.content1.Counter.Should().Be(1);
+            comp.Instance.content2.Counter.Should().Be(2);
+            comp.Instance.content3.Counter.Should().Be(1);
+
+            comp.Instance.tabs.ActivatePanel(0);
+            comp.Instance.content1.Counter.Should().Be(1);
+            comp.Instance.content2.Counter.Should().Be(2);
+            comp.Instance.content3.Counter.Should().Be(1);
+
+            Console.WriteLine(comp.Markup);
+            Console.WriteLine($"{comp.Instance.content1.ComponentName} Counter : {comp.Instance.content1.Counter}");
+            Console.WriteLine($"{comp.Instance.content2.ComponentName} Counter : {comp.Instance.content2.Counter}");
+            Console.WriteLine($"{comp.Instance.content3.ComponentName} Counter : {comp.Instance.content3.Counter}");
+
+        }
+
 
     }
 

--- a/src/MudBlazor/Components/Tabs/MudTabPanel.razor
+++ b/src/MudBlazor/Components/Tabs/MudTabPanel.razor
@@ -4,16 +4,9 @@
 
 @if ((bool)((Parent?.KeepPanelsAlive ?? false)))
 {
-    @if (Parent?.ActivePanel == this && ChildContent != null)
-    {
+    <div style="display:@(Parent?.ActivePanel == this && ChildContent != null ? "default" : "none")">
         @ChildContent
-    }
-    else
-    {
-        <div style="display:none">
-            @ChildContent
-        </div>
-    }
+    </div>
 }
 else
 {

--- a/src/MudBlazor/Components/Tabs/MudTabPanel.razor
+++ b/src/MudBlazor/Components/Tabs/MudTabPanel.razor
@@ -2,9 +2,25 @@
 @inherits MudComponentBase
 @implements IDisposable
 
-@if (Parent?.ActivePanel == this && ChildContent != null)
+@if ((bool)((Parent?.KeepPanelsAlive ?? false)))
 {
-    @ChildContent
+    @if (Parent?.ActivePanel == this && ChildContent != null)
+    {
+        @ChildContent
+    }
+    else
+    {
+        <div style="display:none">
+            @ChildContent
+        </div>
+    }
+}
+else
+{
+    @if (Parent?.ActivePanel == this && ChildContent != null)
+    {
+        @ChildContent
+    }
 }
 
 @code {

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -43,6 +43,11 @@ namespace MudBlazor
             .Build();
 
         /// <summary>
+        /// If true, render all tabs and hide (display:none) every non-active.
+        /// </summary>
+        [Parameter] public bool KeepPanelsAlive { get; set; } = false;
+
+        /// <summary>
         /// If true, sets the border-radius to theme default.
         /// </summary>
         [Parameter] public bool Rounded { get; set; }


### PR DESCRIPTION
This is the first attempt on creating a new way to render tabs, avoind re-rendering issues on changing active tab.

The rendering of active tab is set on style (CSS) when **KeepPanelsAlive** parameter is set to true.

This work is based on #552 .