### PR TITLE
Turn off default expression refactor

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -293,7 +293,7 @@ file_header_template = Not Used
 dotnet_diagnostic.IDE0055.severity = suggestion
 # IDE0044: Make field readonly
 dotnet_diagnostic.IDE0044.severity = none
-# IDE0043: 'default' expression can be simplified
+# IDE0034: 'default' expression can be simplified
 dotnet_diagnostic.IDE0034.severity = none
 
 [*]

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -293,6 +293,8 @@ file_header_template = Not Used
 dotnet_diagnostic.IDE0055.severity = suggestion
 # IDE0044: Make field readonly
 dotnet_diagnostic.IDE0044.severity = none
+# IDE0043: 'default' expression can be simplified
+dotnet_diagnostic.IDE0034.severity = none
 
 [*]
 end_of_line = lf


### PR DESCRIPTION
- `default(DateTime)` is more readable that `default`