### PR TITLE
MudCollapse height fix

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TreeViewTest.cs
+++ b/src/MudBlazor.UnitTests/Components/TreeViewTest.cs
@@ -1,15 +1,8 @@
 ﻿#pragma warning disable IDE1006 // leading underscore
 
 using System;
-using System.Diagnostics;
-using System.Net.Http;
-using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
-using Microsoft.AspNetCore.Components;
-using Microsoft.Extensions.DependencyInjection;
-using MudBlazor.Services;
-using MudBlazor.UnitTests.Mocks;
 using MudBlazor.UnitTests.TestComponents.TreeView;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
@@ -38,11 +31,11 @@ namespace MudBlazor.UnitTests.Components
             Console.WriteLine(comp.Markup);
             comp.FindAll("li.mud-treeview-item").Count.Should().Be(10);
             comp.Find("button").Click();
-            comp.FindAll("li.mud-treeview-item .mud-collapse-container.mud-collapse-expand").Count.Should().Be(1);
+            comp.FindAll("li.mud-treeview-item .mud-collapse-container.mud-collapse-entering").Count.Should().Be(1);
             comp.Find("button").Click();
-            comp.FindAll("li.mud-treeview-item .mud-collapse-container.mud-collapse-expand").Count.Should().Be(0);
+            comp.FindAll("li.mud-treeview-item .mud-collapse-container.mud-collapse-entering").Count.Should().Be(0);
             comp.Find("div.mud-treeview-item-content").Click();
-            comp.FindAll("li.mud-treeview-item .mud-collapse-container.mud-collapse-expand").Count.Should().Be(0);
+            comp.FindAll("li.mud-treeview-item .mud-collapse-container.mud-collapse-entering").Count.Should().Be(0);
         }
 
         [Test]
@@ -52,13 +45,13 @@ namespace MudBlazor.UnitTests.Components
             Console.WriteLine(comp.Markup);
             comp.FindAll("li.mud-treeview-item").Count.Should().Be(10);
             comp.Find("button").Click();
-            comp.FindAll("li.mud-treeview-item .mud-collapse-container.mud-collapse-expand").Count.Should().Be(1);
+            comp.FindAll("li.mud-treeview-item .mud-collapse-container.mud-collapse-entering").Count.Should().Be(1);
             comp.Find("button").Click();
-            comp.FindAll("li.mud-treeview-item .mud-collapse-container.mud-collapse-expand").Count.Should().Be(0);
+            comp.FindAll("li.mud-treeview-item .mud-collapse-container.mud-collapse-entering").Count.Should().Be(0);
             comp.Find("div.mud-treeview-item-content").Click();
-            comp.FindAll("li.mud-treeview-item .mud-collapse-container.mud-collapse-expand").Count.Should().Be(1);
+            comp.FindAll("li.mud-treeview-item .mud-collapse-container.mud-collapse-entering").Count.Should().Be(1);
             comp.Find("div.mud-treeview-item-content").Click();
-            comp.FindAll("li.mud-treeview-item .mud-collapse-container.mud-collapse-expand").Count.Should().Be(0);
+            comp.FindAll("li.mud-treeview-item .mud-collapse-container.mud-collapse-entering").Count.Should().Be(0);
         }
 
         [Test]
@@ -68,7 +61,7 @@ namespace MudBlazor.UnitTests.Components
             Console.WriteLine(comp.Markup);
             comp.FindAll("li.mud-treeview-item").Count.Should().Be(10);
             comp.Find("button").Click();
-            comp.FindAll("li.mud-treeview-item .mud-collapse-container.mud-collapse-expand").Count.Should().Be(1);
+            comp.FindAll("li.mud-treeview-item .mud-collapse-container.mud-collapse-entering").Count.Should().Be(1);
             comp.FindAll("input.mud-checkbox-input").Count.Should().Be(10);
             comp.Find("input.mud-checkbox-input").Change(true);
             comp.Instance.SubItemSelected.Should().BeTrue();

--- a/src/MudBlazor.UnitTests/Mocks/MockDomService.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockDomService.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
 using MudBlazor.Interop;
 using MudBlazor.Services;
 
@@ -21,5 +22,8 @@ namespace MudBlazor.UnitTests.Mocks
 
         public ValueTask<BoundingClientRect> GetBoundingClientRect(ElementReference elementReference)
             => new ValueTask<BoundingClientRect>(new BoundingClientRect());
+
+        public ValueTask AddEventListener<T>(ElementReference element, DotNetObjectReference<T> dotnet, string @event, string callback) where T : class =>
+            new ValueTask();
     }
 }

--- a/src/MudBlazor/Components/Collapse/MudCollapse.razor
+++ b/src/MudBlazor/Components/Collapse/MudCollapse.razor
@@ -2,7 +2,8 @@
 @inherits MudComponentBase
 @using System.Globalization; 
 
-<div @ref="_container"  class="@Classname" style="@(MaxHeight.HasValue && Expanded ? $"max-height:{MaxHeight}px;transition-duration: {CalculatedTransitionDuration.ToString(CultureInfo.InvariantCulture)};" : "")">    <div class="mud-collapse-wrapper">
+<div @ref="_container"  class="@Classname" style="@Stylename">    
+    <div @ref="_wrapper" class="mud-collapse-wrapper">
         <div class="mud-collapse-wrapper-inner">
             @ChildContent
         </div>

--- a/src/MudBlazor/Services/DomService.cs
+++ b/src/MudBlazor/Services/DomService.cs
@@ -12,6 +12,7 @@ namespace MudBlazor.Services
         ValueTask<BoundingClientRect> GetBoundingClientRect(ElementReference elementReference);
         ValueTask ChangeGlobalCssVariable(string variableName, int value);
         ValueTask ChangeCssVariable(ElementReference element, string variableName, int value);
+        ValueTask AddEventListener<T>(ElementReference element, DotNetObjectReference<T> dotnet, string @event, string callback) where T : class;
     }
 
     public class DomService : IDomService
@@ -37,5 +38,8 @@ namespace MudBlazor.Services
         
         public ValueTask ChangeCssVariable(ElementReference element, string variableName, int value) =>
             _jsRuntime.InvokeVoidAsync("changeCssVariable", element, variableName, value);
+
+        public ValueTask AddEventListener<T>(ElementReference element, DotNetObjectReference<T> dotnet, string @event, string callback) where T : class =>
+            _jsRuntime.InvokeVoidAsync("addMudEventListener", element, dotnet, @event, callback);
     }
 }

--- a/src/MudBlazor/Styles/components/_collapse.scss
+++ b/src/MudBlazor/Styles/components/_collapse.scss
@@ -1,26 +1,37 @@
 ﻿.mud-collapse-container {
-    max-height: 0;
+    height: 0px;
     overflow: hidden;
-    transition: max-height 0.5s cubic-bezier(0, 1, 0, 1);
+}
 
-    &.mud-navgroup-collapse {
-        transition: max-height 300ms cubic-bezier(0, 1, 0, 1);
+@keyframes mud-expand-anim {
+    from {
+        height: 0;
     }
 }
 
-.mud-collapse-expand {
-    max-height: 2000px;
-
-    &:not(.mud-navgroup-collapse) {
-        transition: max-height 1s ease-in-out;
-    }
+.mud-collapse-entering {
+    animation: mud-expand-anim 1s ease-in-out 0ms 1 forwards;
 
     &.mud-navgroup-collapse {
-        transition: max-height 300ms ease-in-out;
+        animation-duration: 300ms !important;
     }
+}
 
-    &.mud-collapse-expanded {
-        overflow: initial;
+.mud-collapse-entered {
+    overflow: initial;
+}
+
+@keyframes mud-collapse-anim {
+    to {
+        height: 0;
+    }
+}
+
+.mud-collapse-exiting {
+    animation: mud-collapse-anim 0.5s cubic-bezier(0, 1, 0, 1) 0ms 1 forwards;
+
+    &.mud-navgroup-collapse {
+        animation-duration: 300ms;
     }
 }
 

--- a/src/MudBlazor/TScripts/DOM.js
+++ b/src/MudBlazor/TScripts/DOM.js
@@ -21,8 +21,8 @@ window.changeCssVariable = (element, name, newValue) => {
     element.style.setProperty(name, newValue);
 };
 
-window.addTranstionEndListener = (element, dotnet) => {
-    element.addEventListener("transitionend", function () {
-        dotnet.invokeMethodAsync("TransitionEnd");
+window.addMudEventListener = (element, dotnet, event, callback) => {
+    element.addEventListener(event, function () {
+        dotnet.invokeMethodAsync(callback);
     });
 };


### PR DESCRIPTION
Fixes the height issue in MudCollapse when inner content's height become higher than 2000px. Important changes:
- switched from transition to animation
- removed max-height: 2000px