### PR TITLE
Fix por PR #575 - MudTabs.KeepPanelsAlive

### DIFF
--- a/src/MudBlazor/Components/Tabs/MudTabPanel.razor
+++ b/src/MudBlazor/Components/Tabs/MudTabPanel.razor
@@ -4,7 +4,7 @@
 
 @if ((bool)((Parent?.KeepPanelsAlive ?? false)))
 {
-    <div style="display:@(Parent?.ActivePanel == this && ChildContent != null ? "default" : "none")">
+    <div style="display:@(Parent?.ActivePanel == this && ChildContent != null ? "contents" : "none")">
         @ChildContent
     </div>
 }

--- a/src/MudBlazor/Styles/components/_table.scss
+++ b/src/MudBlazor/Styles/components/_table.scss
@@ -173,6 +173,17 @@
             margin-bottom: -8px;
         }
     }
+
+    & > .mud-select {
+        & > .mud-input-control {
+            & > div.mud-input.mud-input-text {
+                color: var(--mud-theme-on-surface);
+                font-size: 0.875rem;
+                margin-top: -14px;
+                margin-bottom: -8px;
+            }
+        }
+    }
 }
 
 .mud-table-cell-align {


### PR DESCRIPTION
There's an error caused by me on #575 , setting diplay:default for active panel when the Parameter KeepPanelsAlive is set to true.

"default" is not a valid value for display property, and I didn't figure it before merge. 

I've changed it to display: contents and tested.

I'm so sorry for this.