### PR TITLE
Fix coverage bug in coverlet 3.0.0 -> 3.0.1

### DIFF
--- a/src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj
+++ b/src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="bunit" Version="1.0.0-preview-01" />
-    <PackageReference Include="coverlet.msbuild" Version="3.0.0">
+    <PackageReference Include="coverlet.msbuild" Version="3.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
- Easiest increase in code coverage ever
- There was a bug in coverlet introduced in 3.0.0 that wasn't counting some covered lines
- Coverage is now just over 80%