### PR TITLE
Fix build - excubo needs everthing in config

### DIFF
--- a/src/MudBlazor.Docs/MudBlazor.Docs.csproj
+++ b/src/MudBlazor.Docs/MudBlazor.Docs.csproj
@@ -92,7 +92,7 @@
   </Target>
 
   <Target Name="WebCompiler" DependsOnTargets="ToolRestore">
-      <Exec Command="dotnet webcompiler ./Styles/MudBlazorDocs.scss -o ./wwwroot -c excubowebcompiler.json" StandardOutputImportance="high" />
+      <Exec Command="dotnet webcompiler ./Styles/MudBlazorDocs.scss -c excubowebcompiler.json" StandardOutputImportance="high" />
   </Target>
 
   <Target Name="IncludeGeneratedStaticFiles" BeforeTargets="BeforeBuild;BeforeRebuild" DependsOnTargets="WebCompiler;ToolRestore">

--- a/src/MudBlazor.Docs/excubowebcompiler.json
+++ b/src/MudBlazor.Docs/excubowebcompiler.json
@@ -50,6 +50,7 @@
     }
   },
   "Output": {
-    "Preserve": true
+    "Preserve": true,
+    "Directory": "./wwwroot"
   }
 }

--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -59,7 +59,7 @@
   </Target>
 
   <Target Name="WebCompiler" DependsOnTargets="ToolRestore">
-      <Exec Command="dotnet webcompiler ./Styles/MudBlazor.scss -o ./wwwroot -c excubowebcompiler.json" StandardOutputImportance="high" />
+      <Exec Command="dotnet webcompiler ./Styles/MudBlazor.scss -c excubowebcompiler.json" StandardOutputImportance="high" />
   </Target>
 
   <Target Name="IncludeGeneratedStaticFiles" BeforeTargets="BeforeBuild;BeforeRebuild" DependsOnTargets="WebCompiler;ToolRestore">

--- a/src/MudBlazor/excubowebcompiler.json
+++ b/src/MudBlazor/excubowebcompiler.json
@@ -50,6 +50,7 @@
     }
   },
   "Output": {
-    "Preserve": true
+    "Preserve": true,
+    "Directory": "./wwwroot"
   }
 }


### PR DESCRIPTION
- No MudBloazor.min.css was being output to wwwroot using the -o option
- This was working until recently it was switched to config file recently by request
- Turns out you cant mix and match command line and config file in excubo webcompiler
- So here we make sure output `Directory` is in the config file
- Please merge to net5 aswell ASAP