### PR TITLE
Picker performance improvements

### DIFF
--- a/src/MudBlazor.Docs.Compiler/TestsForApiPages.cs
+++ b/src/MudBlazor.Docs.Compiler/TestsForApiPages.cs
@@ -50,6 +50,7 @@ namespace MudBlazor.Docs.Compiler
                 cb.AddLine("ctx.Services.AddTransient<IScrollListener, MockScrollListener>();");
                 cb.AddLine("ctx.Services.AddSingleton<IHeadElementHelper>(new MockHeadElementHelper());");
                 cb.AddLine("ctx.Services.AddSingleton<IBrowserWindowSizeProvider>(new MockBrowserWindowSizeProvider());");
+                cb.AddLine("ctx.Services.AddSingleton<IDomService>(new MockDomService());");
                 cb.AddLine("ctx.Services.AddScoped(sp => new HttpClient());");
                 cb.IndentLevel--;
                 cb.AddLine("}");

--- a/src/MudBlazor.Docs.Compiler/TestsForExamples.cs
+++ b/src/MudBlazor.Docs.Compiler/TestsForExamples.cs
@@ -49,6 +49,7 @@ namespace MudBlazor.Docs.Compiler
                 cb.AddLine("ctx.Services.AddTransient<IScrollManager, MockScrollManager>();");
                 cb.AddLine("ctx.Services.AddTransient<IScrollListener, MockScrollListener>();");
                 cb.AddLine("ctx.Services.AddSingleton<IBrowserWindowSizeProvider>(new MockBrowserWindowSizeProvider());");
+                cb.AddLine("ctx.Services.AddSingleton<IDomService>(new MockDomService());");
 
                 cb.AddLine("ctx.Services.AddScoped(sp => new HttpClient());");
                 // options required for file upload

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -119,7 +119,7 @@ namespace MudBlazor.UnitTests
         {
             var comp = OpenPicker();
             // clicking a day button to select a date and close
-            comp.FindAll("div.mud-picker-calendar button")
+            comp.FindAll("button.mud-picker-calendar-day")
                 .Where(x => x.TrimmedText().Equals("23")).First().Click();
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0), TimeSpan.FromSeconds(5));
             comp.Instance.Date.Should().NotBeNull();
@@ -216,7 +216,7 @@ namespace MudBlazor.UnitTests
             comp.FindAll("div.mud-picker-month-container").Count.Should().Be(1);
             comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-month-container > div.mud-picker-month")
                 .Skip(2).First().Click();
-            comp.FindAll("div.mud-picker-calendar button")
+            comp.FindAll("button.mud-picker-calendar-day")
                 .Where(x => x.TrimmedText().Equals("2")).First().Click();
             comp.Instance.Date.Value.Date.Should().Be(new DateTime(DateTime.Now.Year, 3, 2));
         }
@@ -238,7 +238,7 @@ namespace MudBlazor.UnitTests
             comp.FindAll("div.mud-picker-month-container").Count.Should().Be(1);
             comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-month-container > div.mud-picker-month")
                 .Skip(3).First().Click();
-            comp.FindAll("div.mud-picker-calendar button")
+            comp.FindAll("button.mud-picker-calendar-day")
                 .Where(x => x.TrimmedText().Equals("23")).First().Click();
             comp.Instance.Date.Value.Date.Should().Be(new DateTime(DateTime.Now.Year, 4, 23));
         }
@@ -274,7 +274,7 @@ namespace MudBlazor.UnitTests
             comp.FindAll("div.mud-picker-month-container").Count.Should().Be(1);
             comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-month-container > div.mud-picker-month").Skip(1).First().Click();
             comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-calendar-header").Count.Should().Be(1);
-            comp.FindAll("div.mud-picker-calendar button")
+            comp.FindAll("button.mud-picker-calendar-day")
                 .Where(x => x.TrimmedText().Equals("1")).First().Click();
             comp.Instance.Date.Value.Date.Should().Be(new DateTime(2022, 2, 1));
         }

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -132,7 +132,7 @@ namespace MudBlazor.UnitTests
             DateTime? returnDate = null;
             var comp = OpenPicker(EventCallback("DateChanged", (DateTime? date) => { eventCount++; returnDate = date; }));
             // clicking a day button to select a date and close
-            comp.FindAll("div.mud-picker-calendar-day > button")
+            comp.FindAll("button.mud-picker-calendar-day")
                 .Where(x => x.TrimmedText().Equals("23")).First().Click();
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0), TimeSpan.FromSeconds(5));
             comp.Instance.Date.Should().NotBeNull();

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -119,7 +119,7 @@ namespace MudBlazor.UnitTests
         {
             var comp = OpenPicker();
             // clicking a day button to select a date and close
-            comp.FindAll("div.mud-picker-calendar-day > button")
+            comp.FindAll("div.mud-picker-calendar button")
                 .Where(x => x.TrimmedText().Equals("23")).First().Click();
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0), TimeSpan.FromSeconds(5));
             comp.Instance.Date.Should().NotBeNull();
@@ -216,7 +216,7 @@ namespace MudBlazor.UnitTests
             comp.FindAll("div.mud-picker-month-container").Count.Should().Be(1);
             comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-month-container > div.mud-picker-month")
                 .Skip(2).First().Click();
-            comp.FindAll("div.mud-picker-calendar-day > button")
+            comp.FindAll("div.mud-picker-calendar button")
                 .Where(x => x.TrimmedText().Equals("2")).First().Click();
             comp.Instance.Date.Value.Date.Should().Be(new DateTime(DateTime.Now.Year, 3, 2));
         }
@@ -238,7 +238,7 @@ namespace MudBlazor.UnitTests
             comp.FindAll("div.mud-picker-month-container").Count.Should().Be(1);
             comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-month-container > div.mud-picker-month")
                 .Skip(3).First().Click();
-            comp.FindAll("div.mud-picker-calendar-day > button")
+            comp.FindAll("div.mud-picker-calendar button")
                 .Where(x => x.TrimmedText().Equals("23")).First().Click();
             comp.Instance.Date.Value.Date.Should().Be(new DateTime(DateTime.Now.Year, 4, 23));
         }
@@ -274,7 +274,7 @@ namespace MudBlazor.UnitTests
             comp.FindAll("div.mud-picker-month-container").Count.Should().Be(1);
             comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-month-container > div.mud-picker-month").Skip(1).First().Click();
             comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-calendar-header").Count.Should().Be(1);
-            comp.FindAll("div.mud-picker-calendar-day > button")
+            comp.FindAll("div.mud-picker-calendar button")
                 .Where(x => x.TrimmedText().Equals("1")).First().Click();
             comp.Instance.Date.Value.Date.Should().Be(new DateTime(2022, 2, 1));
         }

--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests .cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests .cs
@@ -81,10 +81,10 @@ namespace MudBlazor.UnitTests
         {
             var comp = OpenPicker();
             // clicking a day button to select a date
-            comp.FindAll("div.mud-picker-calendar button")
+            comp.FindAll("button.mud-picker-calendar-day")
                 .Where(x => x.TrimmedText().Equals("10")).First().Click();
             // clicking a same date then close
-            comp.FindAll("div.mud-picker-calendar button")
+            comp.FindAll("button.mud-picker-calendar-day")
                 .Where(x => x.TrimmedText().Equals("10")).First().Click();
             comp.Instance.DateRange.Start.Should().Be(comp.Instance.DateRange.End);
         }
@@ -95,9 +95,9 @@ namespace MudBlazor.UnitTests
             var start = DateTime.Now.AddMonths(-1);
             var comp = OpenPicker(Parameter(nameof(MudDateRangePicker.StartMonth), start));
             // clicking a day buttons to select a range and close
-            comp.FindAll("div.mud-picker-calendar button")
+            comp.FindAll("button.mud-picker-calendar-day")
                 .Where(x => x.TrimmedText().Equals("10")).First().Click();
-            comp.FindAll("div.mud-picker-calendar button")
+            comp.FindAll("button.mud-picker-calendar-day")
                 .Where(x => x.TrimmedText().Equals("12")).First().Click();
             //check result
             comp.Instance.DateRange.Start.Value.Month.Should().Be(start.Month);
@@ -145,9 +145,9 @@ namespace MudBlazor.UnitTests
         {
             var comp = OpenPicker();
             // clicking a day buttons to select a range and close
-            comp.FindAll("div.mud-picker-calendar button")
+            comp.FindAll("button.mud-picker-calendar-day")
                 .Where(x => x.TrimmedText().Equals("10")).First().Click();
-            comp.FindAll("div.mud-picker-calendar button")
+            comp.FindAll("button.mud-picker-calendar-day")
                 .Where(x => x.TrimmedText().Equals("23")).First().Click();
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0), TimeSpan.FromSeconds(5));
             comp.Instance.DateRange.Should().NotBeNull();
@@ -158,14 +158,14 @@ namespace MudBlazor.UnitTests
         {
             var comp = OpenPicker();
             // clicking a day buttons to select a range and close
-            comp.FindAll("div.mud-picker-calendar button")
+            comp.FindAll("button.mud-picker-calendar-day")
                 .Where(x => x.TrimmedText().Equals("10")).First().Click();
-            comp.FindAll("div.mud-picker-calendar button")
+            comp.FindAll("button.mud-picker-calendar-day")
                 .Where(x => x.TrimmedText().Equals("8")).First().Click();
             comp.FindAll("div.mud-picker-open").Count.Should().Be(1);
             comp.Instance.DateRange.Should().BeNull();
 
-            comp.FindAll("div.mud-picker-calendar button")
+            comp.FindAll("button.mud-picker-calendar-day")
                 .Where(x => x.TrimmedText().Equals("23")).First().Click();
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0), TimeSpan.FromSeconds(5));
             comp.Instance.DateRange.Should().NotBeNull();
@@ -245,9 +245,9 @@ namespace MudBlazor.UnitTests
             comp.FindAll("div.mud-picker-month-container").Count.Should().Be(1);
             comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-month-container > div.mud-picker-month")
                 .Skip(2).First().Click();
-            comp.FindAll("div.mud-picker-calendar button")
+            comp.FindAll("button.mud-picker-calendar-day")
                 .Where(x => x.TrimmedText().Equals("2")).First().Click();
-            comp.FindAll("div.mud-picker-calendar button")
+            comp.FindAll("button.mud-picker-calendar-day")
                 .Where(x => x.TrimmedText().Equals("10")).First().Click();
             comp.Instance.DateRange.Start.Should().Be(new DateTime(DateTime.Now.Year, 3, 2));
         }
@@ -269,9 +269,9 @@ namespace MudBlazor.UnitTests
             comp.FindAll("div.mud-picker-month-container").Count.Should().Be(1);
             comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-month-container > div.mud-picker-month")
                 .Skip(3).First().Click();
-            comp.FindAll("div.mud-picker-calendar button")
+            comp.FindAll("button.mud-picker-calendar-day")
                 .Where(x => x.TrimmedText().Equals("10")).First().Click();
-            comp.FindAll("div.mud-picker-calendar button")
+            comp.FindAll("button.mud-picker-calendar-day")
                 .Where(x => x.TrimmedText().Equals("12")).First().Click();
             comp.Instance.DateRange.End.Should().Be(new DateTime(DateTime.Now.Year, 4, 12));
         }
@@ -307,9 +307,9 @@ namespace MudBlazor.UnitTests
             comp.FindAll("div.mud-picker-month-container").Count.Should().Be(1);
             comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-month-container > div.mud-picker-month").Skip(1).First().Click();
             comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-calendar-header").Count.Should().Be(2);
-            comp.FindAll("div.mud-picker-calendar button")
+            comp.FindAll("button.mud-picker-calendar-day")
                 .Where(x => x.TrimmedText().Equals("1")).First().Click();
-            comp.FindAll("div.mud-picker-calendar button")
+            comp.FindAll("button.mud-picker-calendar-day")
                 .Where(x => x.TrimmedText().Equals("3")).First().Click();
             comp.Instance.DateRange.End.Should().Be(new DateTime(2022, 2, 3));
         }

--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests .cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests .cs
@@ -81,10 +81,10 @@ namespace MudBlazor.UnitTests
         {
             var comp = OpenPicker();
             // clicking a day button to select a date
-            comp.FindAll("div.mud-picker-calendar-day > button")
+            comp.FindAll("div.mud-picker-calendar button")
                 .Where(x => x.TrimmedText().Equals("10")).First().Click();
             // clicking a same date then close
-            comp.FindAll("div.mud-picker-calendar-day > button")
+            comp.FindAll("div.mud-picker-calendar button")
                 .Where(x => x.TrimmedText().Equals("10")).First().Click();
             comp.Instance.DateRange.Start.Should().Be(comp.Instance.DateRange.End);
         }
@@ -95,9 +95,9 @@ namespace MudBlazor.UnitTests
             var start = DateTime.Now.AddMonths(-1);
             var comp = OpenPicker(Parameter(nameof(MudDateRangePicker.StartMonth), start));
             // clicking a day buttons to select a range and close
-            comp.FindAll("div.mud-picker-calendar-day > button")
+            comp.FindAll("div.mud-picker-calendar button")
                 .Where(x => x.TrimmedText().Equals("10")).First().Click();
-            comp.FindAll("div.mud-picker-calendar-day > button")
+            comp.FindAll("div.mud-picker-calendar button")
                 .Where(x => x.TrimmedText().Equals("12")).First().Click();
             //check result
             comp.Instance.DateRange.Start.Value.Month.Should().Be(start.Month);
@@ -145,9 +145,9 @@ namespace MudBlazor.UnitTests
         {
             var comp = OpenPicker();
             // clicking a day buttons to select a range and close
-            comp.FindAll("div.mud-picker-calendar-day > button")
+            comp.FindAll("div.mud-picker-calendar button")
                 .Where(x => x.TrimmedText().Equals("10")).First().Click();
-            comp.FindAll("div.mud-picker-calendar-day > button")
+            comp.FindAll("div.mud-picker-calendar button")
                 .Where(x => x.TrimmedText().Equals("23")).First().Click();
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0), TimeSpan.FromSeconds(5));
             comp.Instance.DateRange.Should().NotBeNull();
@@ -158,14 +158,14 @@ namespace MudBlazor.UnitTests
         {
             var comp = OpenPicker();
             // clicking a day buttons to select a range and close
-            comp.FindAll("div.mud-picker-calendar-day > button")
+            comp.FindAll("div.mud-picker-calendar button")
                 .Where(x => x.TrimmedText().Equals("10")).First().Click();
-            comp.FindAll("div.mud-picker-calendar-day > button")
+            comp.FindAll("div.mud-picker-calendar button")
                 .Where(x => x.TrimmedText().Equals("8")).First().Click();
             comp.FindAll("div.mud-picker-open").Count.Should().Be(1);
             comp.Instance.DateRange.Should().BeNull();
 
-            comp.FindAll("div.mud-picker-calendar-day > button")
+            comp.FindAll("div.mud-picker-calendar button")
                 .Where(x => x.TrimmedText().Equals("23")).First().Click();
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0), TimeSpan.FromSeconds(5));
             comp.Instance.DateRange.Should().NotBeNull();
@@ -245,9 +245,9 @@ namespace MudBlazor.UnitTests
             comp.FindAll("div.mud-picker-month-container").Count.Should().Be(1);
             comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-month-container > div.mud-picker-month")
                 .Skip(2).First().Click();
-            comp.FindAll("div.mud-picker-calendar-day > button")
+            comp.FindAll("div.mud-picker-calendar button")
                 .Where(x => x.TrimmedText().Equals("2")).First().Click();
-            comp.FindAll("div.mud-picker-calendar-day > button")
+            comp.FindAll("div.mud-picker-calendar button")
                 .Where(x => x.TrimmedText().Equals("10")).First().Click();
             comp.Instance.DateRange.Start.Should().Be(new DateTime(DateTime.Now.Year, 3, 2));
         }
@@ -269,9 +269,9 @@ namespace MudBlazor.UnitTests
             comp.FindAll("div.mud-picker-month-container").Count.Should().Be(1);
             comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-month-container > div.mud-picker-month")
                 .Skip(3).First().Click();
-            comp.FindAll("div.mud-picker-calendar-day > button")
+            comp.FindAll("div.mud-picker-calendar button")
                 .Where(x => x.TrimmedText().Equals("10")).First().Click();
-            comp.FindAll("div.mud-picker-calendar-day > button")
+            comp.FindAll("div.mud-picker-calendar button")
                 .Where(x => x.TrimmedText().Equals("12")).First().Click();
             comp.Instance.DateRange.End.Should().Be(new DateTime(DateTime.Now.Year, 4, 12));
         }
@@ -307,9 +307,9 @@ namespace MudBlazor.UnitTests
             comp.FindAll("div.mud-picker-month-container").Count.Should().Be(1);
             comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-month-container > div.mud-picker-month").Skip(1).First().Click();
             comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-calendar-header").Count.Should().Be(2);
-            comp.FindAll("div.mud-picker-calendar-day > button")
+            comp.FindAll("div.mud-picker-calendar button")
                 .Where(x => x.TrimmedText().Equals("1")).First().Click();
-            comp.FindAll("div.mud-picker-calendar-day > button")
+            comp.FindAll("div.mud-picker-calendar button")
                 .Where(x => x.TrimmedText().Equals("3")).First().Click();
             comp.Instance.DateRange.End.Should().Be(new DateTime(2022, 2, 3));
         }

--- a/src/MudBlazor.UnitTests/Mocks/MockDomService.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockDomService.cs
@@ -13,10 +13,10 @@ namespace MudBlazor.UnitTests.Mocks
         public ValueTask ChangeCssById(string id, string css)
             => new ValueTask();
 
-        public ValueTask ChangeGlobalVariable(string variableName, int value)
+        public ValueTask ChangeGlobalCssVariable(string variableName, int value)
             => new ValueTask();
 
-        public ValueTask ChangeVariable(ElementReference element, string variableName, int value)
+        public ValueTask ChangeCssVariable(ElementReference element, string variableName, int value)
             => new ValueTask();
 
         public ValueTask<BoundingClientRect> GetBoundingClientRect(ElementReference elementReference)

--- a/src/MudBlazor.UnitTests/Mocks/MockDomService.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockDomService.cs
@@ -1,0 +1,25 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using MudBlazor.Interop;
+using MudBlazor.Services;
+
+namespace MudBlazor.UnitTests.Mocks
+{
+    public class MockDomService : IDomService
+    {
+        public ValueTask ChangeCss(ElementReference elementReference, string css)
+            => new ValueTask();
+
+        public ValueTask ChangeCssById(string id, string css)
+            => new ValueTask();
+
+        public ValueTask ChangeGlobalVariable(string variableName, int value)
+            => new ValueTask();
+
+        public ValueTask ChangeVariable(ElementReference element, string variableName, int value)
+            => new ValueTask();
+
+        public ValueTask<BoundingClientRect> GetBoundingClientRect(ElementReference elementReference)
+            => new ValueTask<BoundingClientRect>(new BoundingClientRect());
+    }
+}

--- a/src/MudBlazor/Base/MudBasePicker.cs
+++ b/src/MudBlazor/Base/MudBasePicker.cs
@@ -124,8 +124,6 @@ namespace MudBlazor
 
         protected bool IsOpen { get; set; }
 
-        internal Action<bool> OnOpenStateChanged;
-
         public void ToggleOpen()
         {
             if (IsOpen)
@@ -137,14 +135,12 @@ namespace MudBlazor
         public virtual void Close()
         {
             IsOpen = false;
-            OnOpenStateChanged?.Invoke(IsOpen);
             StateHasChanged();
         }
 
         public virtual void Open()
         {
             IsOpen = true;
-            OnOpenStateChanged?.Invoke(IsOpen);
             StateHasChanged();
         }
     }

--- a/src/MudBlazor/Base/MudBasePicker.cs
+++ b/src/MudBlazor/Base/MudBasePicker.cs
@@ -132,16 +132,21 @@ namespace MudBlazor
                 Open();
         }
 
-        public virtual void Close()
+        public void Close()
         {
             IsOpen = false;
             StateHasChanged();
+            OnClosed();
         }
 
-        public virtual void Open()
+        public void Open()
         {
             IsOpen = true;
             StateHasChanged();
+            OnOpened();
         }
+
+        protected virtual void OnClosed() { }
+        protected virtual void OnOpened() { }
     }
 }

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor
@@ -3,12 +3,12 @@
 
 <MudPicker @ref="Picker" Class="@Class" PickerVariant="@PickerVariant" Orientation="@Orientation" Label="@Label" @bind-Value="@Value"
         HelperText="@HelperText" Editable="@Editable" InputVariant="@InputVariant" Disabled="@Disabled" Adornment="@Adornment"
-        IconSize="@IconSize" InputIcon="@InputIcon" Elevation="@Elevation" Square="@Square" Rounded="@Rounded" PickerOpened="OnPickerOpened" IsRange="@IsRange">
+        IconSize="@IconSize" InputIcon="@InputIcon" Elevation="@Elevation" Square="@Square" Rounded="@Rounded" PickerOpened="OnPickerOpened" PickerClosed="OnPickerClosed" IsRange="@IsRange">
     <MudPickerToolbar Class="mud-picker-datepicker-toolbar" DisableToolbar="@DisableToolbar" Orientation="@Orientation" Color="@Color">
         <MudButton Variant="Variant.Text" Color="Color.Inherit" Class="mud-button-year" OnClick="@OnYearClick">@GetFormattedYearString()</MudButton>
         <MudButton Variant="Variant.Text" Color="Color.Inherit" Class="mud-button-date" OnClick="@OnFormattedDateClick">@GetFormattedDateString()</MudButton>
     </MudPickerToolbar>
-    <MudPickerContent>          
+    <MudPickerContent>       
         <div class="mud-picker-calendar-content @($"mud-picker-calendar-content-{MaxMonthColumns ?? DisplayMonths}")">
             @{
                 int dayId = 0;
@@ -88,10 +88,10 @@
                                     @foreach (var day in GetWeek(tempMonth, tempWeek))
                                     {
                                         var tempId = ++dayId;
-                                        <button @key="day" ticks="@day.Ticks" type="button" style="--day-id: @tempId;"
+                                        <button @key="day" type="button" style="--day-id: @tempId;"
                                                 class="mud-button-root mud-icon-button mud-ripple mud-ripple-icon mud-picker-calendar-day @GetDayClasses(tempMonth, day)"
                                                 @onclick="(() => { var d = day; OnDayClicked(d); })" 
-                                                @onmouseover="(()=> { var d = day; OnMouseOver(tempId, day); })"
+                                                onmouseover="this.closest('.mud-picker-calendar-content').style.setProperty('--selected-day', @tempId);"
                                                 disabled="@((day < MinDate) || (day > MaxDate))">
                                             <p class="mud-typography mud-typography-body2 mud-inherit-text">@day.Day</p>
                                         </button>

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor
@@ -2,7 +2,7 @@
 @inherits MudBasePicker
 
 <MudPicker @ref="Picker" Class="@Class" PickerVariant="@PickerVariant" Orientation="@Orientation" Label="@Label" @bind-Value="@Value"
-        HelperText="@HelperText" Editable="@Editable" InputVariant="@InputVariant" Disabled="@Disabled" Adornment="@Adornment"
+        HelperText="@HelperText" Editable="@Editable" InputVariant="@InputVariant" Disabled="@Disabled" Adornment="@Adornment" Style="@Style"
         IconSize="@IconSize" InputIcon="@InputIcon" Elevation="@Elevation" Square="@Square" Rounded="@Rounded" PickerOpened="OnPickerOpened" PickerClosed="OnPickerClosed" IsRange="@IsRange">
     <MudPickerToolbar Class="mud-picker-datepicker-toolbar" DisableToolbar="@DisableToolbar" Orientation="@Orientation" Color="@Color">
         <MudButton Variant="Variant.Text" Color="Color.Inherit" Class="mud-button-year" OnClick="@OnYearClick">@GetFormattedYearString()</MudButton>

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor
@@ -1,7 +1,6 @@
 ﻿@namespace MudBlazor
 @inherits MudBasePicker
 
-
 <MudPicker @ref="Picker" Class="@Class" PickerVariant="@PickerVariant" Orientation="@Orientation" Label="@Label" @bind-Value="@Value"
         HelperText="@HelperText" Editable="@Editable" InputVariant="@InputVariant" Disabled="@Disabled" Adornment="@Adornment"
         IconSize="@IconSize" InputIcon="@InputIcon" Elevation="@Elevation" Square="@Square" Rounded="@Rounded" PickerOpened="OnPickerOpened" IsRange="@IsRange">
@@ -11,6 +10,9 @@
     </MudPickerToolbar>
     <MudPickerContent>          
         <div class="mud-picker-calendar-content @($"mud-picker-calendar-content-{MaxMonthColumns ?? DisplayMonths}")">
+            @{
+                int dayId = 0;
+            }
             @for (int displayMonth = 0; displayMonth < DisplayMonths; ++displayMonth)
             {
                 int tempMonth = displayMonth; //without local variable month names are wrong
@@ -76,21 +78,24 @@
                                 @for (int week = 0; week < 6; week++)
                                 {
                                     int tempWeek = week;
-
-                                    <div class="mud-picker-calendar-week">
-                                        @if (ShowWeekNumbers)
-                                        {
-                                            <div class="mud-picker-calendar-week">
-                                                <MudText class="mud-picker-calendar-week-text" Typo="Typo.caption">@GetWeekNumber(tempMonth, tempWeek)</MudText>
-                                            </div>
-                                        }
-                                        @foreach (var day in GetWeek(tempMonth, tempWeek))
-                                        {
-                                            <div role="presentation" class="mud-picker-calendar-day">
-                                                <MudIconButton Class="@GetDayClasses(tempMonth, day)" @onmouseover="@(() => { var d = day; OnMouseOver(d); })" OnClick="@(() => { var d = day; OnDayClicked(d); })" Disabled="@((day < MinDate) || (day > MaxDate))">@day.Day</MudIconButton>
-                                            </div>
-                                        }
-                                    </div>
+                                    
+                                    @if (ShowWeekNumbers)
+                                    {
+                                        <div class="mud-picker-calendar-week">
+                                            <MudText class="mud-picker-calendar-week-text" Typo="Typo.caption">@GetWeekNumber(tempMonth, tempWeek)</MudText>
+                                        </div>
+                                    }
+                                    @foreach (var day in GetWeek(tempMonth, tempWeek))
+                                    {
+                                        var tempId = ++dayId;
+                                        <button @key="day" ticks="@day.Ticks" type="button" style="--day-id: @tempId;"
+                                                class="mud-button-root mud-icon-button mud-ripple mud-ripple-icon @GetDayClasses(tempMonth, day)"
+                                                @onclick="(() => { var d = day; OnDayClicked(d); })" 
+                                                @onmouseover="(()=> { var d = day; OnMouseOver(tempId, day); })"
+                                                disabled="@((day < MinDate) || (day > MaxDate))">
+                                            <p class="mud-typography mud-typography-body2 mud-inherit-text">@day.Day</p>
+                                        </button>
+                                    }
                                 }
                             </div>
                         </div>

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor
@@ -89,7 +89,7 @@
                                     {
                                         var tempId = ++dayId;
                                         <button @key="day" ticks="@day.Ticks" type="button" style="--day-id: @tempId;"
-                                                class="mud-button-root mud-icon-button mud-ripple mud-ripple-icon @GetDayClasses(tempMonth, day)"
+                                                class="mud-button-root mud-icon-button mud-ripple mud-ripple-icon mud-picker-calendar-day @GetDayClasses(tempMonth, day)"
                                                 @onclick="(() => { var d = day; OnDayClicked(d); })" 
                                                 @onmouseover="(()=> { var d = day; OnMouseOver(tempId, day); })"
                                                 disabled="@((day < MinDate) || (day > MaxDate))">

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -5,13 +5,19 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
 using MudBlazor.Extensions;
+using MudBlazor.Services;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
 {
     public abstract partial class MudBaseDatePicker : MudBasePicker
     {
-        [Inject] IJSRuntime JsRuntime { get; set; }
+        protected bool PreventRender = false;
+
+        [Inject] protected IJSRuntime JsRuntime { get; set; }
+
+        [Inject] protected IDomService DomService { get; set; }
+
         /// <summary>
         /// Max selectable date.
         /// </summary>
@@ -174,7 +180,10 @@ namespace MudBlazor
         /// </summary>
         protected abstract void OnDayClicked(DateTime dateTime);
 
-        protected virtual void OnMouseOver(DateTime time) { }
+        public virtual void OnMouseOver(int id, DateTime day)
+        {
+            PreventRender = true;
+        }
 
         /// <summary>
         /// return Mo, Tu, We, Th, Fr, Sa, Su in the right culture
@@ -345,6 +354,16 @@ namespace MudBlazor
         protected override void OnInitialized()
         {
             _currentView = OpenTo;
+        }
+
+        protected override bool ShouldRender()
+        {
+            if (PreventRender)
+            {
+                PreventRender = false;
+                return false;
+            }
+            return base.ShouldRender();
         }
 
         protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -12,8 +12,6 @@ namespace MudBlazor
 {
     public abstract partial class MudBaseDatePicker : MudBasePicker
     {
-        protected bool PreventRender = false;
-
         [Inject] protected IJSRuntime JsRuntime { get; set; }
 
         [Inject] protected IDomService DomService { get; set; }
@@ -112,12 +110,14 @@ namespace MudBlazor
 
         private OpenTo _currentView;
 
-        private void OnPickerOpened()
+        protected virtual void OnPickerOpened()
         {
             _currentView = OpenTo;
             if (_currentView == OpenTo.Year)
                 _scrollToYearAfterRender = true;
         }
+
+        protected virtual void OnPickerClosed() { }
 
         /// <summary>
         /// Get the first of the month to display
@@ -179,11 +179,6 @@ namespace MudBlazor
         /// User clicked on a day
         /// </summary>
         protected abstract void OnDayClicked(DateTime dateTime);
-
-        public virtual void OnMouseOver(int id, DateTime day)
-        {
-            PreventRender = true;
-        }
 
         /// <summary>
         /// return Mo, Tu, We, Th, Fr, Sa, Su in the right culture
@@ -354,16 +349,6 @@ namespace MudBlazor
         protected override void OnInitialized()
         {
             _currentView = OpenTo;
-        }
-
-        protected override bool ShouldRender()
-        {
-            if (PreventRender)
-            {
-                PreventRender = false;
-                return false;
-            }
-            return base.ShouldRender();
         }
 
         protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -26,15 +26,13 @@ namespace MudBlazor
             set => SetDateAsync(value, true).AndForget();
         }
 
-        public override void Open()
+        protected override void OnOpened()
         {
-            base.Open();
             Picker.Open();
         }
 
-        public override void Close()
+        protected override void OnClosed()
         {
-            base.Close();
             Picker.Close();
         }
 

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
-using Microsoft.JSInterop;
 using MudBlazor.Extensions;
-using MudBlazor.Services;
 using MudBlazor.Utilities;
 using static System.String;
 
@@ -24,13 +22,11 @@ namespace MudBlazor
         protected override void OnClosed()
         {
             Picker.Close();
-            _firstDate = null;
         }
 
         public MudDateRangePicker()
         {
             DisplayMonths = 2;
-            //DisableToolbar = true;
         }
 
         /// <summary>
@@ -80,6 +76,12 @@ namespace MudBlazor
         private DateRange ParseDateRangeValue(string value)
         {
             return DateRange.TryParse(value, out var dateRange) ? dateRange : null;
+        }
+
+        protected override void OnPickerClosed()
+        {
+            _firstDate = null;
+            base.OnPickerClosed();
         }
 
         protected override string GetDayClasses(int month, DateTime day)
@@ -160,12 +162,6 @@ namespace MudBlazor
                 await Task.Delay(ClosingDelay);
                 Picker.Close();
             }
-        }
-
-        public override void OnMouseOver(int id, DateTime day)
-        {
-            DomService.ChangeGlobalCssVariable("--selected-day", id);
-            base.OnMouseOver(id, day);
         }
 
         protected override string GetFormattedDateString()

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.cs
@@ -16,15 +16,13 @@ namespace MudBlazor
 
         protected override bool IsRange => true;
 
-        public override void Open()
+        protected override void OnOpened()
         {
-            base.Open();
             Picker.Open();
         }
 
-        public override void Close()
+        protected override void OnClosed()
         {
-            base.Close();
             Picker.Close();
             _firstDate = null;
         }

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.cs
@@ -26,6 +26,7 @@ namespace MudBlazor
         {
             base.Close();
             Picker.Close();
+            _firstDate = null;
         }
 
         public MudDateRangePicker()
@@ -165,7 +166,7 @@ namespace MudBlazor
 
         public override void OnMouseOver(int id, DateTime day)
         {
-            DomService.ChangeGlobalVariable("--selected-day", id);
+            DomService.ChangeGlobalCssVariable("--selected-day", id);
             base.OnMouseOver(id, day);
         }
 
@@ -177,12 +178,6 @@ namespace MudBlazor
                 return DateRange.Start.Value.ToString("dd MMM", Culture);
 
             return $"{DateRange.Start.Value.ToString("dd MMM", Culture)} - {DateRange.End.Value.ToString("dd MMM", Culture)}";
-        }
-
-        public override void Close()
-        {
-            base.Close();
-            _firstDate = null;
         }
     }
 }

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.cs
@@ -1,15 +1,17 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
 using MudBlazor.Extensions;
+using MudBlazor.Services;
 using MudBlazor.Utilities;
 using static System.String;
 
 namespace MudBlazor
 {
-    public class MudDateRangePicker : MudBaseDatePicker, IDisposable
+    public class MudDateRangePicker : MudBaseDatePicker
     {
-        private DateTime? _firstDate = null, _currentDate;
+        private DateTime? _firstDate = null;
         private DateRange _dateRange;
 
         protected override bool IsRange => true;
@@ -30,21 +32,6 @@ namespace MudBlazor
         {
             DisplayMonths = 2;
             //DisableToolbar = true;
-        }
-
-        protected override void OnAfterRender(bool firstRender)
-        {
-            base.OnAfterRender(firstRender);
-
-            if (firstRender)
-            {
-                Picker.OnOpenStateChanged += OnPickerStateChanged;
-            }
-        }
-
-        public void Dispose()
-        {
-            Picker.OnOpenStateChanged -= OnPickerStateChanged;
         }
 
         /// <summary>
@@ -104,10 +91,10 @@ namespace MudBlazor
                 return b.AddClass("mud-hidden").Build();
             }
 
-            if ((_firstDate != null && day > _firstDate && day < _currentDate) ||
-               (_firstDate == null && _dateRange != null && _dateRange.Start < day && _dateRange.End > day))
+            if (_firstDate == null && _dateRange != null && _dateRange.Start < day && _dateRange.End > day)
             {
-                return b.AddClass("mud-range")
+                return b
+                    .AddClass("mud-range")
                     .AddClass("mud-range-between")
                     .Build();
             }
@@ -118,12 +105,12 @@ namespace MudBlazor
                 return b.AddClass("mud-selected")
                     .AddClass("mud-range")
                     .AddClass("mud-range-start-selected")
+                    .AddClass("mud-range-selection", _firstDate != null)
                     .AddClass($"mud-theme-{Color.ToDescriptionString()}")
                     .Build();
             }
 
-            if ((_firstDate != null && day == _currentDate && day > _firstDate) ||
-                (_firstDate == null && _dateRange != null && _dateRange.Start != day && _dateRange.End == day))
+            if (_firstDate == null && _dateRange != null && _dateRange.Start != day && _dateRange.End == day)
             {
                 return b.AddClass("mud-selected")
                     .AddClass("mud-range")
@@ -135,6 +122,9 @@ namespace MudBlazor
             if (day == DateTime.Today)
             {
                 return b.AddClass("mud-current")
+                    .AddClass("mud-range", _firstDate != null && day > _firstDate)
+                    .AddClass("mud-range-selection", _firstDate != null && day > _firstDate)
+                    .AddClass($"mud-range-selection-{Color.ToDescriptionString()}", _firstDate != null && day > _firstDate)
                     .AddClass($"mud-{Color.ToDescriptionString()}-text")
                     .Build();
             }
@@ -143,9 +133,12 @@ namespace MudBlazor
             {
                 return b.AddClass("mud-selected").AddClass($"mud-theme-{Color.ToDescriptionString()}").Build();
             }
-            else if (_firstDate != null)
+            else if (_firstDate != null && day > _firstDate)
             {
-                return b.AddClass("mud-range").Build();
+                return b.AddClass("mud-range")
+                    .AddClass("mud-range-selection")
+                    .AddClass($"mud-range-selection-{Color.ToDescriptionString()}", _firstDate != null)
+                    .Build();
             }
 
             return b.Build();
@@ -162,7 +155,6 @@ namespace MudBlazor
             await SetDateRangeAsync(new DateRange(_firstDate, dateTime), true);
 
             _firstDate = null;
-            _currentDate = null;
 
             if (PickerVariant != PickerVariant.Static)
             {
@@ -171,12 +163,10 @@ namespace MudBlazor
             }
         }
 
-        protected override void OnMouseOver(DateTime dateTime)
+        public override void OnMouseOver(int id, DateTime day)
         {
-            if (_firstDate != null)
-            {
-                _currentDate = dateTime;
-            }
+            DomService.ChangeGlobalVariable("--selected-day", id);
+            base.OnMouseOver(id, day);
         }
 
         protected override string GetFormattedDateString()
@@ -189,12 +179,10 @@ namespace MudBlazor
             return $"{DateRange.Start.Value.ToString("dd MMM", Culture)} - {DateRange.End.Value.ToString("dd MMM", Culture)}";
         }
 
-        private void OnPickerStateChanged(bool args)
+        public override void Close()
         {
-            if (!args)
-            {
-                _firstDate = null;
-            }
+            base.Close();
+            _firstDate = null;
         }
     }
 }

--- a/src/MudBlazor/Components/Picker/MudPicker.razor
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor
@@ -6,7 +6,7 @@
     {
         @if (!IsRange) 
         { 
-            <MudTextField Label="@Label" @bind-Text="@Value" HelperText="@HelperText" Variant="@InputVariant" ReadOnly="@(!Editable)" T="string"
+            <MudTextField Label="@Label" @bind-Text="@Value" HelperText="@HelperText" Variant="@InputVariant" ReadOnly="@(!Editable)" T="string" Style="@Style"
                           @onclick="@(() => { if (!Editable) ToggleState(); })" OnAdornmentClick="ToggleState" Disabled="@Disabled" Adornment="@Adornment" AdornmentIcon="@InputIcon" IconSize="@IconSize" />
         }
         else 

--- a/src/MudBlazor/Components/Picker/MudPicker.razor
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor
@@ -1,7 +1,4 @@
 @namespace MudBlazor
-@using Microsoft.JSInterop
-@using MudBlazor.Interop
-@using MudBlazor.Utilities
 @inherits MudBasePicker
 
 <div class="@PickerClass">

--- a/src/MudBlazor/Components/Picker/MudPicker.razor
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor
@@ -10,14 +10,14 @@
         @if (!IsRange) 
         { 
             <MudTextField Label="@Label" @bind-Text="@Value" HelperText="@HelperText" Variant="@InputVariant" ReadOnly="@(!Editable)" T="string"
-                          @onclick="@(() => { if (!Editable) ToggleOpen(); })" OnAdornmentClick="ToggleOpen" Disabled="@Disabled" Adornment="@Adornment" AdornmentIcon="@InputIcon" IconSize="@IconSize" />
+                          @onclick="@(() => { if (!Editable) ToggleState(); })" OnAdornmentClick="ToggleState" Disabled="@Disabled" Adornment="@Adornment" AdornmentIcon="@InputIcon" IconSize="@IconSize" />
         }
         else 
         {
-            <MudInputControl Label="@Label" Variant="@InputVariant" HelperText="@HelperText" Disabled="@Disabled" @onclick="@(() => { if (!Editable) ToggleOpen(); })">
+            <MudInputControl Label="@Label" Variant="@InputVariant" HelperText="@HelperText" Disabled="@Disabled" @onclick="@(() => { if (!Editable) ToggleState(); })">
                 <InputContent>
                     <MudRangeInput @attributes="UserAttributes" InputType="@InputType.Text" Class="@PickerInputClass" Style="@Style" Variant="@InputVariant" ReadOnly="@(!Editable)" T="string"
-                                   @bind-Text="@Value" Disabled=@Disabled Adornment="@Adornment" AdornmentIcon="@InputIcon" IconSize="@IconSize" OnAdornmentClick="ToggleOpen"/>
+                                   @bind-Text="@Value" Disabled=@Disabled Adornment="@Adornment" AdornmentIcon="@InputIcon" IconSize="@IconSize" OnAdornmentClick="ToggleState"/>
                 </InputContent>
             </MudInputControl>
         }

--- a/src/MudBlazor/Components/Picker/MudPicker.razor
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor
@@ -25,17 +25,19 @@
     <CascadingValue Value="@this" IsFixed="true">
         @if (IsOpen && PickerVariant != PickerVariant.Dialog)
         {
-            <MudPaper @attributes="UserAttributes" Class="@PickerPaperClass" Elevation="@_pickerElevation" Square="@_pickerSquare">
-                <div @ref="_pickerContainerRef" class="@PickerContainerClass">
-                    @ChildContent
-                </div>
-            </MudPaper>
+            <div @ref="_pickerPaperRef" class="@PickerPaperClass">
+                <MudPaper @attributes="UserAttributes" Elevation="@_pickerElevation" Square="@_pickerSquare">
+                    <div class="@PickerContainerClass">
+                        @ChildContent
+                    </div>
+                </MudPaper>
+            </div>
         }
         else if(IsOpen && PickerVariant == PickerVariant.Dialog)
         {
             <MudOverlay Visible="IsOpen" OnClick="@Close" DarkBackground="true" Class="mud-overlay-dialog">
                 <MudPaper @attributes="UserAttributes" Class="@PickerPaperClass" Elevation="@_pickerElevation" Square="@_pickerSquare">
-                    <div @ref="_pickerContainerRef" class="@PickerContainerClass">
+                    <div class="@PickerContainerClass">
                         @ChildContent
                     </div>
                 </MudPaper>

--- a/src/MudBlazor/Components/Picker/MudPicker.razor
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor
@@ -20,15 +20,23 @@
         }
     }
     <CascadingValue Value="@this" IsFixed="true">
-        @if (IsOpen && PickerVariant != PickerVariant.Dialog)
+        @if (IsOpen && PickerVariant == PickerVariant.Inline)
         {
-            <div @ref="_pickerPaperRef" class="@PickerPaperClass">
-                <MudPaper @attributes="UserAttributes" Elevation="@_pickerElevation" Square="@_pickerSquare">
+            <div @ref="_pickerInlineRef" class="@PickerInlineClass">
+                <MudPaper @attributes="UserAttributes" Class="@PickerPaperClass" Elevation="@_pickerElevation" Square="@_pickerSquare">
                     <div class="@PickerContainerClass">
                         @ChildContent
                     </div>
                 </MudPaper>
             </div>
+        }
+        else if (IsOpen && PickerVariant == PickerVariant.Static)
+        {
+            <MudPaper @attributes="UserAttributes" Class="@PickerPaperClass" Elevation="@_pickerElevation" Square="@_pickerSquare">
+                <div class="@PickerContainerClass">
+                    @ChildContent
+                </div>
+            </MudPaper>
         }
         else if(IsOpen && PickerVariant == PickerVariant.Dialog)
         {

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -167,12 +167,6 @@ namespace MudBlazor
                 return;
             }
 
-            if (size.Width < clientRect.Right)
-            {
-                _pickerHorizontalPosition = size.Width > clientRect.Width ?
-                    PickerHorizontalPosition.Right : PickerHorizontalPosition.Left;
-            }
-
             if (size.Height < clientRect.Height)
             {
                 _pickerVerticalPosition = PickerVerticalPosition.Top;
@@ -199,6 +193,25 @@ namespace MudBlazor
             else
             {
                 _pickerVerticalPosition = PickerVerticalPosition.Below;
+            }
+
+            if (size.Width < clientRect.Right &&
+                (_pickerVerticalPosition == PickerVerticalPosition.Above ||
+                _pickerVerticalPosition == PickerVerticalPosition.Below))
+            {
+                if (clientRect.Left - clientRect.Width + 226 /*width of the input*/ > 0)
+                {
+                    _pickerHorizontalPosition = PickerHorizontalPosition.Right;
+                }
+                else if (clientRect.Left + clientRect.Width / 2 < size.Width)
+                {
+                    _pickerHorizontalPosition = PickerHorizontalPosition.Left;
+                }
+            }
+            else if (size.Width < clientRect.Right)
+            {
+                _pickerHorizontalPosition = size.Width > clientRect.Width ?
+                    PickerHorizontalPosition.Right : PickerHorizontalPosition.Left;
             }
         }
     }

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -107,9 +107,22 @@ namespace MudBlazor
             }
         }
 
-        public override void Open()
+        private void ToggleState()
         {
-            IsOpen = true;
+            if (IsOpen)
+            {
+                IsOpen = false;
+                OnClosed();
+            }
+            else
+            {
+                IsOpen = true;
+                OnOpened();
+            }
+        }
+
+        protected override void OnOpened()
+        {
             OnPickerOpened();
 
             if (PickerVariant == PickerVariant.Inline)
@@ -123,9 +136,8 @@ namespace MudBlazor
             }
         }
 
-        public override void Close()
+        protected override void OnClosed()
         {
-            base.Close();
             _pickerVerticalPosition = PickerVerticalPosition.Unknown;
         }
 

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -1,8 +1,5 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
-using Microsoft.JSInterop;
-using MudBlazor.Extensions;
-using MudBlazor.Interop;
 using MudBlazor.Services;
 using MudBlazor.Utilities;
 
@@ -72,6 +69,7 @@ namespace MudBlazor
         [Parameter] public RenderFragment ChildContent { get; set; }
 
         [Parameter] public EventCallback PickerOpened { get; set; }
+        [Parameter] public EventCallback PickerClosed { get; set; }
 
         private bool _pickerSquare;
         private int _pickerElevation;
@@ -121,29 +119,31 @@ namespace MudBlazor
             }
         }
 
-        protected override void OnOpened()
+        protected override async void OnOpened()
         {
             OnPickerOpened();
 
             if (PickerVariant == PickerVariant.Inline)
             {
-                InvokeAsync(async () =>
-                {
-                    await DeterminePosition();
-                    //StateHasChanged();
-                    await DomService.ChangeCss(_pickerPaperRef, PickerPaperClass);
-                });
+                await DeterminePosition();
+                await DomService.ChangeCss(_pickerPaperRef, PickerPaperClass);
             }
         }
 
         protected override void OnClosed()
         {
+            OnPickerClosed();
             _pickerVerticalPosition = PickerVerticalPosition.Unknown;
         }
 
         protected virtual void OnPickerOpened()
         {
             PickerOpened.InvokeAsync(this);
+        }
+
+        protected virtual void OnPickerClosed()
+        {
+            PickerClosed.InvokeAsync(this);
         }
 
         private async Task DeterminePosition()

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -45,6 +45,10 @@ namespace MudBlazor
             .AddClass("mud-picker-open", IsOpen && PickerVariant == PickerVariant.Inline)
             .AddClass("mud-picker-popover-paper", PickerVariant == PickerVariant.Inline)
             .AddClass("mud-dialog", PickerVariant == PickerVariant.Dialog)
+            .Build();
+
+        protected string PickerInlineClass =>
+        new CssBuilder("mud-picker-inline-paper")
             .AddClass("mud-picker-hidden", _pickerVerticalPosition == PickerVerticalPosition.Unknown && PickerVariant == PickerVariant.Inline)
             .AddClass("mud-picker-pos-top", _pickerVerticalPosition == PickerVerticalPosition.Top)
             .AddClass("mud-picker-pos-above", _pickerVerticalPosition == PickerVerticalPosition.Above)
@@ -52,7 +56,7 @@ namespace MudBlazor
             .AddClass("mud-picker-pos-below", _pickerVerticalPosition == PickerVerticalPosition.Below)
             .AddClass("mud-picker-pos-left", _pickerHorizontalPosition == PickerHorizontalPosition.Left)
             .AddClass("mud-picker-pos-right", _pickerHorizontalPosition == PickerHorizontalPosition.Right)
-            .Build();
+        .Build();
 
         protected string PickerContainerClass =>
         new CssBuilder("mud-picker-container")
@@ -73,7 +77,7 @@ namespace MudBlazor
 
         private bool _pickerSquare;
         private int _pickerElevation;
-        private ElementReference _pickerPaperRef;
+        private ElementReference _pickerInlineRef;
 
         private PickerVerticalPosition _pickerVerticalPosition = PickerVerticalPosition.Unknown;
         private PickerHorizontalPosition _pickerHorizontalPosition = PickerHorizontalPosition.Unknown;
@@ -126,7 +130,7 @@ namespace MudBlazor
             if (PickerVariant == PickerVariant.Inline)
             {
                 await DeterminePosition();
-                await DomService.ChangeCss(_pickerPaperRef, PickerPaperClass);
+                await DomService.ChangeCss(_pickerInlineRef, PickerInlineClass);
             }
         }
 
@@ -155,7 +159,7 @@ namespace MudBlazor
             }
 
             var size = await WindowSizeListener.GetBrowserWindowSize();
-            var clientRect = await DomService.GetBoundingClientRect(_pickerPaperRef);
+            var clientRect = await DomService.GetBoundingClientRect(_pickerInlineRef);
 
             if (size == null || clientRect == null)
             {

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -26,10 +26,9 @@ namespace MudBlazor
             Right
         }
 
-        [Inject] IDomService DomService { get; set; }
+        [Inject] private IDomService DomService { get; set; }
 
-        [Inject]
-        private IBrowserWindowSizeProvider WindowSizeListener { get; set; }
+        [Inject] private IBrowserWindowSizeProvider WindowSizeListener { get; set; }
 
         protected string PickerClass =>
         new CssBuilder("mud-picker")

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor
 @inherits MudBasePicker
 
-<MudPicker @ref="Picker" Class="@Class" PickerVariant="@PickerVariant" 
+<MudPicker @ref="Picker" Class="@Class" PickerVariant="@PickerVariant" Style="@Style"
         Orientation="@Orientation" Label="@Label" @bind-Value="@Value" HelperText="@HelperText" InputVariant="@InputVariant" 
         Editable="@Editable" Disabled="@Disabled" Adornment="@Adornment" IconSize="@IconSize" InputIcon="@InputIcon" 
         Elevation="@Elevation" Square="@Square" Rounded="@Rounded" PickerOpened="OnPickerOpened">

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor
@@ -1,6 +1,5 @@
 ﻿@namespace MudBlazor
 @inherits MudBasePicker
-@using System.Globalization 
 
 <MudPicker @ref="Picker" Class="@Class" PickerVariant="@PickerVariant" 
         Orientation="@Orientation" Label="@Label" @bind-Value="@Value" HelperText="@HelperText" InputVariant="@InputVariant" 

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor
 @inherits MudBasePicker
-
+@using System.Globalization 
 
 <MudPicker @ref="Picker" Class="@Class" PickerVariant="@PickerVariant" 
         Orientation="@Orientation" Label="@Label" @bind-Value="@Value" HelperText="@HelperText" InputVariant="@InputVariant" 
@@ -34,13 +34,14 @@
                             @*Hours from 1 to 12*@
                             for(int i = 1; i <= 12; ++i)
                             {
-                                var angle =  (6 - i) * 30;
-                                <MudText Class="@GetNumberColor(i)" Style="@($"transform: translate{Math.Sin(angle) * 109}px, {(Math.Cos(angle) + 1) * 109 + 5}px);")">i</MudText>
+                                var _i = i;
+                                var angle =  (6 - _i) * 30;
+                                <MudText Class="@GetNumberColor(_i)" Style="@GetTransform(angle, 109, 0, 5)">@_i</MudText>
                             }
                             for(int i = 1; i <= 12; ++i)
                             {
                                 var _i = i;
-                                <div class="mud-picker-stick mud-hour" style="@($"transform: rotateZ({i * 30}deg);")" @onclick="@(() => OnMouseClickHour(_i))" @onmouseover="@(() => OnMouseOverHour(_i))" @onclick:stopPropagation="true"></div>
+                                <div class="mud-picker-stick mud-hour" style="@($"transform: rotateZ({_i * 30}deg);")" @onclick="@(() => OnMouseClickHour(_i))" @onmouseover="@(() => OnMouseOverHour(_i))" @onclick:stopPropagation="true"></div>
                             }
                         }
                         else
@@ -48,19 +49,21 @@
                             @*Hours from 13 to 24 (00)*@
                             for(int i = 1; i <= 12; ++i)
                             {
-                                var angle =  (6 - i) * 30;
-                                <MudText Class="@GetNumberColor((i + 12) % 24)" Style="@($"transform: translate{Math.Sin(angle) * 109}px, {(Math.Cos(angle) + 1) * 109 + 5}px);")">((i + 12) % 24).ToString("D2")</MudText>
+                                var _i = i;
+                                var angle =  (6 - _i) * 30;
+                                <MudText Class="@GetNumberColor((_i + 12) % 24)" Style="@GetTransform(angle, 109, 0, 5)">@(((_i + 12) % 24).ToString("D2"))</MudText>
                             }
                             @*Hours from 1 to 12*@
                             for(int i = 1; i <= 12; ++i)
                             {
-                                var angle =  (6 - i) * 30;
-                                <MudText Class="@GetNumberColor(i)" Typo="Typo.body2" Style="@($"transform: translate{Math.Sin(angle) * 74}px, {(Math.Cos(angle) + 1) * 138 + 40}px);")">i.ToString("D2")</MudText>
+                                var _i = i;
+                                var angle =  (6 - _i) * 30;
+                                <MudText Class="@GetNumberColor(_i)" Typo="Typo.body2" Style="@GetTransform(angle, 74, 0, 40)">@(_i.ToString("D2"))</MudText>
                             }
                             for(int i = 1; i <= 12; ++i)
                             {
                                 var _i = i;
-                                <div class="mud-picker-stick" style="@($"transform: rotateZ({i * 30}deg);")">
+                                <div class="mud-picker-stick" style="@($"transform: rotateZ({_i * 30}deg);")">
                                     <div class="mud-picker-stick-inner mud-hour" @onclick="@(() => OnMouseClickHour(_i))" @onmouseover="@(() => OnMouseOverHour(_i))" @onclick:stopPropagation="true"></div>
                                     <div class="mud-picker-stick-outer mud-hour" @onclick="@(() => OnMouseClickHour(_i + 12))" @onmouseover="@(() => OnMouseOverHour(_i + 12))" @onclick:stopPropagation="true"></div>
                                 </div>
@@ -71,13 +74,14 @@
                         @*Minutes from 05 to 60 (00) - step 5*@                     
                         @for (int i = 0; i < 12; ++i)
                         {
-                            var angle =  (6 - i) * 30;
-                            <MudText Class="@GetNumberColor(i * 5)" Style="@($"transform: translate{Math.Sin(angle) * 109}px, {(Math.Cos(angle) + 1) * 109 + 5}px);")">(i * 5).ToString("D2")</MudText>
+                            var _i = i;
+                            var angle =  (6 - _i) * 30;
+                            <MudText Class="@GetNumberColor(_i * 5)" Style="@GetTransform(angle, 109, 0, 5)">@((_i * 5).ToString("D2"))</MudText>
                         }
                         @for (int i = 0; i < 60; ++i)
                         {
                             var _i = i;
-                            <div class="mud-picker-stick mud-minute" style="@($"transform: rotateZ({i * 6}deg);")" @onclick="@(() => OnMouseClickMinute(_i))" @onmouseover="@(() => OnMouseOverMinute(_i))" @onclick:stopPropagation="true"></div>
+                            <div class="mud-picker-stick mud-minute" style="@($"transform: rotateZ({_i * 6}deg);")" @onclick="@(() => OnMouseClickMinute(_i))" @onmouseover="@(() => OnMouseOverMinute(_i))" @onclick:stopPropagation="true"></div>
                         }
                     </div>
                 </div>

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor
@@ -31,181 +31,54 @@
                     <div class="@HourDialClass">
                         @if (AmPm)
                         {
-                            <MudText Class="@GetNumberColor(1)" Style="transform: translate(55px, 19.6px);">1</MudText>
-                            <MudText Class="@GetNumberColor(2)" Style="transform: translate(94.4px, 59.5px);">2</MudText>
-                            <MudText Class="@GetNumberColor(3)" Style="transform: translate(109px, 114px);">3</MudText>
-                            <MudText Class="@GetNumberColor(4)" Style="transform: translate(94.4px, 168.5px);">4</MudText>
-                            <MudText Class="@GetNumberColor(5)" Style="transform: translate(54.5px, 208.4px);">5</MudText>
-                            <MudText Class="@GetNumberColor(6)" Style="transform: translate(0px, 223px);">6</MudText>
-                            <MudText Class="@GetNumberColor(7)" Style="transform: translate(-54.5px, 208.4px);">7</MudText>
-                            <MudText Class="@GetNumberColor(8)" Style="transform: translate(-94.4px, 168.5px);">8</MudText>
-                            <MudText Class="@GetNumberColor(9)" Style="transform: translate(-109px, 114px);">9</MudText>
-                            <MudText Class="@GetNumberColor(10)" Style="transform: translate(-94.4px, 59.5px);">10</MudText>
-                            <MudText Class="@GetNumberColor(11)" Style="transform: translate(-54.5px, 19.6px);">11</MudText>
-                            <MudText Class="@GetNumberColor(12)" Style="transform: translate(0px, 5px);">12</MudText>
-                            <div class="mud-picker-stick mud-hour" style="transform: rotateZ(30deg);" @onclick="@(() => OnMouseClickHour(1))" @onmouseover="@(() => OnMouseOverHour(1))" @onclick:stopPropagation="true"></div>
-                            <div class="mud-picker-stick mud-hour" style="transform: rotateZ(60deg);" @onclick="@(() => OnMouseClickHour(2))" @onmouseover="@(() => OnMouseOverHour(2))" @onclick:stopPropagation="true"></div>
-                            <div class="mud-picker-stick mud-hour" style="transform: rotateZ(90deg);" @onclick="@(() => OnMouseClickHour(3))" @onmouseover="@(() => OnMouseOverHour(3))" @onclick:stopPropagation="true"></div>
-                            <div class="mud-picker-stick mud-hour" style="transform: rotateZ(120deg);" @onclick="@(() => OnMouseClickHour(4))" @onmouseover="@(() => OnMouseOverHour(4))" @onclick:stopPropagation="true"></div>
-                            <div class="mud-picker-stick mud-hour" style="transform: rotateZ(150deg);" @onclick="@(() => OnMouseClickHour(5))" @onmouseover="@(() => OnMouseOverHour(5))" @onclick:stopPropagation="true"></div>
-                            <div class="mud-picker-stick mud-hour" style="transform: rotateZ(180deg);" @onclick="@(() => OnMouseClickHour(6))" @onmouseover="@(() => OnMouseOverHour(6))" @onclick:stopPropagation="true"></div>
-                            <div class="mud-picker-stick mud-hour" style="transform: rotateZ(210deg);" @onclick="@(() => OnMouseClickHour(7))" @onmouseover="@(() => OnMouseOverHour(7))" @onclick:stopPropagation="true"></div>
-                            <div class="mud-picker-stick mud-hour" style="transform: rotateZ(240deg);" @onclick="@(() => OnMouseClickHour(8))" @onmouseover="@(() => OnMouseOverHour(8))" @onclick:stopPropagation="true"></div>
-                            <div class="mud-picker-stick mud-hour" style="transform: rotateZ(270deg);" @onclick="@(() => OnMouseClickHour(9))" @onmouseover="@(() => OnMouseOverHour(9))" @onclick:stopPropagation="true"></div>
-                            <div class="mud-picker-stick mud-hour" style="transform: rotateZ(300deg);" @onclick="@(() => OnMouseClickHour(10))" @onmouseover="@(() => OnMouseOverHour(10))" @onclick:stopPropagation="true"></div>
-                            <div class="mud-picker-stick mud-hour" style="transform: rotateZ(330deg);" @onclick="@(() => OnMouseClickHour(11))" @onmouseover="@(() => OnMouseOverHour(11))" @onclick:stopPropagation="true"></div>
-                            <div class="mud-picker-stick mud-hour" style="transform: rotateZ(0deg);" @onclick="@(() => OnMouseClickHour(12))" @onmouseover="@(() => OnMouseOverHour(12))" @onclick:stopPropagation="true"></div>
+                            @*Hours from 1 to 12*@
+                            for(int i = 1; i <= 12; ++i)
+                            {
+                                var angle =  (6 - i) * 30;
+                                <MudText Class="@GetNumberColor(i)" Style="@($"transform: translate{Math.Sin(angle) * 109}px, {(Math.Cos(angle) + 1) * 109 + 5}px);")">i</MudText>
+                            }
+                            for(int i = 1; i <= 12; ++i)
+                            {
+                                var _i = i;
+                                <div class="mud-picker-stick mud-hour" style="@($"transform: rotateZ({i * 30}deg);")" @onclick="@(() => OnMouseClickHour(_i))" @onmouseover="@(() => OnMouseOverHour(_i))" @onclick:stopPropagation="true"></div>
+                            }
                         }
                         else
                         {
-                            <MudText Class="@GetNumberColor(13)" Style="transform: translate(55px, 19.6px);">13</MudText>
-                            <MudText Class="@GetNumberColor(14)" Style="transform: translate(94.4px, 59.5px);">14</MudText>
-                            <MudText Class="@GetNumberColor(15)" Style="transform: translate(109px, 114px);">15</MudText>
-                            <MudText Class="@GetNumberColor(16)" Style="transform: translate(94.4px, 168.5px);">16</MudText>
-                            <MudText Class="@GetNumberColor(17)" Style="transform: translate(54.5px, 208.4px);">17</MudText>
-                            <MudText Class="@GetNumberColor(18)" Style="transform: translate(0px, 223px);">18</MudText>
-                            <MudText Class="@GetNumberColor(19)" Style="transform: translate(-54.5px, 208.4px);">19</MudText>
-                            <MudText Class="@GetNumberColor(20)" Style="transform: translate(-94.4px, 168.5px);">20</MudText>
-                            <MudText Class="@GetNumberColor(21)" Style="transform: translate(-109px, 114px);">21</MudText>
-                            <MudText Class="@GetNumberColor(22)" Style="transform: translate(-94.4px, 59.5px);">22</MudText>
-                            <MudText Class="@GetNumberColor(23)" Style="transform: translate(-54.5px, 19.6px);">23</MudText>
-                            <MudText Class="@GetNumberColor(00)" Style="transform: translate(0px, 5px);">00</MudText>
-                            <MudText Class="@GetNumberColor(12)" Typo="Typo.body2" Style="transform: translate(0px, 40px);">12</MudText>
-                            <MudText Class="@GetNumberColor(01)" Typo="Typo.body2" Style="transform: translate(36.9px, 49.9px);">01</MudText>
-                            <MudText Class="@GetNumberColor(02)" Typo="Typo.body2" Style="transform: translate(64px, 77px);">02</MudText>
-                            <MudText Class="@GetNumberColor(03)" Typo="Typo.body2" Style="transform: translate(74px, 114px);">03</MudText>
-                            <MudText Class="@GetNumberColor(04)" Typo="Typo.body2" Style="transform: translate(64px, 151px);">04</MudText>
-                            <MudText Class="@GetNumberColor(05)" Typo="Typo.body2" Style="transform: translate(37px, 178px);">05</MudText>
-                            <MudText Class="@GetNumberColor(06)" Typo="Typo.body2" Style="transform: translate(0px, 188px);">06</MudText>
-                            <MudText Class="@GetNumberColor(07)" Typo="Typo.body2" Style="transform: translate(-37px, 178px);">07</MudText>
-                            <MudText Class="@GetNumberColor(08)" Typo="Typo.body2" Style="transform: translate(-64px, 151px);">08</MudText>
-                            <MudText Class="@GetNumberColor(09)" Typo="Typo.body2" Style="transform: translate(-74px, 114px);">09</MudText>
-                            <MudText Class="@GetNumberColor(10)" Typo="Typo.body2" Style="transform: translate(-64px, 77px);">10</MudText>
-                            <MudText Class="@GetNumberColor(11)" Typo="Typo.body2" Style="transform: translate(-37px, 50px);">11</MudText>
-
-                            <div class="mud-picker-stick" style="transform: rotateZ(30deg);">
-                                <div class="mud-picker-stick-inner mud-hour" @onclick="@(() => OnMouseClickHour(1))" @onmouseover="@(() => OnMouseOverHour(1))" @onclick:stopPropagation="true"></div>
-                                <div class="mud-picker-stick-outer mud-hour" @onclick="@(() => OnMouseClickHour(13))" @onmouseover="@(() => OnMouseOverHour(13))" @onclick:stopPropagation="true"></div>
-                            </div>
-                            <div class="mud-picker-stick" style="transform: rotateZ(60deg);">
-                                <div class="mud-picker-stick-inner mud-hour" @onclick="@(() => OnMouseClickHour(2))" @onmouseover="@(() => OnMouseOverHour(2))" @onclick:stopPropagation="true"></div>
-                                <div class="mud-picker-stick-outer mud-hour" @onclick="@(() => OnMouseClickHour(14))" @onmouseover="@(() => OnMouseOverHour(14))" @onclick:stopPropagation="true"></div>
-                            </div>
-                            <div class="mud-picker-stick" style="transform: rotateZ(90deg);">
-                                <div class="mud-picker-stick-inner mud-hour" @onclick="@(() => OnMouseClickHour(3))" @onmouseover="@(() => OnMouseOverHour(3))" @onclick:stopPropagation="true"></div>
-                                <div class="mud-picker-stick-outer mud-hour" @onclick="@(() => OnMouseClickHour(15))" @onmouseover="@(() => OnMouseOverHour(15))" @onclick:stopPropagation="true"></div>
-                            </div>
-                            <div class="mud-picker-stick" style="transform: rotateZ(120deg);">
-                                <div class="mud-picker-stick-inner mud-hour" @onclick="@(() => OnMouseClickHour(4))" @onmouseover="@(() => OnMouseOverHour(4))" @onclick:stopPropagation="true"></div>
-                                <div class="mud-picker-stick-outer mud-hour" @onclick="@(() => OnMouseClickHour(16))" @onmouseover="@(() => OnMouseOverHour(16))" @onclick:stopPropagation="true"></div>
-                            </div>
-                            <div class="mud-picker-stick" style="transform: rotateZ(150deg);">
-                                <div class="mud-picker-stick-inner mud-hour" @onclick="@(() => OnMouseClickHour(5))" @onmouseover="@(() => OnMouseOverHour(5))" @onclick:stopPropagation="true"></div>
-                                <div class="mud-picker-stick-outer mud-hour" @onclick="@(() => OnMouseClickHour(17))" @onmouseover="@(() => OnMouseOverHour(17))" @onclick:stopPropagation="true"></div>
-                            </div>
-                            <div class="mud-picker-stick" style="transform: rotateZ(180deg);">
-                                <div class="mud-picker-stick-inner mud-hour" @onclick="@(() => OnMouseClickHour(6))" @onmouseover="@(() => OnMouseOverHour(6))" @onclick:stopPropagation="true"></div>
-                                <div class="mud-picker-stick-outer mud-hour" @onclick="@(() => OnMouseClickHour(18))" @onmouseover="@(() => OnMouseOverHour(18))" @onclick:stopPropagation="true"></div>
-                            </div>
-                            <div class="mud-picker-stick" style="transform: rotateZ(210deg);">
-                                <div class="mud-picker-stick-inner mud-hour" @onclick="@(() => OnMouseClickHour(7))" @onmouseover="@(() => OnMouseOverHour(7))" @onclick:stopPropagation="true"></div>
-                                <div class="mud-picker-stick-outer mud-hour" @onclick="@(() => OnMouseClickHour(19))" @onmouseover="@(() => OnMouseOverHour(19))" @onclick:stopPropagation="true"></div>
-                            </div>
-                            <div class="mud-picker-stick" style="transform: rotateZ(240deg);">
-                                <div class="mud-picker-stick-inner mud-hour" @onclick="@(() => OnMouseClickHour(8))" @onmouseover="@(() => OnMouseOverHour(8))" @onclick:stopPropagation="true"></div>
-                                <div class="mud-picker-stick-outer mud-hour" @onclick="@(() => OnMouseClickHour(20))" @onmouseover="@(() => OnMouseOverHour(20))" @onclick:stopPropagation="true"></div>
-                            </div>
-                            <div class="mud-picker-stick" style="transform: rotateZ(270deg);">
-                                <div class="mud-picker-stick-inner mud-hour" @onclick="@(() => OnMouseClickHour(9))" @onmouseover="@(() => OnMouseOverHour(9))" @onclick:stopPropagation="true"></div>
-                                <div class="mud-picker-stick-outer mud-hour" @onclick="@(() => OnMouseClickHour(21))" @onmouseover="@(() => OnMouseOverHour(21))" @onclick:stopPropagation="true"></div>
-                            </div>
-                            <div class="mud-picker-stick" style="transform: rotateZ(300deg);">
-                                <div class="mud-picker-stick-inner mud-hour" @onclick="@(() => OnMouseClickHour(10))" @onmouseover="@(() => OnMouseOverHour(10))" @onclick:stopPropagation="true"></div>
-                                <div class="mud-picker-stick-outer mud-hour" @onclick="@(() => OnMouseClickHour(22))" @onmouseover="@(() => OnMouseOverHour(22))" @onclick:stopPropagation="true"></div>
-                            </div>
-                            <div class="mud-picker-stick" style="transform: rotateZ(330deg);">
-                                <div class="mud-picker-stick-inner mud-hour" @onclick="@(() => OnMouseClickHour(11))" @onmouseover="@(() => OnMouseOverHour(11))" @onclick:stopPropagation="true"></div>
-                                <div class="mud-picker-stick-outer mud-hour" @onclick="@(() => OnMouseClickHour(23))" @onmouseover="@(() => OnMouseOverHour(23))" @onclick:stopPropagation="true"></div>
-                            </div>
-                            <div class="mud-picker-stick" style="transform: rotateZ(0deg);">
-                                <div class="mud-picker-stick-inner mud-hour" @onclick="@(() => OnMouseClickHour(12))" @onmouseover="@(() => OnMouseOverHour(12))" @onclick:stopPropagation="true"></div>
-                                <div class="mud-picker-stick-outer mud-hour" @onclick="@(() => OnMouseClickHour(00))" @onmouseover="@(() => OnMouseOverHour(00))" @onclick:stopPropagation="true"></div>
-                            </div>
+                            @*Hours from 13 to 24 (00)*@
+                            for(int i = 1; i <= 12; ++i)
+                            {
+                                var angle =  (6 - i) * 30;
+                                <MudText Class="@GetNumberColor((i + 12) % 24)" Style="@($"transform: translate{Math.Sin(angle) * 109}px, {(Math.Cos(angle) + 1) * 109 + 5}px);")">((i + 12) % 24).ToString("D2")</MudText>
+                            }
+                            @*Hours from 1 to 12*@
+                            for(int i = 1; i <= 12; ++i)
+                            {
+                                var angle =  (6 - i) * 30;
+                                <MudText Class="@GetNumberColor(i)" Typo="Typo.body2" Style="@($"transform: translate{Math.Sin(angle) * 74}px, {(Math.Cos(angle) + 1) * 138 + 40}px);")">i.ToString("D2")</MudText>
+                            }
+                            for(int i = 1; i <= 12; ++i)
+                            {
+                                var _i = i;
+                                <div class="mud-picker-stick" style="@($"transform: rotateZ({i * 30}deg);")">
+                                    <div class="mud-picker-stick-inner mud-hour" @onclick="@(() => OnMouseClickHour(_i))" @onmouseover="@(() => OnMouseOverHour(_i))" @onclick:stopPropagation="true"></div>
+                                    <div class="mud-picker-stick-outer mud-hour" @onclick="@(() => OnMouseClickHour(_i + 12))" @onmouseover="@(() => OnMouseOverHour(_i + 12))" @onclick:stopPropagation="true"></div>
+                                </div>
+                            }
                         }
                     </div>
-                    <div class="@MinuteDialClass">
-                        <MudText Class="@GetNumberColor(05)" Style="transform: translate(55px, 19.6px);">05</MudText>
-                        <MudText Class="@GetNumberColor(10)" Style="transform: translate(94.4px, 59.5px);">10</MudText>
-                        <MudText Class="@GetNumberColor(15)" Style="transform: translate(109px, 114px);">15</MudText>
-                        <MudText Class="@GetNumberColor(20)" Style="transform: translate(94.4px, 168.5px);">20</MudText>
-                        <MudText Class="@GetNumberColor(25)" Style="transform: translate(54.5px, 208.4px);">25</MudText>
-                        <MudText Class="@GetNumberColor(30)" Style="transform: translate(0px, 223px);">30</MudText>
-                        <MudText Class="@GetNumberColor(35)" Style="transform: translate(-54.5px, 208.4px);">35</MudText>
-                        <MudText Class="@GetNumberColor(40)" Style="transform: translate(-94.4px, 168.5px);">40</MudText>
-                        <MudText Class="@GetNumberColor(45)" Style="transform: translate(-109px, 114px);">45</MudText>
-                        <MudText Class="@GetNumberColor(50)" Style="transform: translate(-94.4px, 59.5px);">50</MudText>
-                        <MudText Class="@GetNumberColor(55)" Style="transform: translate(-54.5px, 19.6px);">55</MudText>
-                        <MudText Class="@GetNumberColor(00)" Style="transform: translate(0px, 5px);">00</MudText>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(0deg);" @onclick="@(() => OnMouseClickMinute(00))" @onmouseover="@(() => OnMouseOverMinute(00))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(6deg);" @onclick="@(() => OnMouseClickMinute(1))" @onmouseover="@(() => OnMouseOverMinute(1))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(12deg);" @onclick="@(() => OnMouseClickMinute(2))" @onmouseover="@(() => OnMouseOverMinute(2))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(18deg);" @onclick="@(() => OnMouseClickMinute(3))" @onmouseover="@(() => OnMouseOverMinute(3))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(24deg);" @onclick="@(() => OnMouseClickMinute(4))" @onmouseover="@(() => OnMouseOverMinute(4))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(30deg);" @onclick="@(() => OnMouseClickMinute(5))" @onmouseover="@(() => OnMouseOverMinute(5))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(36deg);" @onclick="@(() => OnMouseClickMinute(6))" @onmouseover="@(() => OnMouseOverMinute(6))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(42deg);" @onclick="@(() => OnMouseClickMinute(7))" @onmouseover="@(() => OnMouseOverMinute(7))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(48deg);" @onclick="@(() => OnMouseClickMinute(8))" @onmouseover="@(() => OnMouseOverMinute(8))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(54deg);" @onclick="@(() => OnMouseClickMinute(9))" @onmouseover="@(() => OnMouseOverMinute(9))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(60deg);" @onclick="@(() => OnMouseClickMinute(10))" @onmouseover="@(() => OnMouseOverMinute(10))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(66deg);" @onclick="@(() => OnMouseClickMinute(11))" @onmouseover="@(() => OnMouseOverMinute(11))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(72deg);" @onclick="@(() => OnMouseClickMinute(12))" @onmouseover="@(() => OnMouseOverMinute(12))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(78deg);" @onclick="@(() => OnMouseClickMinute(13))" @onmouseover="@(() => OnMouseOverMinute(13))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(84deg);" @onclick="@(() => OnMouseClickMinute(14))" @onmouseover="@(() => OnMouseOverMinute(14))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(90deg);" @onclick="@(() => OnMouseClickMinute(15))" @onmouseover="@(() => OnMouseOverMinute(15))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(96deg);" @onclick="@(() => OnMouseClickMinute(16))" @onmouseover="@(() => OnMouseOverMinute(16))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(102deg);" @onclick="@(() => OnMouseClickMinute(17))" @onmouseover="@(() => OnMouseOverMinute(17))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(108deg);" @onclick="@(() => OnMouseClickMinute(18))" @onmouseover="@(() => OnMouseOverMinute(18))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(114deg);" @onclick="@(() => OnMouseClickMinute(19))" @onmouseover="@(() => OnMouseOverMinute(19))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(120deg);" @onclick="@(() => OnMouseClickMinute(20))" @onmouseover="@(() => OnMouseOverMinute(20))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(126deg);" @onclick="@(() => OnMouseClickMinute(21))" @onmouseover="@(() => OnMouseOverMinute(21))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(132deg);" @onclick="@(() => OnMouseClickMinute(22))" @onmouseover="@(() => OnMouseOverMinute(22))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(138deg);" @onclick="@(() => OnMouseClickMinute(23))" @onmouseover="@(() => OnMouseOverMinute(23))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(144deg);" @onclick="@(() => OnMouseClickMinute(24))" @onmouseover="@(() => OnMouseOverMinute(24))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(150deg);" @onclick="@(() => OnMouseClickMinute(25))" @onmouseover="@(() => OnMouseOverMinute(25))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(156deg);" @onclick="@(() => OnMouseClickMinute(26))" @onmouseover="@(() => OnMouseOverMinute(26))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(162deg);" @onclick="@(() => OnMouseClickMinute(27))" @onmouseover="@(() => OnMouseOverMinute(27))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(168deg);" @onclick="@(() => OnMouseClickMinute(28))" @onmouseover="@(() => OnMouseOverMinute(28))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(174deg);" @onclick="@(() => OnMouseClickMinute(29))" @onmouseover="@(() => OnMouseOverMinute(29))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(180deg);" @onclick="@(() => OnMouseClickMinute(30))" @onmouseover="@(() => OnMouseOverMinute(30))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(186deg);" @onclick="@(() => OnMouseClickMinute(31))" @onmouseover="@(() => OnMouseOverMinute(31))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(192deg);" @onclick="@(() => OnMouseClickMinute(32))" @onmouseover="@(() => OnMouseOverMinute(32))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(198deg);" @onclick="@(() => OnMouseClickMinute(33))" @onmouseover="@(() => OnMouseOverMinute(33))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(204deg);" @onclick="@(() => OnMouseClickMinute(34))" @onmouseover="@(() => OnMouseOverMinute(34))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(210deg);" @onclick="@(() => OnMouseClickMinute(35))" @onmouseover="@(() => OnMouseOverMinute(35))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(216deg);" @onclick="@(() => OnMouseClickMinute(36))" @onmouseover="@(() => OnMouseOverMinute(36))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(222deg);" @onclick="@(() => OnMouseClickMinute(37))" @onmouseover="@(() => OnMouseOverMinute(37))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(228deg);" @onclick="@(() => OnMouseClickMinute(38))" @onmouseover="@(() => OnMouseOverMinute(38))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(234deg);" @onclick="@(() => OnMouseClickMinute(39))" @onmouseover="@(() => OnMouseOverMinute(39))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(240deg);" @onclick="@(() => OnMouseClickMinute(40))" @onmouseover="@(() => OnMouseOverMinute(40))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(246deg);" @onclick="@(() => OnMouseClickMinute(41))" @onmouseover="@(() => OnMouseOverMinute(41))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(252deg);" @onclick="@(() => OnMouseClickMinute(42))" @onmouseover="@(() => OnMouseOverMinute(42))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(258deg);" @onclick="@(() => OnMouseClickMinute(43))" @onmouseover="@(() => OnMouseOverMinute(43))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(264deg);" @onclick="@(() => OnMouseClickMinute(44))" @onmouseover="@(() => OnMouseOverMinute(44))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(270deg);" @onclick="@(() => OnMouseClickMinute(45))" @onmouseover="@(() => OnMouseOverMinute(45))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(276deg);" @onclick="@(() => OnMouseClickMinute(46))" @onmouseover="@(() => OnMouseOverMinute(46))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(282deg);" @onclick="@(() => OnMouseClickMinute(47))" @onmouseover="@(() => OnMouseOverMinute(47))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(288deg);" @onclick="@(() => OnMouseClickMinute(48))" @onmouseover="@(() => OnMouseOverMinute(48))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(294deg);" @onclick="@(() => OnMouseClickMinute(49))" @onmouseover="@(() => OnMouseOverMinute(49))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(300deg);" @onclick="@(() => OnMouseClickMinute(50))" @onmouseover="@(() => OnMouseOverMinute(50))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(306deg);" @onclick="@(() => OnMouseClickMinute(51))" @onmouseover="@(() => OnMouseOverMinute(51))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(312deg);" @onclick="@(() => OnMouseClickMinute(52))" @onmouseover="@(() => OnMouseOverMinute(52))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(318deg);" @onclick="@(() => OnMouseClickMinute(53))" @onmouseover="@(() => OnMouseOverMinute(53))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(324deg);" @onclick="@(() => OnMouseClickMinute(54))" @onmouseover="@(() => OnMouseOverMinute(54))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(330deg);" @onclick="@(() => OnMouseClickMinute(55))" @onmouseover="@(() => OnMouseOverMinute(55))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(336deg);" @onclick="@(() => OnMouseClickMinute(56))" @onmouseover="@(() => OnMouseOverMinute(56))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(342deg);" @onclick="@(() => OnMouseClickMinute(57))" @onmouseover="@(() => OnMouseOverMinute(57))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(348deg);" @onclick="@(() => OnMouseClickMinute(58))" @onmouseover="@(() => OnMouseOverMinute(58))" @onclick:stopPropagation="true"></div>
-                        <div class="mud-picker-stick mud-minute" style="transform: rotateZ(354deg);" @onclick="@(() => OnMouseClickMinute(59))" @onmouseover="@(() => OnMouseOverMinute(59))" @onclick:stopPropagation="true"></div>
+                    <div class="@MinuteDialClass">   
+                        @*Minutes from 05 to 60 (00) - step 5*@                     
+                        @for (int i = 0; i < 12; ++i)
+                        {
+                            var angle =  (6 - i) * 30;
+                            <MudText Class="@GetNumberColor(i * 5)" Style="@($"transform: translate{Math.Sin(angle) * 109}px, {(Math.Cos(angle) + 1) * 109 + 5}px);")">(i * 5).ToString("D2")</MudText>
+                        }
+                        @for (int i = 0; i < 60; ++i)
+                        {
+                            var _i = i;
+                            <div class="mud-picker-stick mud-minute" style="@($"transform: rotateZ({i * 6}deg);")" @onclick="@(() => OnMouseClickMinute(_i))" @onmouseover="@(() => OnMouseOverMinute(_i))" @onclick:stopPropagation="true"></div>
+                        }
                     </div>
                 </div>
             </div>

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -246,6 +246,14 @@ namespace MudBlazor
             return deg;
         }
 
+        private string GetTransform(double angle, double radius, double offsetX, double offsetY)
+        {
+            angle = angle / 180 * Math.PI;
+            var x = (Math.Sin(angle) * radius + offsetX).ToString("F3", CultureInfo.InvariantCulture);
+            var y = ((Math.Cos(angle) + 1) * radius + offsetY).ToString("F3", CultureInfo.InvariantCulture);
+            return $"transform: translate({x}px, {y}px);";
+        }
+
         private string GetPointerRotation()
         {
             double deg = 0;

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -383,15 +383,13 @@ namespace MudBlazor
 
         }
 
-        public override void Open()
+        protected override void OnOpened()
         {
-            base.Open();
             Picker.Open();
         }
 
-        public override void Close()
+        protected override void OnClosed()
         {
-            base.Close();
             Picker.Close();
         }
 

--- a/src/MudBlazor/Services/DomService.cs
+++ b/src/MudBlazor/Services/DomService.cs
@@ -36,6 +36,6 @@ namespace MudBlazor.Services
             _jsRuntime.InvokeVoidAsync("changeGlobalCssVariable", variableName, value);
         
         public ValueTask ChangeCssVariable(ElementReference element, string variableName, int value) =>
-            _jsRuntime.InvokeVoidAsync("changeGlobalCssVariable", element, variableName, value);
+            _jsRuntime.InvokeVoidAsync("changeCssVariable", element, variableName, value);
     }
 }

--- a/src/MudBlazor/Services/DomService.cs
+++ b/src/MudBlazor/Services/DomService.cs
@@ -1,0 +1,41 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+using MudBlazor.Interop;
+
+namespace MudBlazor.Services
+{
+    public interface IDomService
+    {
+        ValueTask ChangeCssById(string id, string css);
+        ValueTask ChangeCss(ElementReference elementReference, string css);
+        ValueTask<BoundingClientRect> GetBoundingClientRect(ElementReference elementReference);
+        ValueTask ChangeGlobalVariable(string variableName, int value);
+        ValueTask ChangeVariable(ElementReference element, string variableName, int value);
+    }
+
+    public class DomService : IDomService
+    {
+        private IJSRuntime _jsRuntime;
+
+        public DomService(IJSRuntime jsRuntime)
+        {
+            _jsRuntime = jsRuntime;
+        }
+
+        public ValueTask ChangeCssById(string id, string css) =>
+            _jsRuntime.InvokeVoidAsync("changeCssById", id, css);
+
+        public ValueTask ChangeCss(ElementReference elementReference, string css) =>
+            _jsRuntime.InvokeVoidAsync("changeCss", elementReference, css);
+
+        public ValueTask<BoundingClientRect> GetBoundingClientRect(ElementReference elementReference) =>
+            _jsRuntime.InvokeAsync<BoundingClientRect>("getMudBoundingClientRect", elementReference);
+
+        public ValueTask ChangeGlobalVariable(string variableName, int value) =>
+            _jsRuntime.InvokeVoidAsync("changeGlobalVariable", variableName, value);
+
+        public ValueTask ChangeVariable(ElementReference element, string variableName, int value) =>
+            _jsRuntime.InvokeVoidAsync("changeGlobalVariable", element, variableName, value);
+    }
+}

--- a/src/MudBlazor/Services/DomService.cs
+++ b/src/MudBlazor/Services/DomService.cs
@@ -10,8 +10,8 @@ namespace MudBlazor.Services
         ValueTask ChangeCssById(string id, string css);
         ValueTask ChangeCss(ElementReference elementReference, string css);
         ValueTask<BoundingClientRect> GetBoundingClientRect(ElementReference elementReference);
-        ValueTask ChangeGlobalVariable(string variableName, int value);
-        ValueTask ChangeVariable(ElementReference element, string variableName, int value);
+        ValueTask ChangeGlobalCssVariable(string variableName, int value);
+        ValueTask ChangeCssVariable(ElementReference element, string variableName, int value);
     }
 
     public class DomService : IDomService
@@ -32,10 +32,10 @@ namespace MudBlazor.Services
         public ValueTask<BoundingClientRect> GetBoundingClientRect(ElementReference elementReference) =>
             _jsRuntime.InvokeAsync<BoundingClientRect>("getMudBoundingClientRect", elementReference);
 
-        public ValueTask ChangeGlobalVariable(string variableName, int value) =>
-            _jsRuntime.InvokeVoidAsync("changeGlobalVariable", variableName, value);
-
-        public ValueTask ChangeVariable(ElementReference element, string variableName, int value) =>
-            _jsRuntime.InvokeVoidAsync("changeGlobalVariable", element, variableName, value);
+        public ValueTask ChangeGlobalCssVariable(string variableName, int value) =>
+            _jsRuntime.InvokeVoidAsync("changeGlobalCssVariable", variableName, value);
+        
+        public ValueTask ChangeCssVariable(ElementReference element, string variableName, int value) =>
+            _jsRuntime.InvokeVoidAsync("changeGlobalCssVariable", element, variableName, value);
     }
 }

--- a/src/MudBlazor/Services/ServiceCollectionExtensions.cs
+++ b/src/MudBlazor/Services/ServiceCollectionExtensions.cs
@@ -100,6 +100,17 @@ namespace MudBlazor.Services
         }
 
         /// <summary>
+        /// Adds Dom manipulation service as a Scoped instance.
+        /// </summary>
+        /// <param name="services">IServiceCollection</param>
+        /// <returns>Continues the IServiceCollection chain.</returns>
+        public static IServiceCollection AddMudBlazorDom(this IServiceCollection services)
+        {
+            services.TryAddScoped<IDomService, DomService>();
+            return services;
+        }
+
+        /// <summary>
         /// Adds common services required by MudBlazor components
         /// </summary>
         /// <param name="services">IServiceCollection</param>
@@ -114,7 +125,8 @@ namespace MudBlazor.Services
                 .AddMudBlazorSnackbar(configuration.SnackbarConfiguration)
                 .AddMudBlazorResizeListener(configuration.ResizeOptions)
                 .AddMudBlazorScrollManager()
-                .AddMudBlazorScrollListener();
+                .AddMudBlazorScrollListener()
+                .AddMudBlazorDom();
         }
 
         /// <summary>
@@ -134,7 +146,8 @@ namespace MudBlazor.Services
                 .AddMudBlazorSnackbar(options.SnackbarConfiguration)
                 .AddMudBlazorResizeListener(options.ResizeOptions)
                 .AddMudBlazorScrollManager()
-                .AddMudBlazorScrollListener();
+                .AddMudBlazorScrollListener()
+                .AddMudBlazorDom();
         }
     }
 }

--- a/src/MudBlazor/Styles/components/_picker.scss
+++ b/src/MudBlazor/Styles/components/_picker.scss
@@ -148,11 +148,12 @@
     visibility: visible;
 
     &.mud-picker-pos-left {
-        left: 10px;
+        left: 50%;
+        transform: translateX(-50%);
     }
 
     &.mud-picker-pos-right {
-        right: 10px;
+        right: 0px;
     }
 }
 
@@ -174,10 +175,11 @@
     visibility: visible;
 
     &.mud-picker-pos-left {
-        left: 10px;
+        left: 50%;
+        transform: translateX(-50%);
     }
 
     &.mud-picker-pos-right {
-        right: 10px;
+        right: 0px;
     }
 }

--- a/src/MudBlazor/Styles/components/_picker.scss
+++ b/src/MudBlazor/Styles/components/_picker.scss
@@ -116,6 +116,15 @@
     }
 }
 
+.mud-picker-inline-paper {
+    position: absolute;
+    z-index: calc(var(--mud-zindex-popover) + 1);
+    
+    .mud-paper {
+        position: relative !important;
+    }
+}
+
 .mud-picker-hidden {
     visibility: hidden;
 }

--- a/src/MudBlazor/Styles/components/_pickerdate.scss
+++ b/src/MudBlazor/Styles/components/_pickerdate.scss
@@ -1,9 +1,5 @@
 ﻿@import '../abstracts/variables';
 
-:root {
-    --selected-day: 0;
-}
-
 .mud-picker-datepicker-toolbar {
     align-items: flex-start;
     flex-direction: column;
@@ -165,6 +161,7 @@
 
 .mud-picker-calendar-content {
     display: grid;
+    --selected-day: 0;
     grid-column-gap: 10px;
     grid-template-columns: auto;
 }
@@ -246,9 +243,11 @@
     }
 }
 
-.mud-picker-calendar-header-last {
-    .mud-picker-nav-button-next {
-        visibility: visible !important;
+:not(.mud-picker-hidden) {
+    .mud-picker-calendar-header-last {
+        .mud-picker-nav-button-next {
+            visibility: visible !important;
+        }
     }
 }
 

--- a/src/MudBlazor/Styles/components/_pickerdate.scss
+++ b/src/MudBlazor/Styles/components/_pickerdate.scss
@@ -251,6 +251,12 @@
     }
 }
 
+.mud-picker-hidden {
+    .mud-picker-nav-button-next, .mud-picker-nav-button-prev {
+        visibility: hidden !important;
+    }
+}
+
 .mud-picker-calendar-container {
     display: flex;
     width: 310px;

--- a/src/MudBlazor/Styles/components/_pickerdate.scss
+++ b/src/MudBlazor/Styles/components/_pickerdate.scss
@@ -1,4 +1,10 @@
-﻿.mud-picker-datepicker-toolbar {
+﻿@import '../abstracts/variables';
+
+:root {
+    --selected-day: 0;
+}
+
+.mud-picker-datepicker-toolbar {
     align-items: flex-start;
     flex-direction: column;
 
@@ -253,65 +259,87 @@
 }
 
 .mud-picker-calendar {
-    .mud-picker-calendar-week {
-        display: flex;
-        justify-content: center;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
 
-        .mud-picker-calendar-day {
-            .mud-day {
-                color: var(--mud-palette-text-primary);
-                width: 36px;
-                height: 36px;
-                margin: 0 2px;
-                padding: 0;
-                font-size: 0.75rem;
-                font-weight: 500;
+    .mud-day {
+        color: var(--mud-palette-text-primary);
+        width: 36px;
+        height: 36px;
+        margin: 0 2px;
+        padding: 0;
+        font-size: 0.75rem;
+        font-weight: 500;
 
-                &:hover {
-                    background-color: var(--mud-palette-action-default-hover);
+        &:hover {
+            background-color: var(--mud-palette-action-default-hover);
+        }
+
+        &.mud-hidden {
+            opacity: 0;
+            pointer-events: none;
+        }
+
+        &.mud-current {
+            font-weight: 600;
+        }
+
+        &.mud-selected {
+            font-weight: 500;
+        }
+
+        .mud-typography {
+            margin-top: 2px;
+        }
+
+        &.mud-disabled {
+            color: var(--mud-palette-text-disabled);
+            pointer-events: none;
+        }
+
+        &.mud-range {
+            margin: 0;
+            width: 40px;
+            transition: none;
+
+            &.mud-range-start-selected {
+                border-radius: 50% 0% 0% 50%;
+            }
+
+            &.mud-range-end-selected {
+                border-radius: 0% 50% 50% 0%;
+            }
+
+            &.mud-range-between {
+                border-radius: 0;
+                background-color: var(--mud-palette-action-default-hover);
+            }
+
+            &.mud-range-selection:hover {
+                &.mud-range-start-selected {
+                    border-radius: 50%;
                 }
 
-                &.mud-hidden {
-                    opacity: 0;
-                    pointer-events: none;
-                }
-
-                &.mud-current {
-                    font-weight: 600;
-                }
-
-                &.mud-selected {
-                    font-weight: 500;
-                }
-
-                .mud-typography {
-                    margin-top: 2px;
-                }
-
-                &.mud-disabled {
-                    color: var(--mud-palette-text-disabled);
-                    pointer-events: none;
-                }
-
-                &.mud-range {
-                    margin: 0;
-                    width: 40px;
-                    transition: none;
-
-                    &.mud-range-start-selected {
-                        border-radius: 50% 0% 0% 50%;
-                    }
-
-                    &.mud-range-end-selected {
-                        border-radius: 0% 50% 50% 0%;
-                    }
-
-                    &.mud-range-between {
-                        border-radius: 0;
-                        background-color: var(--mud-palette-action-default-hover);
-                    }
+                &:not(.mud-range-start-selected) {
+                    border-radius: 0% 50% 50% 0%;
                 }
             }
+
+            &.mud-range-selection:not(:hover):not(.mud-range-start-selected) {
+                border-radius: 0;
+                background: linear-gradient(var(--mud-palette-action-default-hover) 100%, var(--mud-palette-action-default-hover) 100%, transparent 0%);
+                background-size: 100% calc(100% * (var(--selected-day) - var(--day-id)));
+            }
+        }
+    }
+}
+
+@each $color in $mud-palette-colors {
+    .mud-range-selection-#{$color} {
+        &:hover {
+            color: var(--mud-palette-#{$color}-text) !important;
+            background-color: var(--mud-palette-#{$color}) !important;
         }
     }
 }

--- a/src/MudBlazor/TScripts/DOM.js
+++ b/src/MudBlazor/TScripts/DOM.js
@@ -13,11 +13,11 @@ window.changeCssById = (id, css) => {
     }
 };
 
-window.changeGlobalVariable = (name, newValue) => {
+window.changeGlobalCssVariable = (name, newValue) => {
     document.documentElement.style.setProperty(name, newValue);
 };
 
-window.changeVariable = (element, name, newValue) => {
+window.changeCssVariable = (element, name, newValue) => {
     element.style.setProperty(name, newValue);
 };
 

--- a/src/MudBlazor/TScripts/DOM.js
+++ b/src/MudBlazor/TScripts/DOM.js
@@ -2,6 +2,25 @@
     return element.getBoundingClientRect();
 };
 
+window.changeCss = (element, css) => {
+    element.className = css;
+};
+
+window.changeCssById = (id, css) => {
+    var element = document.getElementById(id);
+    if (element) {
+        element.className = css;
+    }
+};
+
+window.changeGlobalVariable = (name, newValue) => {
+    document.documentElement.style.setProperty(name, newValue);
+};
+
+window.changeVariable = (element, name, newValue) => {
+    element.style.setProperty(name, newValue);
+};
+
 window.addTranstionEndListener = (element, dotnet) => {
     element.addEventListener("transitionend", function () {
         dotnet.invokeMethodAsync("TransitionEnd");


### PR DESCRIPTION
This PR addresses #578 Main changes:
- Reduce the number of renders on picker opening. This is currently one
- The date picker has a mouseover event on each day, which raises new render. This was eliminated by overriding the `ShouldRender `method.
- Datepicker days are replaced with simple html and I removed MudIconButtons. Basically I copied the rendered html, but this also improves performace.
- Range selection "animation" can be done with pure css with a small javascript. No additional renders are necessary.
- I make some changes in the timepicker razor code, because basically it looked like a lot of copy-paste. If you  don't like it, I can revert this change.
- (Also I adjusted the tests to the changes in the rendered DOM)