### PR TITLE
Remove MudProviders

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ Add the following to `_Imports.razor`
 ```
 Add the following to the `MainLayout.razor` or `App.razor`
 ```razor
-<MudProviders/>
+<MudThemeProvider/>
+<MudDialogProvider/>
+<MudSnackbarProvider/>
 ```
 Add the following to `index.html` (client-side) or `_Host.cshtml` (server-side) in the `head`
 ```razor

--- a/src/MudBlazor.Docs/Pages/Getting Started/Installation/Installation.razor
+++ b/src/MudBlazor.Docs/Pages/Getting Started/Installation/Installation.razor
@@ -60,7 +60,7 @@
         <DocsPageSection>
             <SectionHeader>
                 <SubTitle>5. Add Components</SubTitle>
-                <Description>Add the following component to your <CodeInline>MainLayout.razor</CodeInline> or <CodeInline>App.razor</CodeInline>.</Description>
+                <Description>Add the following components to your <CodeInline>MainLayout.razor</CodeInline> or <CodeInline>App.razor</CodeInline> note that the <CodeInline>ThemeProvider</CodeInline> is essential for MudBlazor but the rest is optional.</Description>
             </SectionHeader>
             <MarkdownAddComponents />
         </DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Getting Started/Installation/ManualMarkDown/MarkdownAddComponents.razor
+++ b/src/MudBlazor.Docs/Pages/Getting Started/Installation/ManualMarkDown/MarkdownAddComponents.razor
@@ -3,7 +3,9 @@
 <div class="mud-codeblock">
 <div class="html">
 <pre>
-<span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">MudProviders</span><span class="htmlTagDelimiter">/&gt;</span>
+<span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">MudThemeProvider</span><span class="htmlTagDelimiter">/&gt;</span>
+<span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">MudDialogProvider</span><span class="htmlTagDelimiter">/&gt;</span>
+<span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">MudSnackbarProvider</span><span class="htmlTagDelimiter">/&gt;</span>
 </pre>
 </div>
 </div>

--- a/src/MudBlazor.UnitTests.Viewer/Shared/MainLayout.razor
+++ b/src/MudBlazor.UnitTests.Viewer/Shared/MainLayout.razor
@@ -1,5 +1,7 @@
 ﻿@inherits LayoutComponentBase
 
-<MudProviders />
+<MudThemeProvider/>
+<MudDialogProvider/>
+<MudSnackbarProvider/>
 
 @Body

--- a/src/MudBlazor/Components/MudProviders.razor
+++ b/src/MudBlazor/Components/MudProviders.razor
@@ -1,7 +1,0 @@
-@* Convenience component for common providers *@
-
-@namespace MudBlazor
-
-<MudThemeProvider/>
-<MudDialogProvider/>
-<MudSnackbarProvider/>


### PR DESCRIPTION
- We should still think about the concept of `<MudProviders/>` but we need a better grasp of how the configuration will work.