### PR TITLE
Project changes for F5 from clone experience

### DIFF
--- a/src/MudBlazor.Docs/MudBlazor.Docs.csproj
+++ b/src/MudBlazor.Docs/MudBlazor.Docs.csproj
@@ -2,14 +2,6 @@
 <!--Use: dotnet msbuild -preprocess:<fileName>.xml to evaluate this project-->
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
-  <!--Make sure this projects build targets run before other referenced projects-->
-  <PropertyGroup>
-    <BuildDependsOn>
-      CompileDocs;
-      $(BuildDependsOn)
-    </BuildDependsOn>
-  </PropertyGroup>
-
   <PropertyGroup>
     <ResolveStaticWebAssetsInputsDependsOn>
       IncludeGeneratedStaticFiles;

--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -68,15 +68,13 @@
   </Target>
 
   <ItemGroup>
-    <None Include="..\.editorconfig" Link=".editorconfig" />
-    <None Include="bundleconfig.json">
-      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
-    </None>
-    <None Include="compilerconfig.json">
+    <None Include="..\.editorconfig" Link=".editorconfig">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </None>
     <None Include="excubocompilerconfig.json">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </None>
+    <None Remove="compilerconfig.json"/>
+    <None Remove="DoNotRemove.txt"/>
   </ItemGroup>
 </Project>

--- a/src/MudBlazor/wwwroot/DoNotRemove.txt
+++ b/src/MudBlazor/wwwroot/DoNotRemove.txt
@@ -1,0 +1,1 @@
+This file keeps thw wwwroot alive in the repo so we can build from clone.


### PR DESCRIPTION
- As described
- We recently stopped getting static assets css and js in the docs site F5 from clone.  We want that for a good clone F5 experience for new devs
- This restores that functionality by adding a placehoder file to keep the static assets directory alive.