### PR TITLE
Avoid async call in ToggleIconButton property setter

### DIFF
--- a/src/MudBlazor/Components/Button/MudToggleIconButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudToggleIconButton.razor.cs
@@ -63,8 +63,16 @@ namespace MudBlazor
 
         public Task Toggle()
         {
-            Toggled = !Toggled;
-            return ToggledChanged.InvokeAsync(Toggled);
+            return SetToggledAsync(!Toggled);
+        }
+
+        protected async Task SetToggledAsync(bool toggled)
+        {
+            if (Toggled != toggled)
+            {
+                Toggled = toggled;
+                await ToggledChanged.InvokeAsync(Toggled);
+            }
         }
     }
 }

--- a/src/MudBlazor/Components/Button/MudToggleIconButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudToggleIconButton.razor.cs
@@ -6,25 +6,10 @@ namespace MudBlazor
 {
     public partial class MudToggleIconButton
     {
-        private bool _toggled;
-
         /// <summary>
         /// The toggled value.
         /// </summary>
-        [Parameter] public bool Toggled
-        {
-            get => _toggled;
-            set => SetToggledAsync(value).AndForget();
-        }
-
-        protected async Task SetToggledAsync(bool toggled)
-        {
-            if (_toggled != toggled)
-            {
-                _toggled = toggled;
-                await ToggledChanged.InvokeAsync(_toggled);
-            }
-        }
+        [Parameter] public bool Toggled { get; set; }
 
         /// <summary>
         /// Fires whenever toggled is changed. 
@@ -78,7 +63,8 @@ namespace MudBlazor
 
         public Task Toggle()
         {
-            return SetToggledAsync(!Toggled);
+            Toggled = !Toggled;
+            return ToggledChanged.InvokeAsync(Toggled);
         }
     }
 }


### PR DESCRIPTION
Finally found that managing the Changed event inside the property setter is redondant according to Blazor lifecycle.

State propagation for multiple buttons bound to same variable is still working and is validated by a test I pushed sooner in a previous PR.

