### PR TITLE
Avoid element repeat in checkbox

### DIFF
--- a/src/MudBlazor/Components/CheckBox/MudCheckBox.razor
+++ b/src/MudBlazor/Components/CheckBox/MudCheckBox.razor
@@ -6,24 +6,9 @@
     <span class="@CheckBoxClassname">
         @*note: stopping the click propagation is important here. otherwise checking the checkbox results in click events on its parent (i.e. table row), which is generally not what you would want*@
         <input @attributes="UserAttributes" type="checkbox" class="mud-checkbox-input" @bind="@BoolValue" disabled="@Disabled" @onclick:stopPropagation="true" @onclick:preventDefault="@ReadOnly"/>
-        @if (BoolValue == true)
-        {
-            <svg class="mud-svg-icon-root" focusable="false" viewBox="0 0 24 24" role="presentation" aria-hidden="true">
-                <path d="@_checkedIcon"></path>
-            </svg>
-        }
-        else if (BoolValue == false)
-        {
-            <svg class="mud-svg-icon-root" focusable="false" viewBox="0 0 24 24" role="presentation" aria-hidden="true">
-                <path d="@_uncheckedIcon"></path>
-            </svg>
-        }
-        else
-        {
-            <svg class="mud-svg-icon-root" focusable="false" viewBox="0 0 24 24" role="presentation" aria-hidden="true">
-                <path d="@_indeterminateIcon"></path>
-            </svg>
-        }
+        <svg class="mud-svg-icon-root" focusable="false" viewBox="0 0 24 24" role="presentation" aria-hidden="true">
+            <path d="@GetIcon()"></path>
+        </svg>
     </span>
     @if (!String.IsNullOrEmpty(Label))
     {

--- a/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
+++ b/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
@@ -11,6 +11,7 @@ namespace MudBlazor
             .AddClass($"mud-disabled", Disabled)
           .AddClass(Class)
         .Build();
+
         protected string CheckBoxClassname =>
         new CssBuilder("mud-button-root mud-icon-button")
             .AddClass($"mud-checkbox-{Color.ToDescriptionString()}")
@@ -48,28 +49,32 @@ namespace MudBlazor
         /// Custom checked icon, leave null for default.
         /// </summary>
         [Parameter]
-        public string CheckedIcon { get; set; } = null;
-
-        protected string _checkedIcon => CheckedIcon ??
-                                         "M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z";
+        public string CheckedIcon { get; set; }
 
         /// <summary>
         /// Custom unchecked icon, leave null for default.
         /// </summary>
         [Parameter]
-        public string UncheckedIcon { get; set; } = null;
-
-        protected string _uncheckedIcon => UncheckedIcon ??
-                                           "M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z";
+        public string UncheckedIcon { get; set; }
 
         /// <summary>
         /// Custom indeterminate icon, leave null for default.
         /// </summary>
         [Parameter]
-        public string IndeterminateIcon { get; set; } = null;
+        public string IndeterminateIcon { get; set; }
 
-        protected string _indeterminateIcon => IndeterminateIcon ??
-                                           "M17,13H7V11H17M19,3H5C3.89,3 3,3.89 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V5C21,3.89 20.1,3 19,3Z";
+        private string GetIcon()
+        {
+            if (BoolValue == true)
+                return CheckedIcon ??
+                       "M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z";
 
+            if (BoolValue == false)
+                return UncheckedIcon ??
+                       "M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z";
+
+            return IndeterminateIcon ??
+                   "M17,13H7V11H17M19,3H5C3.89,3 3,3.89 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V5C21,3.89 20.1,3 19,3Z";
+        }
     }
 }


### PR DESCRIPTION
I noticed that the exact same svg element was repeated for each possible checkbox state. Now the svg element is defined only once and use a single method to define which icon to display.