### PR TITLE
Add code behind

### DIFF
--- a/src/MudBlazor/Components/Card/MudCardMedia.razor
+++ b/src/MudBlazor/Components/Card/MudCardMedia.razor
@@ -1,15 +1,4 @@
 ﻿@namespace MudBlazor
-@using MudBlazor.Utilities
 @inherits MudComponentBase
 
-
-<div title="@Title" class="@Classname" style="@StyleString">
-</div>
-
-@code {
-    protected string Classname =>
-    new CssBuilder("mud-card-media")
-      .AddClass(Class)
-    .Build();
-}
-
+<div title="@Title" class="@Classname" style="@StyleString"></div>

--- a/src/MudBlazor/Components/Card/MudCardMedia.razor.cs
+++ b/src/MudBlazor/Components/Card/MudCardMedia.razor.cs
@@ -5,8 +5,14 @@ namespace MudBlazor
 {
     public partial class MudCardMedia : MudComponentBase
     {
-        protected string StyleString => StyleBuilder.Default($"background-image:url({_imageUrl});{_height};")
+        protected string StyleString =>
+            StyleBuilder.Default($"background-image:url({_imageUrl});{_height};")
                 .AddStyle(this.Style)
+                .Build();
+
+        protected string Classname =>
+            new CssBuilder("mud-card-media")
+                .AddClass(Class)
                 .Build();
 
         [Parameter] public string Title { get; set; }
@@ -15,8 +21,8 @@ namespace MudBlazor
 
         [Parameter] public int Height { get; set; } = 300;
 
-        private string _height { get; set; }
-        private string _imageUrl { get; set; }
+        private string _height;
+        private string _imageUrl;
 
         protected override void OnInitialized()
         {

--- a/src/MudBlazor/Components/Collapse/MudCollapse.razor
+++ b/src/MudBlazor/Components/Collapse/MudCollapse.razor
@@ -1,5 +1,5 @@
 ﻿@namespace MudBlazor
-@using MudBlazor.Utilities;
+@inherits MudComponentBase
 
 <div class="@Classname" style="@(MaxHeight.HasValue && Expanded ? $"max-height:{MaxHeight}px;transition-duration: {CalculatedTransitionDuration}s;" : "")">
     <div class="mud-collapse-wrapper">
@@ -8,51 +8,3 @@
         </div>
     </div>
 </div>
-
-@code {
-
-    /// <summary>
-    /// If true, expands the panel, otherwise collapse it. Setting this prop enables control over the panel.
-    /// </summary>
-    [Parameter] public bool Expanded { get; set; }
-
-    /// <summary>
-    /// Explicitly sets the height for the Collapse element to override the css default.
-    /// </summary>
-    [Parameter] public int? MaxHeight { get; set; }
-
-    /// <summary>
-    /// User class names, separated by space
-    /// </summary>
-    [Parameter] public string Class { get; set; }
-
-    /// <summary>
-    /// Child content of component.
-    /// </summary>
-    [Parameter] public RenderFragment ChildContent { get; set; }
-
-    /// <summary>
-    /// Modified transition duration that scales with height parameter.
-    /// Basic implementation for now but should be a math formula to allow it to scale between 0.1s and 1s for the effect to be consistently smooth.
-    /// </summary>
-    private decimal CalculatedTransitionDuration
-    {
-        get
-        {
-            if (MaxHeight.HasValue && Expanded)
-            {
-                if (MaxHeight <= 200) { return 0.2m; }
-                else if (MaxHeight <= 600) { return 0.4m; }
-                else if (MaxHeight <= 1400) { return 0.6m; };
-            }
-            return 1;
-        }
-        set { }
-    }
-
-    protected string Classname =>
-        new CssBuilder("mud-collapse-container")
-          .AddClass($"mud-collapse-expanded", Expanded)
-          .AddClass(Class)
-        .Build();
-}

--- a/src/MudBlazor/Components/Collapse/MudCollapse.razor.cs
+++ b/src/MudBlazor/Components/Collapse/MudCollapse.razor.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.AspNetCore.Components;
+using MudBlazor.Utilities;
+
+namespace MudBlazor
+{
+    public partial class MudCollapse : MudComponentBase
+    {
+
+        /// <summary>
+        /// If true, expands the panel, otherwise collapse it. Setting this prop enables control over the panel.
+        /// </summary>
+        [Parameter] public bool Expanded { get; set; }
+
+        /// <summary>
+        /// Explicitly sets the height for the Collapse element to override the css default.
+        /// </summary>
+        [Parameter] public int? MaxHeight { get; set; }
+
+        /// <summary>
+        /// Child content of component.
+        /// </summary>
+        [Parameter] public RenderFragment ChildContent { get; set; }
+
+        /// <summary>
+        /// Modified transition duration that scales with height parameter.
+        /// Basic implementation for now but should be a math formula to allow it to scale between 0.1s and 1s for the effect to be consistently smooth.
+        /// </summary>
+        private decimal CalculatedTransitionDuration
+        {
+            get
+            {
+                if (MaxHeight.HasValue && Expanded)
+                {
+                    if (MaxHeight <= 200) { return 0.2m; }
+                    else if (MaxHeight <= 600) { return 0.4m; }
+                    else if (MaxHeight <= 1400) { return 0.6m; };
+                }
+                return 1;
+            }
+            set { }
+        }
+
+        protected string Classname =>
+            new CssBuilder("mud-collapse-container")
+            .AddClass($"mud-collapse-expanded", Expanded)
+            .AddClass(Class)
+            .Build();
+    }
+}

--- a/src/MudBlazor/Components/Layout/MudLayout.razor
+++ b/src/MudBlazor/Components/Layout/MudLayout.razor
@@ -1,5 +1,4 @@
 ﻿@namespace MudBlazor
-@using MudBlazor.Utilities
 @inherits MudComponentBase
 
 <div @attributes="UserAttributes" class="@Classname" style="@Style">
@@ -9,68 +8,3 @@
         </CascadingValue>
     </CascadingValue>
 </div>
-
-@code {
-
-    protected string Classname =>
-    new CssBuilder("mud-layout")
-        .AddClass("mud-application-layout-rtl", RightToLeft)
-        .AddClass(Class)
-    .Build();
-
-    /// <summary>
-    /// Child content of component.
-    /// </summary>
-    [Parameter] public RenderFragment ChildContent { get; set; }
-
-    private bool _rtl;
-
-    /// <summary>
-    /// If set, changes the layout to RightToLeft.
-    /// </summary>
-    [Parameter]
-    public bool RightToLeft
-    {
-        get => _rtl;
-        set
-        {
-            if (_rtl != value)
-            {
-                _rtl = value;
-                StateHasChanged();
-            }
-        }
-    }
-
-    List<MudDrawer> _drawers = new List<MudDrawer>();
-
-    public void Add(MudDrawer drawer)
-    {
-        _drawers.Add(drawer);
-    }
-
-    public void Remove(MudDrawer drawer)
-    {
-        _drawers.Remove(drawer);
-    }
-
-    public bool? IsDrawerOpen(Anchor anchor)
-    {
-        return _drawers.FirstOrDefault(d => d.Anchor == anchor)?.Open;
-    }
-
-    public bool? IsDrawerClipped(Anchor anchor)
-    {
-        return _drawers.FirstOrDefault(d => d.Anchor == anchor)?.Clipped;
-    }
-
-    public void FireDrawersChanged()
-    {
-        StateHasChanged();
-    }
-
-    public bool HasDrawer(Anchor anchor)
-    {
-        return _drawers.Any(d => d.Anchor == anchor);
-    }
-}

--- a/src/MudBlazor/Components/Layout/MudLayout.razor.cs
+++ b/src/MudBlazor/Components/Layout/MudLayout.razor.cs
@@ -1,0 +1,72 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Components;
+using MudBlazor.Utilities;
+
+namespace MudBlazor
+{
+    public partial class MudLayout : MudComponentBase
+    {
+        protected string Classname =>
+        new CssBuilder("mud-layout")
+            .AddClass("mud-application-layout-rtl", RightToLeft)
+            .AddClass(Class)
+            .Build();
+
+        /// <summary>
+        /// Child content of component.
+        /// </summary>
+        [Parameter] public RenderFragment ChildContent { get; set; }
+
+        private bool _rtl;
+
+        /// <summary>
+        /// If set, changes the layout to RightToLeft.
+        /// </summary>
+        [Parameter]
+        public bool RightToLeft
+        {
+            get => _rtl;
+            set
+            {
+                if (_rtl != value)
+                {
+                    _rtl = value;
+                    StateHasChanged();
+                }
+            }
+        }
+
+        List<MudDrawer> _drawers = new List<MudDrawer>();
+
+        public void Add(MudDrawer drawer)
+        {
+            _drawers.Add(drawer);
+        }
+
+        public void Remove(MudDrawer drawer)
+        {
+            _drawers.Remove(drawer);
+        }
+
+        public bool? IsDrawerOpen(Anchor anchor)
+        {
+            return _drawers.FirstOrDefault(d => d.Anchor == anchor)?.Open;
+        }
+
+        public bool? IsDrawerClipped(Anchor anchor)
+        {
+            return _drawers.FirstOrDefault(d => d.Anchor == anchor)?.Clipped;
+        }
+
+        public void FireDrawersChanged()
+        {
+            StateHasChanged();
+        }
+
+        public bool HasDrawer(Anchor anchor)
+        {
+            return _drawers.Any(d => d.Anchor == anchor);
+        }
+    }
+}

--- a/src/MudBlazor/Components/Progress/MudProgressCircular.razor
+++ b/src/MudBlazor/Components/Progress/MudProgressCircular.razor
@@ -1,6 +1,4 @@
 ﻿@namespace MudBlazor
-@using MudBlazor.Utilities;
-@using MudBlazor.Extensions;
 @inherits MudComponentBase
 
 <div class="@DivClassname" role="progressbar" style="transform: rotate(-90deg);@Style" aria-valuenow="@Value">
@@ -16,72 +14,3 @@
     </svg>
 </div>
 
-
-@code {
-    private const int MagicNumber = 126; // weird, but required for the SVG to work
-
-    protected string DivClassname =>
-    new CssBuilder("mud-progress-circular")
-        .AddClass($"mud-{Color.ToDescriptionString()}-text")
-        .AddClass($"mud-progress-{Size.ToDescriptionString()}")
-        .AddClass($"mud-progress-indeterminate", Indeterminate)
-        .AddClass($"mud-progress-static", !Indeterminate)
-        .AddClass(Class)
-    .Build();
-
-    protected string SvgClassname =>
-        new CssBuilder("mud-progress-circular-circle")
-            .AddClass($"mud-progress-indeterminate", Indeterminate)
-        .AddClass($"mud-progress-static", !Indeterminate)
-        .Build();
-
-    /// <summary>
-    /// The color of the component. It supports the theme colors.
-    /// </summary>
-    [Parameter] public Color Color { get; set; } = Color.Default;
-
-    /// <summary>
-    /// The size of the component.
-    /// </summary>
-    [Parameter] public Size Size { get; set; } = Size.Medium;
-    [Parameter] public bool Indeterminate { get; set; }
-
-    [Parameter] public double Minimum { get; set; } = 0.0;
-
-    [Parameter] public double Maximum { get; set; } = 100.0;
-
-    private int _svg_value;
-    private double _value;
-
-    [Parameter]
-    public double Value
-    {
-        get => _value;
-        set
-        {
-            if (_value.Equals(value))
-                return;
-            _value = value;
-            _svg_value = ToSvgValue(_value);
-            InvokeAsync(StateHasChanged);
-        }
-    }
-
-    private int ToSvgValue(double in_value)
-    {
-        var value = Math.Min(Math.Max(Minimum, in_value), Maximum);
-        // calculate fraction, which is a value between 0 and 1
-        var fraction = (value - Minimum) / (Maximum - Minimum);
-        // now project into the range of the SVG value (126 .. 0)
-        return (int)Math.Round(MagicNumber - MagicNumber * fraction);
-    }
-
-    [Parameter] public int StrokeWidth { get; set; } = 3;
-
-    protected override void OnInitialized()
-    {
-        base.OnInitialized();
-        _svg_value = ToSvgValue(_value);
-    }
-
-}

--- a/src/MudBlazor/Components/Progress/MudProgressCircular.razor.cs
+++ b/src/MudBlazor/Components/Progress/MudProgressCircular.razor.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using Microsoft.AspNetCore.Components;
+using MudBlazor.Extensions;
+using MudBlazor.Utilities;
+
+namespace MudBlazor
+{
+    public partial class MudProgressCircular : MudComponentBase
+    {
+        private const int MagicNumber = 126; // weird, but required for the SVG to work
+
+        protected string DivClassname =>
+            new CssBuilder("mud-progress-circular")
+                .AddClass($"mud-{Color.ToDescriptionString()}-text")
+                .AddClass($"mud-progress-{Size.ToDescriptionString()}")
+                .AddClass($"mud-progress-indeterminate", Indeterminate)
+                .AddClass($"mud-progress-static", !Indeterminate)
+                .AddClass(Class)
+                .Build();
+
+        protected string SvgClassname =>
+            new CssBuilder("mud-progress-circular-circle")
+                .AddClass($"mud-progress-indeterminate", Indeterminate)
+                .AddClass($"mud-progress-static", !Indeterminate)
+                .Build();
+
+        /// <summary>
+        /// The color of the component. It supports the theme colors.
+        /// </summary>
+        [Parameter] public Color Color { get; set; } = Color.Default;
+
+        /// <summary>
+        /// The size of the component.
+        /// </summary>
+        [Parameter] public Size Size { get; set; } = Size.Medium;
+        [Parameter] public bool Indeterminate { get; set; }
+
+        [Parameter] public double Minimum { get; set; } = 0.0;
+
+        [Parameter] public double Maximum { get; set; } = 100.0;
+
+        private int _svg_value;
+        private double _value;
+
+        [Parameter]
+        public double Value
+        {
+            get => _value;
+            set
+            {
+                if (_value.Equals(value))
+                    return;
+                _value = value;
+                _svg_value = ToSvgValue(_value);
+                InvokeAsync(StateHasChanged);
+            }
+        }
+
+        private int ToSvgValue(double in_value)
+        {
+            var value = Math.Min(Math.Max(Minimum, in_value), Maximum);
+            // calculate fraction, which is a value between 0 and 1
+            var fraction = (value - Minimum) / (Maximum - Minimum);
+            // now project into the range of the SVG value (126 .. 0)
+            return (int)Math.Round(MagicNumber - MagicNumber * fraction);
+        }
+
+        [Parameter] public int StrokeWidth { get; set; } = 3;
+
+        protected override void OnInitialized()
+        {
+            base.OnInitialized();
+            _svg_value = ToSvgValue(_value);
+        }
+
+    }
+}

--- a/src/MudBlazor/Components/Progress/MudProgressLinear.razor
+++ b/src/MudBlazor/Components/Progress/MudProgressLinear.razor
@@ -1,6 +1,5 @@
 ﻿@namespace MudBlazor
-@using MudBlazor.Utilities;
-@using MudBlazor.Extensions;
+@using MudBlazor.Extensions
 @inherits MudComponentBase
 
 <div class="@DivClassname" role="progressbar" aria-valuenow="@Value" aria-valuemin="0" aria-valuemax="100">
@@ -20,71 +19,3 @@
         <div class="@LinearClassname" style="transform: translateX(-@Value%);"></div>
     }
 </div>
-
-
-@code {
-    protected string DivClassname =>
-    new CssBuilder("mud-progress-linear")
-        .AddClass($"mud-progress-linear-color-{Color.ToDescriptionString()}", !Buffer)
-        .AddClass(Class)
-    .Build();
-
-    protected string LinearClassname =>
-        new CssBuilder("mud-progress-linear-bar")
-            .AddClass($"mud-{Color.ToDescriptionString()}")
-            .AddClass($"mud-progress-indeterminate", Indeterminate)
-        .AddClass($"mud-progress-linear-bar-1-determinate", !Indeterminate)
-        .Build();
-
-    protected string BufferClassname =>
-        new CssBuilder("mud-progress-linear-dashed")
-            .AddClass($"mud-progress-linear-dashed-color-{Color.ToDescriptionString()}")
-        .Build();
-
-    /// <summary>
-    /// The color of the component. It supports the theme colors.
-    /// </summary>
-    [Parameter] public Color Color { get; set; } = Color.Default;
-
-    /// <summary>
-    /// The color of the component. It supports the theme colors.
-    /// </summary>
-    [Parameter] public Size Size { get; set; } = Size.Medium;
-    [Parameter] public bool Indeterminate { get; set; }
-    [Parameter] public bool Buffer { get; set; }
-    [Parameter] public bool Static { get; set; }
-    [Parameter] public int StrokeWidth { get; set; } = 3;
-
-    [Parameter] public double Minimum { get; set; } = 0.0;
-
-    [Parameter] public double Maximum { get; set; } = 100.0;
-
-    private double _value;
-    private double _bufferValue;
-
-    [Parameter]
-    public double Value
-    {
-        get => _value;
-        set
-        {
-            if (_value.Equals(value))
-                return;
-            _value = value;
-            InvokeAsync(StateHasChanged);
-        }
-    }
-
-    [Parameter]
-    public double BufferValue
-    {
-        get => _bufferValue;
-        set
-        {
-            if (_bufferValue.Equals(value))
-                return;
-            _bufferValue = value;
-            InvokeAsync(StateHasChanged);
-        }
-    }
-}

--- a/src/MudBlazor/Components/Progress/MudProgressLinear.razor.cs
+++ b/src/MudBlazor/Components/Progress/MudProgressLinear.razor.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using Microsoft.AspNetCore.Components;
+using MudBlazor.Extensions;
+using MudBlazor.Utilities;
+
+namespace MudBlazor
+{
+    public partial class MudProgressLinear : MudComponentBase
+    {
+        protected string DivClassname =>
+            new CssBuilder("mud-progress-linear")
+                .AddClass($"mud-progress-linear-color-{Color.ToDescriptionString()}", !Buffer)
+                .AddClass(Class)
+                .Build();
+
+        protected string LinearClassname =>
+            new CssBuilder("mud-progress-linear-bar")
+                .AddClass($"mud-{Color.ToDescriptionString()}")
+                .AddClass($"mud-progress-indeterminate", Indeterminate)
+                .AddClass($"mud-progress-linear-bar-1-determinate", !Indeterminate)
+                .Build();
+
+        protected string BufferClassname =>
+            new CssBuilder("mud-progress-linear-dashed")
+                .AddClass($"mud-progress-linear-dashed-color-{Color.ToDescriptionString()}")
+                .Build();
+
+        /// <summary>
+        /// The color of the component. It supports the theme colors.
+        /// </summary>
+        [Parameter] public Color Color { get; set; } = Color.Default;
+
+        /// <summary>
+        /// The color of the component. It supports the theme colors.
+        /// </summary>
+        [Parameter] public Size Size { get; set; } = Size.Medium;
+        [Parameter] public bool Indeterminate { get; set; }
+        [Parameter] public bool Buffer { get; set; }
+        [Parameter] public bool Static { get; set; }
+        [Parameter] public int StrokeWidth { get; set; } = 3;
+
+        [Parameter] public double Minimum { get; set; } = 0.0;
+
+        [Parameter] public double Maximum { get; set; } = 100.0;
+
+        private double _value;
+        private double _bufferValue;
+
+        [Parameter]
+        public double Value
+        {
+            get => _value;
+            set
+            {
+                if (_value.Equals(value))
+                    return;
+                _value = value;
+                InvokeAsync(StateHasChanged);
+            }
+        }
+
+        [Parameter]
+        public double BufferValue
+        {
+            get => _bufferValue;
+            set
+            {
+                if (_bufferValue.Equals(value))
+                    return;
+                _bufferValue = value;
+                InvokeAsync(StateHasChanged);
+            }
+        }
+    }
+}

--- a/src/MudBlazor/Components/Skeleton/MudSkeleton.razor
+++ b/src/MudBlazor/Components/Skeleton/MudSkeleton.razor
@@ -1,55 +1,5 @@
 ﻿@namespace MudBlazor
-@using MudBlazor.Utilities
-@using MudBlazor.Extensions
 @inherits MudComponentBase;
 
 <span class="@Classname" style="@StyleString"></span>
 
-@code {
-
-    protected string Classname =>
-    new CssBuilder("mud-skeleton")
-      .AddClass($"mud-skeleton-{SkeletonType.ToDescriptionString()}")
-      .AddClass($"mud-skeleton-{Animation.ToDescriptionString()}")
-      .AddClass(Class)
-    .Build();
-
-    /// <summary>
-    /// With defined in string, needs px or % or equal prefix.
-    /// </summary>
-    [Parameter] public string Width { set; get; }
-
-    /// <summary>
-    /// Height defined in string, needs px or % or equal prefix.
-    /// </summary>
-    [Parameter] public string Height { set; get; }
-
-    /// <summary>
-    /// Shape of the skeleton that will be renderd.
-    /// </summary>
-    [Parameter] public SkeletonType SkeletonType { set; get; } = SkeletonType.Text;
-
-    /// <summary>
-    /// Animation style, if false it will be disabled.
-    /// </summary>
-    [Parameter] public Animation Animation { set; get; } = Animation.Pulse;
-
-    private string _width { get; set; }
-    private string _height { get; set; }
-    private string StyleString { get; set; }
-
-    protected override void OnInitialized()
-    {
-        if(!String.IsNullOrEmpty(Width))
-        {
-            _width = $"width:{Width};";
-        }
-
-        if (!String.IsNullOrEmpty(Height))
-        {
-            _height = $"height:{Height};";
-        }
-
-        StyleString = $"{_width}{_height}{Style}";
-    }
-}

--- a/src/MudBlazor/Components/Skeleton/MudSkeleton.razor.cs
+++ b/src/MudBlazor/Components/Skeleton/MudSkeleton.razor.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using Microsoft.AspNetCore.Components;
+using MudBlazor.Extensions;
+using MudBlazor.Utilities;
+
+namespace MudBlazor
+{
+    public partial class MudSkeleton : MudComponentBase
+    {
+        protected string Classname =>
+            new CssBuilder("mud-skeleton")
+                .AddClass($"mud-skeleton-{SkeletonType.ToDescriptionString()}")
+                .AddClass($"mud-skeleton-{Animation.ToDescriptionString()}")
+                .AddClass(Class)
+                .Build();
+
+        /// <summary>
+        /// With defined in string, needs px or % or equal prefix.
+        /// </summary>
+        [Parameter] public string Width { set; get; }
+
+        /// <summary>
+        /// Height defined in string, needs px or % or equal prefix.
+        /// </summary>
+        [Parameter] public string Height { set; get; }
+
+        /// <summary>
+        /// Shape of the skeleton that will be renderd.
+        /// </summary>
+        [Parameter] public SkeletonType SkeletonType { set; get; } = SkeletonType.Text;
+
+        /// <summary>
+        /// Animation style, if false it will be disabled.
+        /// </summary>
+        [Parameter] public Animation Animation { set; get; } = Animation.Pulse;
+
+        private string _width { get; set; }
+        private string _height { get; set; }
+        private string StyleString { get; set; }
+
+        protected override void OnInitialized()
+        {
+            if (!String.IsNullOrEmpty(Width))
+            {
+                _width = $"width:{Width};";
+            }
+
+            if (!String.IsNullOrEmpty(Height))
+            {
+                _height = $"height:{Height};";
+            }
+
+            StyleString = $"{_width}{_height}{Style}";
+        }
+    }
+}


### PR DESCRIPTION
- We said we would have code behind for all components
- This PR moves adds code behind for some of the larger components (I left the ones with small `@code`)
- None that are being worked on as far as I know.
- Added inheritance to MudComponentBase for MudCollapse