### PR TITLE
Avoid async calls in BooleanInput property setters

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -313,18 +313,16 @@ namespace MudBlazor.UnitTests
             // select elements needed for the test
             var table = comp.FindComponent<MudTable<int>>().Instance;
             var text = comp.FindComponent<MudText>();
-            var checkboxes = comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).ToArray();
+            var checkboxRendered = comp.FindComponents<MudCheckBox<bool>>().ToArray();
+            var checkboxes = checkboxRendered.Select(x => x.Instance).ToArray();
             table.SelectedItems.Count.Should().Be(1); // selected items should be empty
             comp.Find("p").TextContent.Should().Be("SelectedItems { 1 }");
             checkboxes.Sum(x => x.Checked ? 1 : 0).Should().Be(1);
             checkboxes[0].Checked.Should().Be(false);
             checkboxes[2].Checked.Should().Be(true);
             // uncheck it
-            comp.InvokeAsync(() =>
-            {
-                checkboxes[2].Checked = false;
-            });
-            comp.WaitForState(() => checkboxes[2].Checked == false);
+            checkboxRendered[2].Find("input").Change(false);
+            // check result
             table.SelectedItems.Count.Should().Be(0);
             comp.Find("p").TextContent.Should().Be("SelectedItems {  }");
             checkboxes.Sum(x => x.Checked ? 1 : 0).Should().Be(0);
@@ -342,16 +340,13 @@ namespace MudBlazor.UnitTests
             // select elements needed for the test
             var table = comp.FindComponent<MudTable<int>>().Instance;
             var text = comp.FindComponent<MudText>();
-            var checkboxes = comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).ToArray();
+            var checkboxRendered = comp.FindComponents<MudCheckBox<bool>>().ToArray();
+            var checkboxes = checkboxRendered.Select(x => x.Instance).ToArray();
             table.SelectedItems.Count.Should().Be(3);
             comp.Find("p").TextContent.Should().Be("SelectedItems { 0, 1, 2 }");
             checkboxes.Sum(x => x.Checked ? 1 : 0).Should().Be(4);
             // uncheck only row 1 => header checkbox should be off then
-            comp.InvokeAsync(() =>
-            {
-                checkboxes[2].Checked = false;
-            });
-            comp.WaitForState(() => checkboxes[2].Checked == false);
+            checkboxRendered[2].Find("input").Change(false);
             checkboxes[0].Checked.Should().Be(false); // header checkbox should be off
             table.SelectedItems.Count.Should().Be(2);
             comp.Find("p").TextContent.Should().Be("SelectedItems { 0, 2 }");
@@ -370,12 +365,13 @@ namespace MudBlazor.UnitTests
             // select elements needed for the test
             var table = comp.FindComponent<MudTable<int>>().Instance;
             var text = comp.FindComponent<MudText>();
-            var checkboxes = comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).ToArray();
+            var checkboxRendered = comp.FindComponents<MudCheckBox<bool>>().ToArray();
+            var checkboxes = checkboxRendered.Select(x => x.Instance).ToArray();
             table.SelectedItems.Count.Should().Be(4);
             comp.Find("p").TextContent.Should().Be("SelectedItems { 0, 1, 2, 3 }");
             checkboxes.Sum(x => x.Checked ? 1 : 0).Should().Be(3);
             // uncheck a row then switch to page 2 and both checkboxes on page 2 should be checked
-            await comp.InvokeAsync(() => checkboxes[1].Checked = false);
+            checkboxRendered[1].Find("input").Change(false);
             checkboxes.Sum(x => x.Checked ? 1 : 0).Should().Be(1);
             // switch page 
             await comp.InvokeAsync(() => table.CurrentPage = 1);

--- a/src/MudBlazor/Components/CheckBox/MudCheckBox.razor
+++ b/src/MudBlazor/Components/CheckBox/MudCheckBox.razor
@@ -5,7 +5,7 @@
 <label class="@Classname" style="@Style">
     <span class="@CheckBoxClassname">
         @*note: stopping the click propagation is important here. otherwise checking the checkbox results in click events on its parent (i.e. table row), which is generally not what you would want*@
-        <input @attributes="UserAttributes" type="checkbox" class="mud-checkbox-input" @bind="@BoolValue" disabled="@Disabled" @onclick:stopPropagation="true" @onclick:preventDefault="@ReadOnly"/>
+        <input @attributes="UserAttributes" type="checkbox" class="mud-checkbox-input" checked="@BoolValue" @onchange="@OnChange" disabled="@Disabled" @onclick:stopPropagation="true" @onclick:preventDefault="@ReadOnly"/>
         <svg class="mud-svg-icon-root" focusable="false" viewBox="0 0 24 24" role="presentation" aria-hidden="true">
             <path d="@GetIcon()"></path>
         </svg>

--- a/src/MudBlazor/Components/Switch/MudSwitch.razor
+++ b/src/MudBlazor/Components/Switch/MudSwitch.razor
@@ -6,7 +6,7 @@
     <span class="mud-switch-span">
         <span class="@SwitchClassname">
             <span class="mud-switch-button">
-                <input @attributes="UserAttributes" type="checkbox" class="mud-switch-input" @bind="@BoolValue" disabled="@Disabled" @onclick:preventDefault="@ReadOnly"/>
+                <input @attributes="UserAttributes" type="checkbox" class="mud-switch-input" checked="@BoolValue" @onchange="@OnChange" disabled="@Disabled" @onclick:preventDefault="@ReadOnly"/>
                 <span class="mud-switch-thumb"></span>
             </span>
         </span>


### PR DESCRIPTION
Refactored to completely avoid async calls in property setters.

The idea is to bound the DOM element event to a separated handler instead of the property directly, as demonstrated in Microsoft documentation.

The automated tests were fixed to avoid manipulating the property directly. They are now calling the onchange event, which is more Blazor-compliant.

Also, I found that a converter change was setting the Touched state to true, which is incorrect. This is fixed by this PR (Now Touched state is set to true only by onchange handler)