### PR TITLE
MudAutoComplete style for Table Cell

### DIFF
--- a/src/MudBlazor/Styles/components/_table.scss
+++ b/src/MudBlazor/Styles/components/_table.scss
@@ -173,6 +173,17 @@
             margin-bottom: -8px;
         }
     }
+
+    & > .mud-select {
+        & > .mud-input-control {
+            & > div.mud-input.mud-input-text {
+                color: var(--mud-theme-on-surface);
+                font-size: 0.875rem;
+                margin-top: -14px;
+                margin-bottom: -8px;
+            }
+        }
+    }
 }
 
 .mud-table-cell-align {


### PR DESCRIPTION
The purpose of this PR is about to match the MudAutocomplete style with another input elements when it's inside a table cell.