### PR TITLE
Backto defaults disable vendor prefix

### DIFF
--- a/src/MudBlazor.Docs/excubowebcompiler.json
+++ b/src/MudBlazor.Docs/excubowebcompiler.json
@@ -19,7 +19,7 @@
     }
   },
   "Autoprefix": {
-    "Enabled": true,
+    "Enabled": false,
     "ProcessingOptions": {
       "Browsers": [
         "last 4 versions"

--- a/src/MudBlazor/excubowebcompiler.json
+++ b/src/MudBlazor/excubowebcompiler.json
@@ -3,17 +3,40 @@
     "GZip": false,
     "Enabled": true,
     "Css": {
+      "CommentMode": "Important",
+      "ColorNames": "Hex",
       "TermSemicolons": true,
-      "OutputMode": "SingleLine"
+      "OutputMode": "SingleLine",
+      "IndentSize": 2
+    },
+    "Javascript": {
+      "RenameLocals": true,
+      "PreserveImportantComments": true,
+      "EvalTreatment": "Ignore",
+      "TermSemicolons": true,
+      "OutputMode": "SingleLine",
+      "IndentSize": 2
     }
   },
-  "Javascript": {
-    "RenameLocals": true,
-    "PreserveImportantComments": true,
-    "EvalTreatment": "Ignore",
-    "TermSemicolons": true,
-    "OutputMode": "SingleLine",
-    "IndentSize": 2
+  "Autoprefix": {
+    "Enabled": false,
+    "ProcessingOptions": {
+      "Browsers": [
+        "last 4 versions"
+      ],
+      "Cascade": true,
+      "Add": true,
+      "Remove": true,
+      "Supports": true,
+      "Flexbox": "All",
+      "Grid": "None",
+      "IgnoreUnknownVersions": false,
+      "Stats": "",
+      "SourceMap": true,
+      "InlineSourceMap": false,
+      "SourceMapIncludeContents": false,
+      "OmitSourceMapUrl": false
+    }
   },
   "CompilerSettings": {
     "Sass": {


### PR DESCRIPTION
- We revert to the default config file so we can see the settings
- We turn of vendor prefixing.  We should let the compiler take care of this really.
@Garderoben 