### PR TITLE
Fix toggle icon button event propagation

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/ToggleIconButton/Examples/ToggleIconButtonEventCallbackExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ToggleIconButton/Examples/ToggleIconButtonEventCallbackExample.razor
@@ -1,32 +1,29 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudToggleIconButton Toggled="@AlarmOn" ToggledChanged="(toggleValue) => IncrementSwitchedOn(toggleValue)"
+<MudToggleIconButton Toggled="@AlarmOn" ToggledChanged="OnToggledChanged"
                      Icon="@Icons.Material.AlarmOff" Color="@Color.Error" 
                      ToggledIcon="@Icons.Material.AlarmOn" ToggledColor="@Color.Success" />
 
 <span>Alarm is @(AlarmOn ? "On" : "Off")</span>
-<span>@($"I have been switched on {SwitchedOnCount} times.")</span>
+<span>@($"I have been switched on {SwitchedOnCount} times (Remaining: {MaxCount - SwitchedOnCount})")</span>
 
 @code {
     public bool AlarmOn { get; set; }
     public int SwitchedOnCount { get; set; }
 
-    public void IncrementSwitchedOn(bool toggleValue)
+    private const int MaxCount = 5;
+
+    public void OnToggledChanged(bool toggled)
     {
-        // You can do things before assignment
-        // ...
-
-        // Assignment of one-way bound parameter
-        AlarmOn = toggleValue;
-
-        // And after assignment has been made
-        // ...
+        // Because variable is not two-way bound, we need to update it ourself
+        AlarmOn = toggled;
 
         if (AlarmOn)
         {
-            SwitchedOnCount++;
+            if (SwitchedOnCount < MaxCount)
+                SwitchedOnCount++;
+            else
+                AlarmOn = false;    // We can force a state under specific condition (max count reached)
         }
-
     }
 }
-

--- a/src/MudBlazor.Docs/Pages/Components/ToggleIconButton/ToggleIconButtonPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ToggleIconButton/ToggleIconButtonPage.razor
@@ -22,7 +22,7 @@
         <DocsPageSection>
             <SectionHeader>
                 <Title>Advanced usage</Title>
-                <Description>Use <CodeInline>EventCallback</CodeInline> with manual assignment of the one-way bound value if you want to act on the toggle event.</Description>
+                <Description>You may act on the toggled state by using the <CodeInline>Toggled</CodeInline> EventCallback.</Description>
             </SectionHeader>
             <SectionContent Outlined="true">
                 <ToggleIconButtonEventCallbackExample />

--- a/src/MudBlazor/Components/Button/MudToggleIconButton.razor
+++ b/src/MudBlazor/Components/Button/MudToggleIconButton.razor
@@ -1,3 +1,9 @@
 ﻿@namespace MudBlazor
 
-<MudIconButton Icon="@(_toggled?ToggledIcon:Icon)" Size="@(_toggled?ToggledSize:Size)" Color="@(_toggled?ToggledColor:Color)" Disabled="@Disabled" Edge="@Edge" DisableRipple="@DisableRipple" OnClick="@Toggle" />
+<MudIconButton Icon="@(Toggled ? ToggledIcon : Icon)" 
+               Size="@(Toggled ? ToggledSize : Size)" 
+               Color="@(Toggled ? ToggledColor : Color)" 
+               Disabled="@Disabled" 
+               Edge="@Edge" 
+               DisableRipple="@DisableRipple" 
+               OnClick="@Toggle" />

--- a/src/MudBlazor/Components/Button/MudToggleIconButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudToggleIconButton.razor.cs
@@ -1,4 +1,4 @@
-﻿
+﻿using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 
@@ -11,7 +11,20 @@ namespace MudBlazor
         /// <summary>
         /// The toggled value.
         /// </summary>
-        [Parameter] public bool Toggled { get; set; }
+        [Parameter] public bool Toggled
+        {
+            get => _toggled;
+            set => SetToggledAsync(value).AndForget();
+        }
+
+        protected async Task SetToggledAsync(bool toggled)
+        {
+            if (_toggled != toggled)
+            {
+                _toggled = toggled;
+                await ToggledChanged.InvokeAsync(_toggled);
+            }
+        }
 
         /// <summary>
         /// Fires whenever toggled is changed. 
@@ -63,15 +76,9 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public bool Disabled { get; set; }
 
-        protected override void OnInitialized()
+        public Task Toggle()
         {
-            _toggled = Toggled;
-        }
-
-        public async Task Toggle()
-        {
-            _toggled = !_toggled;
-            await ToggledChanged.InvokeAsync(_toggled);
+            return SetToggledAsync(!Toggled);
         }
     }
 }


### PR DESCRIPTION
ToggledChanged event was not raised by parameter property setter, so the event was not correctly propagated.

See this example, where three components are bound to the same bool variable, but clicking on a component does not correctly update the others:

https://try.mudblazor.com/snippet/GFEFlKlr52S1wdUs24

I also enhanced the doc example to show that it is possible to force a specific state while inside the event handler.