### PR TITLE
Update Docs for MudServices

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,16 @@
 [![GitHub last commit](https://img.shields.io/github/last-commit/garderoben/mudblazor?style=flat-square)](https://github.com/Garderoben/MudBlazor)
 [![Nuget](https://img.shields.io/nuget/v/MudBlazor?style=flat-square)](https://www.nuget.org/packages/MudBlazor/)
 
-MudBlazor is an ambitious Material Design component framework for Blazor with an emphasis on ease of use and clear structure. It is perfect for .NET developers who want to rapidly build web applications without having to struggle with CSS and Javascript. MudBlazor, being written entirely in C#, empowers them to adapt, fix or extend the framework and the multitude of examples in the documentation makes learning MudBlazor very easy. 
+MudBlazor is an ambitious Material Design component framework for Blazor with an emphasis on ease of use and clear structure. It is perfect for .NET developers who want to rapidly build web applications without having to struggle with CSS and Javascript. MudBlazor, being written entirely in C#, empowers you to adapt, fix or extend the framework. There are plenty of examples in the documentation, which makes understanding and learning MudBlazor very easy. 
 ### Design goals:
- - Clean and aesthetic graphic design based on Material Design
- - Clear and easy to understand structure
- - Good documentation with many examples and source snippets
- - All components are written entirely in C#, no JavaScript allowed (except absolutely necessary)
+ - Clean and aesthetic graphic design based on Material Design.
+ - Clear and easy to understand structure.
+ - Good documentation with many examples and source snippets.
+ - All components are written entirely in C#, no JavaScript allowed (except where absolutely necessary).
  - Users can make beautiful apps without needing CSS (but they can of course use CSS too)
- - No dependencies on other component libraries, 100% control over components and features
+ - No dependencies on other component libraries, 100% control over components and features.
  - Stability! We strive for a complete test coverage. 
- - Releasing often so developers can get their PRs and fixes in a timely fashion
+ - Releasing often so developers can get their PRs and fixes in a timely fashion.
 ## Documentation & Demo
 - [MudBlazor.com](https://mudblazor.com)
 - [Try.MudBlazor.com](https://try.mudblazor.com/)
@@ -24,7 +24,7 @@ MudBlazor is an ambitious Material Design component framework for Blazor with an
 - [.NET Core 3.1](https://dotnet.microsoft.com/download/dotnet-core/3.1)
 ## Getting Started 
 - Full installation instructions can be found at [mudblazor.com](https://mudblazor.com/getting-started/installation)  
-- Alternatively use one of our templates from our [MudBlazor.Templates](https://github.com/Garderoben/MudBlazor.Templates) repo. 
+- Alternatively use one of our templates from the [MudBlazor.Templates](https://github.com/Garderoben/MudBlazor.Templates) repo. 
 ### Quick Installation Guide
 #### Common Configuration (Client-Side or Server-Side)
 Install Package

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@
 [![Nuget](https://img.shields.io/nuget/v/MudBlazor?style=flat-square)](https://www.nuget.org/packages/MudBlazor/)
 
 MudBlazor is an ambitious Material Design component framework for Blazor with an emphasis on ease of use and clear structure. It is perfect for .NET developers who want to rapidly build web applications without having to struggle with CSS and Javascript. MudBlazor, being written entirely in C#, empowers them to adapt, fix or extend the framework and the multitude of examples in the documentation makes learning MudBlazor very easy. 
-	
-Design goals:
+### Design goals:
  - Clean and aesthetic graphic design based on Material Design
  - Clear and easy to understand structure
  - Good documentation with many examples and source snippets
@@ -18,43 +17,54 @@ Design goals:
  - No dependencies on other component libraries, 100% control over components and features
  - Stability! We strive for a complete test coverage. 
  - Releasing often so developers can get their PRs and fixes in a timely fashion
-
 ## Documentation & Demo
 - [MudBlazor.com](https://mudblazor.com)
 - [Try.MudBlazor.com](https://try.mudblazor.com/)
-
-
 ## Prerequisites
-
-- .NET Core 3.1
-- Visual Studio 2019 with the ASP.NET and Web development.
-
-
-## Installation 
-#### Full installation instructions
-At mudblazor.com we have more in depth installation instructions, [available here.](https://mudblazor.com/getting-started/installation)
-
-#### Simplified installation instructions
+- [.NET Core 3.1](https://dotnet.microsoft.com/download/dotnet-core/3.1)
+## Getting Started 
+- Full installation instructions can be found at [mudblazor.com](https://mudblazor.com/getting-started/installation)  
+- Alternatively use one of our templates from our [MudBlazor.Templates](https://github.com/Garderoben/MudBlazor.Templates) repo. 
+### Quick Installation Guide
+#### Common Configuration (Client-Side or Server-Side)
+Install Package
 ```
-Install-Package MudBlazor
+dotnet add package MudBlazor
 ```
-In `_Imports.razor`
-```
+Add the following to `_Imports.razor`
+```razor
 @using MudBlazor
 ```
-
-Add the following link's in your head section. For **Client Side (WebAssembly)** you do that in `index.html` and for **Server Side** `_Host.cshtml`
+Add the following to the `MainLayout.razor` or `App.razor`
+```razor
+<MudProviders/>
 ```
+Add the following to `index.html` (client-side) or `_Host.cshtml` (server-side) in the `head`
+```razor
 <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet" />
 <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
 ```
-
-In `MainLayout.razor` or `App.razor`
+Add the following to `index.html` or `_Host.cshtml` in the `body`
+```razor
+<script src="_content/MudBlazor/MudBlazor.min.js"></script>
 ```
-<MudThemeProvider/>
+#### Client-Side Configuration(WebAssembly) 
+Add the following to the relevant sections of `Program.cs`
+```c#
+using MudBlazor.Services;
 ```
-
-## Usage
+```c#
+builder.Services.AddMudServices();
+```
+#### Server-Side Configuration
+Add the following to the relevant sections of `Startup.cs`
+```c#
+using MudBlazor.Services;
+```
+```c#
+services.AddMudServices();
+```
+### Usage
 ```html
 <Typography Typo="Typo.h6">MudBlazor is @Text</Typography>
 <Button Variant="Variant.Contained" Color="Color.Primary" OnClick="ButtonOnClick">@ButtonText</Button>

--- a/src/MudBlazor.Docs/Pages/Getting Started/Installation/Installation.razor
+++ b/src/MudBlazor.Docs/Pages/Getting Started/Installation/Installation.razor
@@ -60,7 +60,7 @@
         <DocsPageSection>
             <SectionHeader>
                 <SubTitle>5. Add Components</SubTitle>
-                <Description>Add the following components to your <CodeInline>MainLayout.razor</CodeInline> or <CodeInline>App.razor</CodeInline> note that the <CodeInline>ThemeProvider</CodeInline> is essential for MudBlazor but the rest is optional.</Description>
+                <Description>Add the following component to your <CodeInline>MainLayout.razor</CodeInline> or <CodeInline>App.razor</CodeInline>.</Description>
             </SectionHeader>
             <MarkdownAddComponents />
         </DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Getting Started/Installation/ManualMarkDown/MarkdownAddComponents.razor
+++ b/src/MudBlazor.Docs/Pages/Getting Started/Installation/ManualMarkDown/MarkdownAddComponents.razor
@@ -3,9 +3,7 @@
 <div class="mud-codeblock">
 <div class="html">
 <pre>
-<span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">MudThemeProvider</span><span class="htmlTagDelimiter">/&gt;</span>
-<span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">MudDialogProvider</span><span class="htmlTagDelimiter">/&gt;</span>
-<span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">MudSnackbarProvider</span><span class="htmlTagDelimiter">/&gt;</span>
+<span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">MudProviders</span><span class="htmlTagDelimiter">/&gt;</span>
 </pre>
 </div>
 </div>

--- a/src/MudBlazor.Docs/Pages/Getting Started/Installation/ManualMarkDown/MarkdownRegisterServicesServer.razor
+++ b/src/MudBlazor.Docs/Pages/Getting Started/Installation/ManualMarkDown/MarkdownRegisterServicesServer.razor
@@ -3,14 +3,11 @@
 <div class="mud-codeblock">
 <div class="csharp">
     <pre>
-<span class="keyword">using</span> MudBlazor;
 <span class="keyword">using</span> MudBlazor.Services;
 
 <span class="keyword">public</span> <span class="keyword">void</span> <span class="function">ConfigureServices</span>(<span class="interface">IServiceCollection</span> <span class="localVar">services</span>)
 {
-    <span class="localVar">services</span>.<span class="function">AddMudBlazorDialog</span>();
-    <span class="localVar">services</span>.<span class="function">AddMudBlazorSnackbar</span>();
-    <span class="localVar">services</span>.<span class="function">AddMudBlazorResizeListener</span>();
+    <span class="localVar">services</span>.<span class="function">AddMudServices</span>();
 }
 </pre>
 </div>

--- a/src/MudBlazor.Docs/Pages/Getting Started/Installation/ManualMarkDown/MarkdownRegisterServicesWebAssembly.razor
+++ b/src/MudBlazor.Docs/Pages/Getting Started/Installation/ManualMarkDown/MarkdownRegisterServicesWebAssembly.razor
@@ -3,7 +3,6 @@
 <div class="mud-codeblock">
 <div class="csharp">
     <pre>
-<span class="keyword">using</span> MudBlazor;
 <span class="keyword">using</span> MudBlazor.Services;
 
 <span class="keyword">public</span> <span class="keyword">static</span> <span class="keyword">async</span> <span class="class">Task</span> <span class="function">Main</span>(<span class="keyword">string</span>[] <span class="localVar">args</span>)
@@ -12,9 +11,7 @@
     <span class="localVar">builder</span>.RootComponents.Add&lt;<span class="class">App</span>&gt;(<span class="string">&quot;app&quot;</span>);
 
     <span class="localVar">builder</span>.Services.<span class="function">AddScoped</span>(<span class="localVar">sp</span> =&gt; <span class="keyword">new</span> <span class="class">HttpClient</span> { BaseAddress = <span class="keyword">new</span> <span class="class">Uri</span>(<span class="localVar">builder</span>.HostEnvironment.BaseAddress) });
-    <span class="localVar">builder</span>.Services.<span class="function">AddMudBlazorDialog</span>();
-    <span class="localVar">builder</span>.Services.<span class="function">AddMudBlazorSnackbar</span>();
-    <span class="localVar">builder</span>.Services.<span class="function">AddMudBlazorResizeListener</span>();
+    <span class="localVar">builder</span>.Services.<span class="function">AddMudServices</span>();
 
     <span class="keyword">await</span> <span class="localVar">builder</span>.<span class="function">Build</span>().<span class="function">RunAsync</span>();
 }

--- a/src/MudBlazor.UnitTests.Viewer/Program.cs
+++ b/src/MudBlazor.UnitTests.Viewer/Program.cs
@@ -15,11 +15,7 @@ namespace MudBlazor.UnitTests
             builder.RootComponents.Add<App>("app");
 
             builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
-            builder.Services.AddMudBlazorResizeListener();
-            builder.Services.AddMudBlazorDialog();
-            builder.Services.AddMudBlazorSnackbar();
-            builder.Services.AddMudBlazorScrollManager();
-            builder.Services.AddMudBlazorScrollListener();
+            builder.Services.AddMudServices();
 
             await builder.Build().RunAsync();
         }

--- a/src/MudBlazor.UnitTests.Viewer/Shared/MainLayout.razor
+++ b/src/MudBlazor.UnitTests.Viewer/Shared/MainLayout.razor
@@ -1,7 +1,5 @@
 ﻿@inherits LayoutComponentBase
 
-<MudThemeProvider />
-<MudDialogProvider />
-<MudSnackbarProvider />
+<MudProviders />
 
 @Body

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -24,7 +24,7 @@ namespace MudBlazor.UnitTests
         public void Setup()
         {
             ctx = new Bunit.TestContext();
-            ctx.AddMudBlazorServices();
+            ctx.AddTestServices();
         }
 
         [TearDown]

--- a/src/MudBlazor.UnitTests/Components/BreadcrumbTests.cs
+++ b/src/MudBlazor.UnitTests/Components/BreadcrumbTests.cs
@@ -15,7 +15,7 @@ namespace MudBlazor.UnitTests.Components
         public void Setup()
         {
             ctx = new Bunit.TestContext();
-            ctx.AddMudBlazorServices();
+            ctx.AddTestServices();
         }
 
         [TearDown]

--- a/src/MudBlazor.UnitTests/Components/ButtonsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ButtonsTests.cs
@@ -14,7 +14,7 @@ namespace MudBlazor.UnitTests
         public void Setup()
         {
             ctx = new Bunit.TestContext();
-            ctx.AddMudBlazorServices();
+            ctx.AddTestServices();
         }
 
         [TearDown]

--- a/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
@@ -26,7 +26,7 @@ namespace MudBlazor.UnitTests
         public void Setup()
         {
             ctx = new Bunit.TestContext();
-            ctx.AddMudBlazorServices();
+            ctx.AddTestServices();
         }
 
         [TearDown]

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -24,7 +24,7 @@ namespace MudBlazor.UnitTests
         public void Setup()
         {
             ctx = new Bunit.TestContext();
-            ctx.AddMudBlazorServices();
+            ctx.AddTestServices();
         }
 
         [TearDown]

--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests .cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests .cs
@@ -19,7 +19,7 @@ namespace MudBlazor.UnitTests
         public void Setup()
         {
             ctx = new Bunit.TestContext();
-            ctx.AddMudBlazorServices();
+            ctx.AddTestServices();
         }
 
         [TearDown]

--- a/src/MudBlazor.UnitTests/Components/DialogTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DialogTests.cs
@@ -28,7 +28,7 @@ namespace MudBlazor.UnitTests
         public void Setup()
         {
             ctx = new Bunit.TestContext();
-            ctx.AddMudBlazorServices();
+            ctx.AddTestServices();
         }
 
         [TearDown]

--- a/src/MudBlazor.UnitTests/Components/ElementTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ElementTests.cs
@@ -14,7 +14,7 @@ namespace MudBlazor.UnitTests
         public void Setup()
         {
             ctx = new Bunit.TestContext();
-            ctx.AddMudBlazorServices();
+            ctx.AddTestServices();
         }
 
         [TearDown]

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -26,7 +26,7 @@ namespace MudBlazor.UnitTests
         public void Setup()
         {
             ctx = new Bunit.TestContext();
-            ctx.AddMudBlazorServices();
+            ctx.AddTestServices();
         }
 
         [TearDown]

--- a/src/MudBlazor.UnitTests/Components/HighlighterTests.cs
+++ b/src/MudBlazor.UnitTests/Components/HighlighterTests.cs
@@ -62,7 +62,7 @@ namespace MudBlazor.UnitTests
         public void Setup()
         {
             ctx = new Bunit.TestContext();
-            ctx.AddMudBlazorServices();
+            ctx.AddTestServices();
         }
 
         [TearDown]

--- a/src/MudBlazor.UnitTests/Components/ListTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ListTests.cs
@@ -20,7 +20,7 @@ namespace MudBlazor.UnitTests
         public void Setup()
         {
             ctx = new Bunit.TestContext();
-            ctx.AddMudBlazorServices();
+            ctx.AddTestServices();
         }
 
         [TearDown]

--- a/src/MudBlazor.UnitTests/Components/RadioTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RadioTests.cs
@@ -19,7 +19,7 @@ namespace MudBlazor.UnitTests
         public void Setup()
         {
             ctx = new Bunit.TestContext();
-            ctx.AddMudBlazorServices();
+            ctx.AddTestServices();
         }
 
         [TearDown]

--- a/src/MudBlazor.UnitTests/Components/RatingTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RatingTests.cs
@@ -19,7 +19,7 @@ namespace MudBlazor.UnitTests
         public void Setup()
         {
             ctx = new Bunit.TestContext();
-            ctx.AddMudBlazorServices();
+            ctx.AddTestServices();
         }
 
         [TearDown]

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -24,7 +24,7 @@ namespace MudBlazor.UnitTests
         public void Setup()
         {
             ctx = new Bunit.TestContext();
-            ctx.AddMudBlazorServices();
+            ctx.AddTestServices();
         }
 
         [TearDown]

--- a/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
@@ -28,7 +28,7 @@ namespace MudBlazor.UnitTests
         public void Setup()
         {
             ctx = new Bunit.TestContext();
-            ctx.AddMudBlazorServices();
+            ctx.AddTestServices();
         }
 
         [TearDown]

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -25,7 +25,7 @@ namespace MudBlazor.UnitTests
         public void Setup()
         {
             ctx = new Bunit.TestContext();
-            ctx.AddMudBlazorServices();
+            ctx.AddTestServices();
         }
 
         [TearDown]

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -28,7 +28,7 @@ namespace MudBlazor.UnitTests
         public void Setup()
         {
             ctx = new Bunit.TestContext();
-            ctx.AddMudBlazorServices();
+            ctx.AddTestServices();
         }
 
         [TearDown]

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -27,7 +27,7 @@ namespace MudBlazor.UnitTests
         public void Setup()
         {
             ctx = new Bunit.TestContext();
-            ctx.AddMudBlazorServices();
+            ctx.AddTestServices();
         }
 
         [TearDown]

--- a/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
@@ -25,7 +25,7 @@ namespace MudBlazor.UnitTests
         public void Setup()
         {
             ctx = new Bunit.TestContext();
-            ctx.AddMudBlazorServices();
+            ctx.AddTestServices();
         }
 
         [TearDown]

--- a/src/MudBlazor.UnitTests/Components/ToggleIconButtonTest.cs
+++ b/src/MudBlazor.UnitTests/Components/ToggleIconButtonTest.cs
@@ -21,7 +21,7 @@ namespace MudBlazor.UnitTests.Components
         public void Setup()
         {
             ctx = new Bunit.TestContext();
-            ctx.AddMudBlazorServices();
+            ctx.AddTestServices();
         }
 
         [TearDown]

--- a/src/MudBlazor.UnitTests/Components/TreeViewTest.cs
+++ b/src/MudBlazor.UnitTests/Components/TreeViewTest.cs
@@ -23,7 +23,7 @@ namespace MudBlazor.UnitTests.Components
         public void Setup()
         {
             ctx = new Bunit.TestContext();
-            ctx.AddMudBlazorServices();
+            ctx.AddTestServices();
         }
 
         [TearDown]

--- a/src/MudBlazor.UnitTests/Extensions/TestContextExtensions.cs
+++ b/src/MudBlazor.UnitTests/Extensions/TestContextExtensions.cs
@@ -12,19 +12,15 @@ namespace MudBlazor.UnitTests
 {
     public static class TestContextExtensions
     {
-        public static void AddMudBlazorServices(this Bunit.TestContext ctx)
+        public static void AddTestServices(this Bunit.TestContext ctx)
         {
             ctx.JSInterop.Mode = JSRuntimeMode.Loose;
             ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager());
-            ctx.Services.AddSingleton<IDialogService>(new DialogService());
-            ctx.Services.AddSingleton<ISnackbar>(new SnackbarService(new SnackbarConfiguration() { ShowTransitionDuration = 0, HideTransitionDuration = 0 }));
-            ctx.Services.AddSingleton<IResizeListenerService>(new MockResizeListenerService());
-
-            ctx.Services.AddTransient<IScrollListener, MockScrollListener>();
-            ctx.Services.AddTransient<IScrollManager, MockScrollManager>();
-
-            ctx.Services.AddSingleton<IBrowserWindowSizeProvider>(new MockBrowserWindowSizeProvider());
-
+            ctx.Services.AddMudServices(options =>
+            {
+                options.SnackbarConfiguration.ShowTransitionDuration = 0;
+                options.SnackbarConfiguration.HideTransitionDuration = 0;
+            });
             ctx.Services.AddScoped(sp => new HttpClient());
             ctx.Services.AddOptions();
         }


### PR DESCRIPTION
- Updated to reflect changes for `AddMudServices()`
- @porkopek Can you update your docs for ScrollServices please 😄 
- For the install guides I have used `<MudProviders/>` which for that senario is fine.  We need to think about configuration of the providers `<MudThemeProvider Theme="MyCustomTheme" />` for example.  If someone adds that in addition to the default providers what happens.  In `AddMudServices()` we use `TryAdd..` which only registers in the DI container once so that is covered.