### PR TITLE
Add test for DateChanged event count

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -128,6 +128,22 @@ namespace MudBlazor.UnitTests
         }
 
         [Test]
+        public void Open_CloseBySelectingADate_CheckClosed_Check_DateChangedCount()
+        {
+            var eventCount = 0;
+            DateTime? returnDate = null;
+            var comp = OpenPicker(EventCallback("DateChanged", (DateTime? date) => { eventCount++; returnDate = date; }));
+            // clicking a day button to select a date and close
+            comp.FindAll("div.mud-picker-calendar-day > button")
+                .Where(x => x.TrimmedText().Equals("23")).First().Click();
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0), TimeSpan.FromSeconds(5));
+            comp.Instance.Date.Should().NotBeNull();
+            eventCount.Should().Be(1);
+            var now = DateTime.Now;
+            returnDate.Should().Be(new DateTime(now.Year, now.Month, 23));
+        }
+
+        [Test]
         public void OpenToYear_CheckYearsShown()
         {
             var comp = OpenPicker(Parameter("OpenTo", OpenTo.Year));


### PR DESCRIPTION
- Recently I thought I saw DateChanged fired twice when doing some debugging.
- I wrote test to make sure it is always one after selecting a date.