### PR TITLE
Manage call loops by update flags in Picker components

### DIFF
--- a/src/MudBlazor/Base/MudBasePicker.cs
+++ b/src/MudBlazor/Base/MudBasePicker.cs
@@ -100,15 +100,16 @@ namespace MudBlazor
         public string Value
         {
             get => _value;
-            set => SetValueAsync(value).AndForget();
+            set => SetValueAsync(value, true).AndForget();
         }
 
-        private async Task SetValueAsync(string value)
+        protected async Task SetValueAsync(string value, bool callback)
         {
             if (_value != value)
             {
                 _value = value;
-                StringValueChanged(_value);
+                if (callback)
+                    await StringValueChanged(_value);
                 await ValueChanged.InvokeAsync(_value);
             }
         }
@@ -116,8 +117,9 @@ namespace MudBlazor
         /// <summary>
         /// Value change hook for descendants.
         /// </summary>
-        protected virtual void StringValueChanged(string value)
+        protected virtual Task StringValueChanged(string value)
         {
+            return Task.CompletedTask;
         }
 
         protected bool IsOpen { get; set; }

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -3,12 +3,13 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.Extensions;
 using MudBlazor.Utilities;
+using static System.String;
 
 namespace MudBlazor
 {
     public class MudDatePicker : MudBaseDatePicker
     {
-        protected DateTime? _date;
+        private DateTime? _date;
 
         /// <summary>
         /// Fired when the DateFormat changes.
@@ -22,39 +23,36 @@ namespace MudBlazor
         public DateTime? Date
         {
             get => _date;
-            set
+            set => SetDateAsync(value, true).AndForget();
+        }
+
+        protected async Task SetDateAsync(DateTime? date, bool updateValue)
+        {
+            if (_date != date)
             {
-                if (value == _date)
-                    return;
-                if (_setting_date)
-                    return;
-                _setting_date = true;
-                try
+                _date = date;
+
+                if (updateValue)
                 {
-                    _date = value;
-                    if ((!string.IsNullOrEmpty(DateFormat)) && _date.HasValue)
-                        Value = _date.Value.ToString(DateFormat);
+                    if ((!IsNullOrEmpty(DateFormat)) && _date.HasValue)
+                        await SetValueAsync(_date.Value.ToString(DateFormat), false);
                     else
-                        Value = _date.ToIsoDateString();
-                    InvokeAsync(StateHasChanged);
-                    DateChanged.InvokeAsync(value);
+                        await SetValueAsync(_date.ToIsoDateString(), false);
                 }
-                finally
-                {
-                    _setting_date = false;
-                }
+
+                await DateChanged.InvokeAsync(_date);
             }
         }
 
-        private bool _setting_date;
-
-        protected override void StringValueChanged(string value)
+        protected override Task StringValueChanged(string value)
         {
-            // update the date property
-            if (DateTime.TryParse(value, out var date))
-                Date = date;
-            else
-                Date = null;
+            // Update the date property (without updating back the Value property)
+            return SetDateAsync(ParseDateValue(value), false);
+        }
+
+        private DateTime? ParseDateValue(string value)
+        {
+            return DateTime.TryParse(value, out var date) ? date : (DateTime?)null;
         }
 
         protected override string GetDayClasses(int month, DateTime day)
@@ -62,7 +60,7 @@ namespace MudBlazor
             var b = new CssBuilder("mud-day");
             if (day < GetMonthStart(month) || day > GetMonthEnd(month))
                 return b.AddClass("mud-hidden").Build();
-            if (_date.HasValue && _date.Value.Date == day)
+            if (Date?.Date == day)
                 return b.AddClass("mud-selected").AddClass($"mud-theme-{Color.ToDescriptionString()}").Build();
             if (day == DateTime.Today)
                 return b.AddClass("mud-current").AddClass($"mud-{Color.ToDescriptionString()}-text").Build();
@@ -71,7 +69,8 @@ namespace MudBlazor
 
         protected override async void OnDayClicked(DateTime dateTime)
         {
-            Date = dateTime;
+            await SetDateAsync(dateTime, true);
+
             if (PickerVariant != PickerVariant.Static)
             {
                 await Task.Delay(ClosingDelay);
@@ -81,9 +80,7 @@ namespace MudBlazor
 
         protected override string GetFormattedDateString()
         {
-            if (Date == null)
-                return "";
-            return Date.Value.ToString("ddd, dd MMM", Culture);
+            return Date?.ToString("ddd, dd MMM", Culture) ?? "";
         }
     }
 }


### PR DESCRIPTION
As discussed in #572, here's the fix to manage call loops by using boolean flag in Set methods, as it was also implemented in BaseInput.