### PR TITLE
Publish coverage task

### DIFF
--- a/.azure/pipelines/jobs/default-test.yml
+++ b/.azure/pipelines/jobs/default-test.yml
@@ -17,7 +17,21 @@ steps:
   displayName: Test
   inputs:
     command: 'test'
-    # Timeout if we encounter never ending test and show current test
-    arguments: '--blame-hang --blame-hang-timeout 60s'
+    arguments: '--blame-hang
+                --blame-hang-timeout 60s
+                /property:GenerateFullPaths=true
+                /consoleloggerparameters:NoSummary
+                /p:CollectCoverage=true
+                /p:CoverletOutputFormat=cobertura
+                /p:ExcludeByAttribute="ExcludeFromCodeCoverage"
+                /p:Include="[MudBlazor]*"
+                /p:SkipAutoProps=true
+                /p:CoverletOutput="./TestResults/"'
     projects: 'src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj'
     testRunTitle: 'UnitTest'
+    
+- task: PublishCodeCoverageResults@1
+  inputs:
+    codeCoverageTool: 'Cobertura'
+    summaryFileLocation: '$(System.DefaultWorkingDirectory)/src/MudBlazor.UnitTests/TestResults/coverage.cobertura.xml'
+     


### PR DESCRIPTION
- This adds code covergage as a build artifact to the test stage of the pipeline
- With this change PRs and commits give code coverage statistics (currently 65%)
- You can also add a badge using shields.io.  The badge for this branch is
- ![Azure DevOps coverage (coverage)](https://img.shields.io/azure-devops/coverage/mikes0712/mikes/4/coverage.svg?style=flat-square)
- `![Azure DevOps coverage (coverage)](https://img.shields.io/azure-devops/coverage/mikes0712/mikes/4/coverage.svg?style=flat-square)`
- `https://img.shields.io/azure-devops/coverage/` is the type of badge
- `coverage.svg` is the branchname BTW. thats a bit confusing.  Anyway I can PR a badge with the right info