### PR TITLE
Avoid async calls in BaseInput property setters

### DIFF
--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -40,7 +40,8 @@ namespace MudBlazor.UnitTests
             var comp = ctx.RenderComponent<AutocompleteTest1>();
             Console.WriteLine(comp.Markup);
             // select elements needed for the test
-            var autocomplete = comp.FindComponent<MudAutocomplete<string>>().Instance;
+            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
+            var autocomplete = autocompletecomp.Instance;
             var menu = comp.Find("div.mud-popover");
 
             // check initial state
@@ -52,7 +53,7 @@ namespace MudBlazor.UnitTests
             menu.ClassList.Should().NotContain("mud-popover-open");
 
             // now let's type a different state to see the popup open
-            autocomplete.Text = "Calif";
+            autocompletecomp.Find("input").Input("Calif");
             await Task.Delay(100);
             menu = comp.Find("div.mud-popover");
             menu.ClassList.Should().Contain("mud-popover-open");
@@ -92,12 +93,12 @@ namespace MudBlazor.UnitTests
             menu.ClassList.Should().NotContain("mud-popover-open");
 
             // type 3 characters and check if it has toggled the menu
-            select.Instance.Text = "ala";
+            select.Find("input").Input("ala");
             await Task.Delay(100);
             menu.ClassList.Should().Contain("mud-popover-open");
 
             // type 2 characters and check if it has toggled the menu
-            select.Instance.Text = "al";
+            select.Find("input").Input("al");
             await Task.Delay(100);
             menu.ClassList.Should().NotContain("mud-popover-open");
         }
@@ -136,17 +137,15 @@ namespace MudBlazor.UnitTests
         {
             var comp = ctx.RenderComponent<AutocompleteTest1>();
             Console.WriteLine(comp.Markup);
-            var autocomplete = comp.FindComponent<MudAutocomplete<string>>().Instance;
+            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
+            var autocomplete = autocompletecomp.Instance;
             await comp.InvokeAsync(() => autocomplete.DebounceInterval = 0);
             // check initial state
             autocomplete.Value.Should().Be("Alabama");
             autocomplete.Text.Should().Be("Alabama");
             // set a value the search won't find
-            await comp.InvokeAsync(() =>
-            {
-                autocomplete.Text = "Austria"; // not part of the U.S. thank god
-                autocomplete.ToggleMenu();
-            });
+            autocompletecomp.Find("input").Input("Austria"); // not part of the U.S. thank god
+            await comp.InvokeAsync(() => autocomplete.ToggleMenu());
             // now trigger the coercion by closing the menu 
             await comp.InvokeAsync(() => autocomplete.ToggleMenu());
             autocomplete.Value.Should().Be("Alabama");
@@ -158,18 +157,16 @@ namespace MudBlazor.UnitTests
         {
             var comp = ctx.RenderComponent<AutocompleteTest1>();
             Console.WriteLine(comp.Markup);
-            var autocomplete = comp.FindComponent<MudAutocomplete<string>>().Instance;
+            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
+            var autocomplete = autocompletecomp.Instance;
             await comp.InvokeAsync(() => autocomplete.DebounceInterval = 0);
             await comp.InvokeAsync(() => autocomplete.CoerceText = false);
             // check initial state
             autocomplete.Value.Should().Be("Alabama");
             autocomplete.Text.Should().Be("Alabama");
             // set a value the search won't find
-            await comp.InvokeAsync(() =>
-            {
-                autocomplete.Text = "Austria";
-                autocomplete.ToggleMenu();
-            });
+            autocompletecomp.Find("Input").Input("Austria");
+            await comp.InvokeAsync(() => autocomplete.ToggleMenu());
             // now trigger the coercion by closing the menu 
             await comp.InvokeAsync(() => autocomplete.ToggleMenu());
             autocomplete.Value.Should().Be("Alabama");

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -50,27 +50,27 @@ namespace MudBlazor.UnitTests
             form.IsValid.Should().Be(false);
             textField.Error.Should().BeFalse();
             textField.ErrorText.Should().BeNullOrEmpty();
-            textFieldcomp.SetParametersAndRender(ComponentParameter.CreateParameter("Value", "Marilyn Manson"));
+            textFieldcomp.Find("input").Change("Marilyn Manson");
             form.IsValid.Should().Be(true);
             form.Errors.Length.Should().Be(0);
             textField.Error.Should().BeFalse();
             textField.ErrorText.Should().BeNullOrEmpty();
             // clear value to null
-            textFieldcomp.SetParametersAndRender(ComponentParameter.CreateParameter("Value", null));
+            textFieldcomp.Find("input").Change(null);
             form.IsValid.Should().Be(false);
             form.Errors.Length.Should().Be(1);
             form.Errors[0].Should().Be("Enter a rock star");
             textField.Error.Should().BeTrue();
             textField.ErrorText.Should().Be("Enter a rock star");
             // set value to "" -> should also be an error
-            textFieldcomp.SetParametersAndRender(ComponentParameter.CreateParameter("Value", ""));
+            textFieldcomp.Find("input").Change("");
             form.IsValid.Should().Be(false);
             form.Errors.Length.Should().Be(1);
             form.Errors[0].Should().Be("Enter a rock star");
             textField.Error.Should().BeTrue();
             textField.ErrorText.Should().Be("Enter a rock star");
             //
-            textFieldcomp.SetParametersAndRender(ComponentParameter.CreateParameter("Value", "Kurt Cobain"));
+            textFieldcomp.Find("input").Change("Kurt Cobain");
             form.IsValid.Should().Be(true);
             form.Errors.Length.Should().Be(0);
             textField.Error.Should().BeFalse();
@@ -90,7 +90,7 @@ namespace MudBlazor.UnitTests
             var textFieldcomp = comp.FindComponent<MudTextField<string>>();
             // check initial state: form should be valid due to field not being required!
             form.IsValid.Should().Be(true);
-            textFieldcomp.SetParametersAndRender(ComponentParameter.CreateParameter("Value", "This value doesn't matter"));
+            textFieldcomp.Find("input").Change("This value doesn't matter");
             form.IsValid.Should().Be(true);
         }
 
@@ -110,14 +110,14 @@ namespace MudBlazor.UnitTests
             form.IsValid.Should().Be(false);
             textField.Error.Should().BeFalse();
             textField.ErrorText.Should().BeNullOrEmpty();
-            textFieldcomp.SetParametersAndRender(ComponentParameter.CreateParameter("Value", "Marilyn Manson"));
-
+            // this rock star starts with Marilyn
+            textFieldcomp.Find("input").Change("Marilyn Manson");
             form.IsValid.Should().Be(true);
             form.Errors.Length.Should().Be(0);
             textField.Error.Should().BeFalse();
             textField.ErrorText.Should().BeNullOrEmpty();
             // this rock star doesn't start with Marilyn
-            textFieldcomp.SetParametersAndRender(ComponentParameter.CreateParameter("Value", "Kurt Cobain"));
+            textFieldcomp.Find("input").Change("Kurt Cobain");
             form.IsValid.Should().Be(false);
             form.Errors.Length.Should().Be(1);
             textField.Error.Should().BeTrue();
@@ -134,7 +134,7 @@ namespace MudBlazor.UnitTests
             //textField.ErrorText.Should().BeNullOrEmpty();
 
             // ok, not a rock star, but a star nonetheless
-            textFieldcomp.SetParametersAndRender(ComponentParameter.CreateParameter("Value", "Marilyn Monroe"));
+            textFieldcomp.Find("input").Change("Marilyn Monroe");
             form.IsValid.Should().Be(true);
             form.Errors.Length.Should().Be(0);
             textField.Error.Should().BeFalse();
@@ -158,10 +158,10 @@ namespace MudBlazor.UnitTests
             var form = comp.FindComponent<MudForm>().Instance;
             var textFieldcomp = comp.FindComponent<MudTextField<string>>();
             form.IsValid.Should().Be(false);
-            textFieldcomp.SetParametersAndRender(ComponentParameter.CreateParameter("Value", "Marilyn Manson"));
+            textFieldcomp.Find("input").Change("Marilyn Manson");
             form.IsValid.Should().Be(true);
             // this one might not be a star, but our custom validation func deems him valid nonetheless
-            textFieldcomp.SetParametersAndRender(ComponentParameter.CreateParameter("Value", "Charles Manson"));
+            textFieldcomp.Find("input").Change("Charles Manson");
             form.IsValid.Should().Be(true);
 
             // note: this logic is invalid, so it was removed. Validaton funcs are always called
@@ -172,10 +172,10 @@ namespace MudBlazor.UnitTests
             //form.IsValid.Should().Be(true);
 
             // clearly a star
-            textFieldcomp.SetParametersAndRender(ComponentParameter.CreateParameter("Value", "Marilyn Monroe"));
+            textFieldcomp.Find("input").Change("Marilyn Monroe");
             form.IsValid.Should().Be(true);
             // not a star according to our validation func
-            textFieldcomp.SetParametersAndRender(ComponentParameter.CreateParameter("Value", "Manson Marilyn"));
+            textFieldcomp.Find("input").Change("Manson Marilyn");
             form.IsValid.Should().Be(false);
         }
 
@@ -191,7 +191,7 @@ namespace MudBlazor.UnitTests
             var textFieldcomp = comp.FindComponent<MudTextField<string>>();
             var textField = textFieldcomp.Instance;
             form.IsValid.Should().Be(false);
-            textFieldcomp.SetParametersAndRender(ComponentParameter.CreateParameter("Value", "Some value"));
+            textFieldcomp.Find("input").Change("Some value");
             form.IsValid.Should().Be(true);
             // calling Reset() should reset the textField's value
             await comp.InvokeAsync(() => form.Reset());
@@ -225,16 +225,16 @@ namespace MudBlazor.UnitTests
             // validate initial field state
             textField.ValidationErrors.Should().BeEmpty();
             // make sure error can be detected
-            textFieldcomp.SetParametersAndRender(ComponentParameter.CreateParameter("Value", "def"));
+            textFieldcomp.Find("input").Change("def");
             await Task.Delay(InValidDelay + WaitDelay);
             textField.ValidationErrors.Should().ContainSingle("invalid");
             // make sure success can be detected
-            textFieldcomp.SetParametersAndRender(ComponentParameter.CreateParameter("Value", "abc"));
+            textFieldcomp.Find("input").Change("abc");
             await Task.Delay(ValidDelay + WaitDelay);
             textField.ValidationErrors.Should().BeEmpty();
             // send invalid value, then valid value
-            textFieldcomp.SetParametersAndRender(ComponentParameter.CreateParameter("Value", "def"));
-            textFieldcomp.SetParametersAndRender(ComponentParameter.CreateParameter("Value", "abc"));
+            textFieldcomp.Find("input").Change("def");
+            textFieldcomp.Find("input").Change("abc");
             // validate that first call result (invalid, longer return time) will not overwrite second call result (valid, shorter return time)
             await Task.Delay(InValidDelay + WaitDelay);
             textField.ValidationErrors.Should().BeEmpty();

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -44,32 +44,33 @@ namespace MudBlazor.UnitTests
             var comp = ctx.RenderComponent<FormIsValidTest>();
             Console.WriteLine(comp.Markup);
             var form = comp.FindComponent<MudForm>().Instance;
-            var textField = comp.FindComponent<MudTextField<string>>().Instance;
+            var textFieldcomp = comp.FindComponent<MudTextField<string>>();
+            var textField = textFieldcomp.Instance;
             // check initial state: form should not be valid, but text field does not display an error initially!
             form.IsValid.Should().Be(false);
             textField.Error.Should().BeFalse();
             textField.ErrorText.Should().BeNullOrEmpty();
-            await comp.InvokeAsync(() => textField.Value = "Marilyn Manson");
+            textFieldcomp.SetParametersAndRender(ComponentParameter.CreateParameter("Value", "Marilyn Manson"));
             form.IsValid.Should().Be(true);
             form.Errors.Length.Should().Be(0);
             textField.Error.Should().BeFalse();
             textField.ErrorText.Should().BeNullOrEmpty();
             // clear value to null
-            await comp.InvokeAsync(() => textField.Value = null);
+            textFieldcomp.SetParametersAndRender(ComponentParameter.CreateParameter("Value", null));
             form.IsValid.Should().Be(false);
             form.Errors.Length.Should().Be(1);
             form.Errors[0].Should().Be("Enter a rock star");
             textField.Error.Should().BeTrue();
             textField.ErrorText.Should().Be("Enter a rock star");
             // set value to "" -> should also be an error
-            await comp.InvokeAsync(() => textField.Value = "");
+            textFieldcomp.SetParametersAndRender(ComponentParameter.CreateParameter("Value", ""));
             form.IsValid.Should().Be(false);
             form.Errors.Length.Should().Be(1);
             form.Errors[0].Should().Be("Enter a rock star");
             textField.Error.Should().BeTrue();
             textField.ErrorText.Should().Be("Enter a rock star");
             //
-            await comp.InvokeAsync(() => textField.Value = "Kurt Cobain");
+            textFieldcomp.SetParametersAndRender(ComponentParameter.CreateParameter("Value", "Kurt Cobain"));
             form.IsValid.Should().Be(true);
             form.Errors.Length.Should().Be(0);
             textField.Error.Should().BeFalse();
@@ -86,10 +87,10 @@ namespace MudBlazor.UnitTests
             var comp = ctx.RenderComponent<FormIsValidTest2>();
             Console.WriteLine(comp.Markup);
             var form = comp.FindComponent<MudForm>().Instance;
-            var textField = comp.FindComponent<MudTextField<string>>().Instance;
+            var textFieldcomp = comp.FindComponent<MudTextField<string>>();
             // check initial state: form should be valid due to field not being required!
             form.IsValid.Should().Be(true);
-            await comp.InvokeAsync(() => textField.Value = "This value doesn't matter");
+            textFieldcomp.SetParametersAndRender(ComponentParameter.CreateParameter("Value", "This value doesn't matter"));
             form.IsValid.Should().Be(true);
         }
 
@@ -103,18 +104,20 @@ namespace MudBlazor.UnitTests
             var comp = ctx.RenderComponent<FormValidationTest>(ComponentParameter.CreateParameter("validation", validationFunc));
             Console.WriteLine(comp.Markup);
             var form = comp.FindComponent<MudForm>().Instance;
-            var textField = comp.FindComponent<MudTextField<string>>().Instance;
+            var textFieldcomp = comp.FindComponent<MudTextField<string>>();
+            var textField = textFieldcomp.Instance;
             // check initial state: form should not be valid, but text field does not display an error initially!
             form.IsValid.Should().Be(false);
             textField.Error.Should().BeFalse();
             textField.ErrorText.Should().BeNullOrEmpty();
-            await comp.InvokeAsync(() => textField.Value = "Marilyn Manson");
+            textFieldcomp.SetParametersAndRender(ComponentParameter.CreateParameter("Value", "Marilyn Manson"));
+
             form.IsValid.Should().Be(true);
             form.Errors.Length.Should().Be(0);
             textField.Error.Should().BeFalse();
             textField.ErrorText.Should().BeNullOrEmpty();
             // this rock star doesn't start with Marilyn
-            await comp.InvokeAsync(() => textField.Value = "Kurt Cobain");
+            textFieldcomp.SetParametersAndRender(ComponentParameter.CreateParameter("Value", "Kurt Cobain"));
             form.IsValid.Should().Be(false);
             form.Errors.Length.Should().Be(1);
             textField.Error.Should().BeTrue();
@@ -131,7 +134,7 @@ namespace MudBlazor.UnitTests
             //textField.ErrorText.Should().BeNullOrEmpty();
 
             // ok, not a rock star, but a star nonetheless
-            await comp.InvokeAsync(() => textField.Value = "Marilyn Monroe");
+            textFieldcomp.SetParametersAndRender(ComponentParameter.CreateParameter("Value", "Marilyn Monroe"));
             form.IsValid.Should().Be(true);
             form.Errors.Length.Should().Be(0);
             textField.Error.Should().BeFalse();
@@ -153,12 +156,12 @@ namespace MudBlazor.UnitTests
             var comp = ctx.RenderComponent<FormValidationTest>(ComponentParameter.CreateParameter("validation", validationFunc));
             Console.WriteLine(comp.Markup);
             var form = comp.FindComponent<MudForm>().Instance;
-            var textField = comp.FindComponent<MudTextField<string>>().Instance;
+            var textFieldcomp = comp.FindComponent<MudTextField<string>>();
             form.IsValid.Should().Be(false);
-            await comp.InvokeAsync(() => textField.Value = "Marilyn Manson");
+            textFieldcomp.SetParametersAndRender(ComponentParameter.CreateParameter("Value", "Marilyn Manson"));
             form.IsValid.Should().Be(true);
             // this one might not be a star, but our custom validation func deems him valid nonetheless
-            await comp.InvokeAsync(() => textField.Value = "Charles Manson");
+            textFieldcomp.SetParametersAndRender(ComponentParameter.CreateParameter("Value", "Charles Manson"));
             form.IsValid.Should().Be(true);
 
             // note: this logic is invalid, so it was removed. Validaton funcs are always called
@@ -169,10 +172,10 @@ namespace MudBlazor.UnitTests
             //form.IsValid.Should().Be(true);
 
             // clearly a star
-            await comp.InvokeAsync(() => textField.Value = "Marilyn Monroe");
+            textFieldcomp.SetParametersAndRender(ComponentParameter.CreateParameter("Value", "Marilyn Monroe"));
             form.IsValid.Should().Be(true);
             // not a star according to our validation func
-            await comp.InvokeAsync(() => textField.Value = "Manson Marilyn");
+            textFieldcomp.SetParametersAndRender(ComponentParameter.CreateParameter("Value", "Manson Marilyn"));
             form.IsValid.Should().Be(false);
         }
 
@@ -185,9 +188,10 @@ namespace MudBlazor.UnitTests
             var comp = ctx.RenderComponent<FormValidationTest>();
             Console.WriteLine(comp.Markup);
             var form = comp.FindComponent<MudForm>().Instance;
-            var textField = comp.FindComponent<MudTextField<string>>().Instance;
+            var textFieldcomp = comp.FindComponent<MudTextField<string>>();
+            var textField = textFieldcomp.Instance;
             form.IsValid.Should().Be(false);
-            await comp.InvokeAsync(() => textField.Value = "Some value");
+            textFieldcomp.SetParametersAndRender(ComponentParameter.CreateParameter("Value", "Some value"));
             form.IsValid.Should().Be(true);
             // calling Reset() should reset the textField's value
             await comp.InvokeAsync(() => form.Reset());
@@ -216,20 +220,21 @@ namespace MudBlazor.UnitTests
             var comp = ctx.RenderComponent<FormValidationTest>(ComponentParameter.CreateParameter("validation", validationFunc));
             Console.WriteLine(comp.Markup);
             var form = comp.FindComponent<MudForm>().Instance;
-            var textField = comp.FindComponent<MudTextField<string>>().Instance;
+            var textFieldcomp = comp.FindComponent<MudTextField<string>>();
+            var textField = textFieldcomp.Instance;
             // validate initial field state
             textField.ValidationErrors.Should().BeEmpty();
             // make sure error can be detected
-            _ = comp.InvokeAsync(() => textField.Value = "def");
+            textFieldcomp.SetParametersAndRender(ComponentParameter.CreateParameter("Value", "def"));
             await Task.Delay(InValidDelay + WaitDelay);
             textField.ValidationErrors.Should().ContainSingle("invalid");
             // make sure success can be detected
-            _ = comp.InvokeAsync(() => textField.Value = "abc");
+            textFieldcomp.SetParametersAndRender(ComponentParameter.CreateParameter("Value", "abc"));
             await Task.Delay(ValidDelay + WaitDelay);
             textField.ValidationErrors.Should().BeEmpty();
             // send invalid value, then valid value
-            _ = comp.InvokeAsync(() => textField.Value = "def");
-            _ = comp.InvokeAsync(() => textField.Value = "abc");
+            textFieldcomp.SetParametersAndRender(ComponentParameter.CreateParameter("Value", "def"));
+            textFieldcomp.SetParametersAndRender(ComponentParameter.CreateParameter("Value", "abc"));
             // validate that first call result (invalid, longer return time) will not overwrite second call result (valid, shorter return time)
             await Task.Delay(InValidDelay + WaitDelay);
             textField.ValidationErrors.Should().BeEmpty();
@@ -323,8 +328,8 @@ namespace MudBlazor.UnitTests
             Console.WriteLine(comp.Markup);
             var form = comp.FindComponent<MudForm>().Instance;
             form.IsValid.Should().BeFalse(because: "textfield is required");
-            var textfield = comp.FindComponent<MudTextField<string>>().Instance;
-            await comp.InvokeAsync(() => textfield.Text = "Moby Dick");
+            var textfield = comp.FindComponent<MudTextField<string>>();
+            textfield.Find("input").Change("Moby Dick");
             form.IsValid.Should().BeTrue(because: "select is not required");
         }
 
@@ -338,10 +343,10 @@ namespace MudBlazor.UnitTests
             Console.WriteLine(comp.Markup);
             var form = comp.FindComponent<MudForm>().Instance;
             form.IsValid.Should().BeTrue();
-            var textfield = comp.FindComponent<MudTextField<int>>().Instance;
-            await comp.InvokeAsync(() => textfield.Text = "Not and int");
+            var textfield = comp.FindComponent<MudTextField<int>>();
+            textfield.Find("input").Input("Not and int");
             form.IsValid.Should().BeFalse(because: "conversion error is forwarded to form");
-            await comp.InvokeAsync(() => textfield.Text = "17");
+            textfield.Find("input").Input("17");
             form.IsValid.Should().BeTrue(because: "conversion error is gone");
         }
 
@@ -382,14 +387,12 @@ namespace MudBlazor.UnitTests
             checkbox.Instance.HasErrors.Should().BeFalse();
             checkbox.Instance.ErrorText.Should().BeNullOrEmpty();
             // fill in the form to make it valid
-            await comp.InvokeAsync(() => { 
-                textfields[0].Instance.Text = "Rick Sanchez";
-                textfields[1].Instance.Text = "rick.sanchez@citadel-of-ricks.com";
-                textfields[2].Instance.Text = "Wabalabadubdub1234!";
-                textfields[3].Instance.Text = "Wabalabadubdub1234!";
-                checkbox.Instance.Checked = true;
-            });
-            comp.WaitForAssertion(()=>form.IsValid.Should().BeTrue());
+            textfields[0].Find("input").Change("Rick Sanchez");
+            textfields[1].Find("input").Change("rick.sanchez@citadel-of-ricks.com");
+            textfields[2].Find("input").Change("Wabalabadubdub1234!");
+            textfields[3].Find("input").Change("Wabalabadubdub1234!");
+            checkbox.Find("input").Change(true);
+            comp.WaitForAssertion(() => form.IsValid.Should().BeTrue());
             comp.WaitForState(() => form.Errors.Length == 0);
             // click reset 
             var resetButton = buttons[2];

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -152,17 +152,17 @@ namespace MudBlazor.UnitTests
             // print the generated html      
             Console.WriteLine(comp.Markup);
             // select elements needed for the test
-            var pager = comp.FindComponent<MudSelect<string>>().Instance;
+            var pager = comp.FindComponent<MudSelect<string>>();
             // change page size
-            await comp.InvokeAsync(() => pager.Value = "20");
+            pager.SetParametersAndRender(ComponentParameter.CreateParameter("Value", "20"));
             comp.FindAll("tr.mud-table-row").Count.Should().Be(20);
             comp.FindAll("p.mud-table-pagination-caption").Last().TextContent.Trim().Should().Be("1-20 of 59");
             // change page size
-            await comp.InvokeAsync(() => pager.Value = "60");
+            pager.SetParametersAndRender(ComponentParameter.CreateParameter("Value", "60"));
             comp.FindAll("tr.mud-table-row").Count.Should().Be(59);
             comp.FindAll("p.mud-table-pagination-caption").Last().TextContent.Trim().Should().Be("1-59 of 59");
             // change page size
-            await comp.InvokeAsync(() => pager.Value = "10");
+            pager.SetParametersAndRender(ComponentParameter.CreateParameter("Value", "10"));
             comp.FindAll("tr.mud-table-row").Count.Should().Be(10);
             comp.FindAll("p.mud-table-pagination-caption").Last().TextContent.Trim().Should().Be("1-10 of 59");
         }

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -152,17 +152,21 @@ namespace MudBlazor.UnitTests
             // print the generated html      
             Console.WriteLine(comp.Markup);
             // select elements needed for the test
-            var pager = comp.FindComponent<MudSelect<string>>();
+            var table = comp.FindComponent<MudTable<string>>();
+            var pager = comp.FindComponent<MudSelect<string>>().Instance;
             // change page size
-            pager.SetParametersAndRender(ComponentParameter.CreateParameter("Value", "20"));
+            table.SetParametersAndRender(ComponentParameter.CreateParameter("RowsPerPage", 20));
+            pager.Value.Should().Be("20");
             comp.FindAll("tr.mud-table-row").Count.Should().Be(20);
             comp.FindAll("p.mud-table-pagination-caption").Last().TextContent.Trim().Should().Be("1-20 of 59");
             // change page size
-            pager.SetParametersAndRender(ComponentParameter.CreateParameter("Value", "60"));
+            table.SetParametersAndRender(ComponentParameter.CreateParameter("RowsPerPage", 60));
+            pager.Value.Should().Be("60");
             comp.FindAll("tr.mud-table-row").Count.Should().Be(59);
             comp.FindAll("p.mud-table-pagination-caption").Last().TextContent.Trim().Should().Be("1-59 of 59");
             // change page size
-            pager.SetParametersAndRender(ComponentParameter.CreateParameter("Value", "10"));
+            table.SetParametersAndRender(ComponentParameter.CreateParameter("RowsPerPage", 10));
+            pager.Value.Should().Be("10");
             comp.FindAll("tr.mud-table-row").Count.Should().Be(10);
             comp.FindAll("p.mud-table-pagination-caption").Last().TextContent.Trim().Should().Be("1-10 of 59");
         }

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -83,11 +83,10 @@ namespace MudBlazor.UnitTests
             var comp = ctx.RenderComponent<MudTextField<int?>>(ComponentParameter.CreateParameter("Value", 17));
             // print the generated html
             Console.WriteLine(comp.Markup);
-            var textfield = comp.Instance;
-            await comp.InvokeAsync(() => textfield.Value = null);
+            comp.SetParametersAndRender(ComponentParameter.CreateParameter("Value", null));
             comp.Find("input").Blur();
             comp.FindAll("div.mud-input-error").Count.Should().Be(0);
-            await comp.InvokeAsync(() => textfield.Text = "");
+            comp.Find("input").Change("");
             comp.Find("input").Blur();
             comp.FindAll("div.mud-input-error").Count.Should().Be(0);
         }
@@ -101,8 +100,7 @@ namespace MudBlazor.UnitTests
             var comp = ctx.RenderComponent<MudTextField<int?>>();
             // print the generated html
             //Console.WriteLine(comp.Markup);
-            var textfield = comp.Instance;
-            await comp.InvokeAsync(() => textfield.Text = "seventeen");
+            comp.Find("input").Change("seventeen");
             comp.Find("input").Blur();
             Console.WriteLine(comp.Markup);
             comp.FindAll("p.mud-input-error").Count.Should().Be(1);
@@ -209,11 +207,11 @@ namespace MudBlazor.UnitTests
             var textfield = comp.Instance;
             Console.WriteLine(comp.Markup);
             // first try a valid credit card number
-            await comp.InvokeAsync(() => textfield.Text = "4012 8888 8888 1881");
+            comp.Find("input").Change("4012 8888 8888 1881");
             textfield.Error.Should().BeFalse(because: "The number is a valid VISA test credit card number");
             textfield.ErrorText.Should().BeNullOrEmpty();
             // now try something that produces a validation error
-            await comp.InvokeAsync(() => textfield.Text = "0000 1111 2222 3333");
+            comp.Find("input").Change("0000 1111 2222 3333");
             textfield.Error.Should().BeTrue(because: "The credit card number is fake");
             Console.WriteLine("Error message: " + textfield.ErrorText);
             textfield.ErrorText.Should().NotBeNullOrEmpty();
@@ -232,10 +230,10 @@ namespace MudBlazor.UnitTests
             var textfield = comp.Instance;
             textfield.Converter.SetFunc = s => $"{s}x";
             textfield.Converter.GetFunc = s => $"{s}y";
-            await comp.InvokeAsync(() => textfield.Value = "A");
+            comp.SetParametersAndRender(ComponentParameter.CreateParameter("Value", "A"));
             textfield.Value.Should().Be("A");
             textfield.Text.Should().Be("Ax");
-            await comp.InvokeAsync(() => textfield.Text = "B");
+            comp.Find("input").Change("B");
             textfield.Value.Should().Be("By");
             textfield.Text.Should().Be("B");
         }
@@ -250,10 +248,10 @@ namespace MudBlazor.UnitTests
                 EventCallback<string>("TextChanged", x => changed_text = x)
             );
             var textfield = comp.Instance;
-            await comp.InvokeAsync(() => textfield.Value = "A");
+            comp.SetParametersAndRender(ComponentParameter.CreateParameter("Value", "A"));
             changed_value.Should().Be("A");
             changed_text.Should().Be("A");
-            await comp.InvokeAsync(() => textfield.Text = "B");
+            comp.Find("input").Change("B");
             changed_value.Should().Be("B");
             changed_text.Should().Be("B");
         }
@@ -268,7 +266,7 @@ namespace MudBlazor.UnitTests
         {
             var comp = ctx.RenderComponent<MudTextField<int?>>(ComponentParameter.CreateParameter("Required", true));
             var textfield = comp.Instance;
-            await comp.InvokeAsync(() => textfield.Text = "A");
+            comp.Find("input").Change("A");
             comp.Find("input").Blur();
             textfield.HasErrors.Should().Be(true);
             textfield.ErrorText.Should().Be("Not a valid number");

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -239,7 +239,25 @@ namespace MudBlazor.UnitTests
         }
 
         [Test]
-        public async Task TextField_Should_FireValueChanged()
+        public async Task TextField_Should_FireValueChangedOnTextParameterChange()
+        {
+            string changed_value = null;
+            var comp = ctx.RenderComponent<MudTextField<string>>(EventCallback<string>("ValueChanged", x => changed_value = x));
+            comp.SetParametersAndRender(ComponentParameter.CreateParameter("Text", "A"));
+            changed_value.Should().Be("A");
+        }
+
+        [Test]
+        public async Task TextField_Should_FireTextChangedOnValueParameterChange()
+        {
+            string changed_text = null;
+            var comp = ctx.RenderComponent<MudTextField<string>>(EventCallback<string>("TextChanged", x => changed_text = x));
+            comp.SetParametersAndRender(ComponentParameter.CreateParameter("Value", "A"));
+            changed_text.Should().Be("A");
+        }
+
+        [Test]
+        public async Task TextField_Should_FireTextAndValueChangedOnTextInput()
         {
             string changed_value = null;
             string changed_text = null;
@@ -247,10 +265,6 @@ namespace MudBlazor.UnitTests
                 EventCallback<string>("ValueChanged", x => changed_value = x),
                 EventCallback<string>("TextChanged", x => changed_text = x)
             );
-            var textfield = comp.Instance;
-            comp.SetParametersAndRender(ComponentParameter.CreateParameter("Value", "A"));
-            changed_value.Should().Be("A");
-            changed_text.Should().Be("A");
             comp.Find("input").Change("B");
             changed_value.Should().Be("B");
             changed_text.Should().Be("B");

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -107,10 +107,10 @@ namespace MudBlazor
         public string Text
         {
             get => _text;
-            set => SetTextAsync(value, true).AndForget();
+            set => SetTextAsync(value).AndForget();
         }
 
-        protected async Task SetTextAsync(string text, bool updateValue)
+        protected async Task SetTextAsync(string text, bool updateValue = true)
         {
             if (_text != text)
             {
@@ -176,10 +176,10 @@ namespace MudBlazor
         public T Value
         {
             get => _value;
-            set => SetValueAsync(value, true).AndForget();
+            set => SetValueAsync(value).AndForget();
         }
 
-        protected async Task SetValueAsync(T value, bool updateText)
+        protected async Task SetValueAsync(T value, bool updateText = true)
         {
             if (!EqualityComparer<T>.Default.Equals(_value, value))
             {

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -7,7 +7,7 @@
         <MudInputControl Label="@Label" Variant="@Variant" HelperText="@HelperText" FullWidth="@FullWidth" Margin="@Margin" Class="@Classname" Style="@Style"
                          Error="@Error" ErrorText="@ErrorText" Disabled="@Disabled" @onclick="@ToggleMenu">
             <InputContent>
-                <MudInput @ref="_elementReference" InputType="InputType.Text" Variant="@Variant" @attributes="UserAttributes" @bind-Value="@Text" DisableUnderLine="@DisableUnderLine" Placeholder="@Placeholder" Disabled=@Disabled ReadOnly="@ReadOnly"
+                <MudInput T="string" @ref="_elementReference" InputType="InputType.Text" Variant="@Variant" @attributes="UserAttributes" Value="@Text" ValueChanged="(s) => SetTextAsync(s)" DisableUnderLine="@DisableUnderLine" Placeholder="@Placeholder" Disabled=@Disabled ReadOnly="@ReadOnly"
                           Immediate="true" Class="mud-select-input" Error="@Error" AdornmentIcon="@CurrentIcon" Adornment="Adornment.End" IconSize="Size.Medium" OnKeyDown="@this.OnInputKeyDown"
                           OnBlur="@OnInputBlurred" OnKeyUp="@base.onKeyUp" OnKeyPress="@base.onKeyPress" />
             </InputContent>

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -239,7 +239,7 @@ namespace MudBlazor
             switch (args.Key)
             {
                 case "Enter":
-                    OnEnterKey();
+                    await OnEnterKey();
                     break;
                 case "ArrowDown":
                     await SelectNextItem(+1);
@@ -297,14 +297,15 @@ namespace MudBlazor
             return $"{_componentId}_item{index}";
         }
 
-        private void OnEnterKey()
+        private Task OnEnterKey()
         {
             if (IsOpen == false)
-                return;
+                return Task.CompletedTask;
             if (_items == null || _items.Length == 0)
-                return;
+                return Task.CompletedTask;
             if (_selectedListItemIndex >= 0 && _selectedListItemIndex < _items.Length)
-                SelectOption(_items[_selectedListItemIndex]);
+                return SelectOption(_items[_selectedListItemIndex]);
+            return Task.CompletedTask;
         }
 
         private Task OnInputBlurred(FocusEventArgs args)

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -128,7 +128,7 @@ namespace MudBlazor
         public async Task SelectOption(T value)
         {
             _timer?.Dispose();
-            await SetValueAsync(value, true);
+            await SetValueAsync(value);
             if (_items != null)
                 _selectedListItemIndex = Array.IndexOf(_items, value);
             _text = GetItemString(value);
@@ -322,14 +322,14 @@ namespace MudBlazor
             if (Value == null)
             {
                 _timer?.Dispose();
-                await SetTextAsync(null, true);
+                await SetTextAsync(null);
                 return;
             }
             var actualvalueStr = GetItemString(Value);
             if (!object.Equals(actualvalueStr, Text))
             {
                 _timer?.Dispose();
-                await SetTextAsync(actualvalueStr, true);
+                await SetTextAsync(actualvalueStr);
             }
         }
 

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -178,17 +178,17 @@ namespace MudBlazor
         private T[] _items;
         private int _selectedListItemIndex = 0;
 
-        protected override void UpdateTextProperty(bool updateValue)
+        protected override Task UpdateTextPropertyAsync(bool updateValue)
         {
-            base.UpdateTextProperty(updateValue);
             _timer?.Dispose();
+            return base.UpdateTextPropertyAsync(updateValue);
         }
 
-        protected override void UpdateValueProperty(bool updateText)
+        protected override async Task UpdateValuePropertyAsync(bool updateText)
         {
-            if (ResetValueOnEmptyText && string.IsNullOrWhiteSpace(Text))
-                Value = default(T);
             _timer?.Dispose();
+            if (ResetValueOnEmptyText && string.IsNullOrWhiteSpace(Text))
+                await SetValueAsync(default(T), updateText);
             _timer = new Timer(OnTimerComplete, null, DebounceInterval, Timeout.Infinite);
         }
 

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -125,20 +125,20 @@ namespace MudBlazor
 
         private MudInput<string> _elementReference;
 
-        public void SelectOption(T value)
+        public async Task SelectOption(T value)
         {
-            Value = value;
+            _timer?.Dispose();
+            await SetValueAsync(value, true);
             if (_items != null)
                 _selectedListItemIndex = Array.IndexOf(_items, value);
             _text = GetItemString(value);
-            _timer?.Dispose();
             IsOpen = false;
             UpdateIcon();
             BeginValidate();
             StateHasChanged();
         }
 
-        public void ToggleMenu()
+        public async Task ToggleMenu()
         {
             if (Disabled || MinCharacters > 0 && (string.IsNullOrEmpty(Text) || Text.Length < MinCharacters))
                 return;
@@ -151,7 +151,7 @@ namespace MudBlazor
             }
             else
             {
-                CoerceTextToValue();
+                await CoerceTextToValue();
             }
             UpdateIcon();
             StateHasChanged();
@@ -307,30 +307,29 @@ namespace MudBlazor
                 SelectOption(_items[_selectedListItemIndex]);
         }
 
-        private void OnInputBlurred(FocusEventArgs args)
+        private Task OnInputBlurred(FocusEventArgs args)
         {
-            if (!IsOpen)
-                CoerceTextToValue();
+            return !IsOpen ? CoerceTextToValue() : Task.CompletedTask;
             // we should not validate on blur in autocomplete, because the user needs to click out of the input to select a value, 
             // resulting in a premature validation. thus, don't call base
             //base.OnBlurred(args);
         }
 
-        private void CoerceTextToValue()
+        private async Task CoerceTextToValue()
         {
             if (CoerceText == false)
                 return;
             if (Value == null)
             {
-                Text = null;
                 _timer?.Dispose();
+                await SetTextAsync(null, true);
                 return;
             }
             var actualvalueStr = GetItemString(Value);
             if (!object.Equals(actualvalueStr, Text))
             {
-                Text = actualvalueStr;
                 _timer?.Dispose();
+                await SetTextAsync(actualvalueStr, true);
             }
         }
 

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -131,7 +131,7 @@ namespace MudBlazor
             await SetValueAsync(value);
             if (_items != null)
                 _selectedListItemIndex = Array.IndexOf(_items, value);
-            _text = GetItemString(value);
+            Text = GetItemString(value);
             IsOpen = false;
             UpdateIcon();
             BeginValidate();

--- a/src/MudBlazor/Components/Input/MudInput.razor
+++ b/src/MudBlazor/Components/Input/MudInput.razor
@@ -12,7 +12,7 @@
     @if (Lines > 1)
     {
         <textarea @ref="_elementReference" rows="@Lines" @attributes="UserAttributes" type="@InputTypeString" class="@InputClassname" placeholder="@Placeholder" disabled=@Disabled readonly="@ReadOnly"
-                  @bind-value="@Text" @bind-value:event="@((Immediate ? "oninput" : "onchange"))" @onblur="@OnBlurred" @onkeydown="@onKeyDown" @onkeypress="@onKeyPress" @onkeyup="@onKeyUp">
+                  @oninput="OnInput" @onchange="OnChange" @onblur="@OnBlurred" @onkeydown="@onKeyDown" @onkeypress="@onKeyPress" @onkeyup="@onKeyUp">
             @Text
         </textarea>
     }
@@ -25,7 +25,7 @@
             </div>
         }
 
-        <input @ref="_elementReference" @attributes="UserAttributes" type="@InputTypeString" class="@InputClassname" @bind-value="@Text" @bind-value:event="@((Immediate ? "oninput" : "onchange"))"
+        <input @ref="_elementReference" @attributes="UserAttributes" type="@InputTypeString" class="@InputClassname" value="@Text" @oninput="OnInput" @onchange="OnChange"
                placeholder="@Placeholder" disabled=@Disabled readonly="@ReadOnly" @onblur="@OnBlurred" @onkeydown="@onKeyDown" @onkeypress="@onKeyPress" @onkeyup="@onKeyUp" />
     }
 

--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -20,12 +20,12 @@ namespace MudBlazor
 
         protected Task OnInput(ChangeEventArgs args)
         {
-            return Immediate ? SetTextAsync(args.Value as string) : Task.CompletedTask;
+            return Immediate ? SetTextAsync(args?.Value as string) : Task.CompletedTask;
         }
 
         protected Task OnChange(ChangeEventArgs args)
         {
-            return Immediate ? Task.CompletedTask : SetTextAsync(args.Value as string);
+            return Immediate ? Task.CompletedTask : SetTextAsync(args?.Value as string);
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -18,6 +18,16 @@ namespace MudBlazor
 
         protected string InputTypeString => InputType.ToDescriptionString();
 
+        protected Task OnInput(ChangeEventArgs args)
+        {
+            return Immediate ? SetTextAsync(args.Value as string) : Task.CompletedTask;
+        }
+
+        protected Task OnChange(ChangeEventArgs args)
+        {
+            return Immediate ? Task.CompletedTask : SetTextAsync(args.Value as string);
+        }
+
         /// <summary>
         /// ChildContent of the MudInput will only be displayed if InputType.Hidden and if its not null.
         /// </summary>

--- a/src/MudBlazor/Components/Input/MudRangeInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudRangeInput.razor.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Components;
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
 using MudBlazor.Extensions;
 
 namespace MudBlazor
@@ -61,16 +62,16 @@ namespace MudBlazor
             }
         }
 
-        protected override void UpdateTextProperty(bool updateValue)
+        protected override async Task UpdateTextPropertyAsync(bool updateValue)
         {
-            base.UpdateTextProperty(updateValue);
+            await base.UpdateTextPropertyAsync(updateValue);
 
             RangeConverter<T>.Split(Text, out _textStart, out _textEnd);
         }
 
-        protected override void UpdateValueProperty(bool updateText)
+        protected override async Task UpdateValuePropertyAsync(bool updateText)
         {
-            base.UpdateValueProperty(updateText);
+            await base.UpdateValuePropertyAsync(updateText);
 
             RangeConverter<T>.Split(Text, out _textStart, out _textEnd);
         }

--- a/src/MudBlazor/Components/Input/MudRangeInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudRangeInput.razor.cs
@@ -10,7 +10,7 @@ namespace MudBlazor
 
         public MudRangeInput()
         {
-            _value = new Range<T>();
+            Value = new Range<T>();
             Converter = new RangeConverter<T>();
         }
 

--- a/src/MudBlazor/Components/Input/MudRangeInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudRangeInput.razor.cs
@@ -46,7 +46,7 @@ namespace MudBlazor
                 if (_textStart == value)
                     return;
                 _textStart = value;
-                SetTextAsync(RangeConverter<T>.Join(_textStart, _textEnd), true).AndForget();
+                SetTextAsync(RangeConverter<T>.Join(_textStart, _textEnd)).AndForget();
             }
         }
 
@@ -58,7 +58,7 @@ namespace MudBlazor
                 if (_textEnd == value)
                     return;
                 _textEnd = value;
-                SetTextAsync(RangeConverter<T>.Join(_textStart, _textEnd), true).AndForget();
+                SetTextAsync(RangeConverter<T>.Join(_textStart, _textEnd)).AndForget();
             }
         }
 

--- a/src/MudBlazor/Components/Input/MudRangeInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudRangeInput.razor.cs
@@ -46,7 +46,7 @@ namespace MudBlazor
                 if (_textStart == value)
                     return;
                 _textStart = value;
-                Text = RangeConverter<T>.Join(_textStart, _textEnd);
+                SetTextAsync(RangeConverter<T>.Join(_textStart, _textEnd), true).AndForget();
             }
         }
 
@@ -58,7 +58,7 @@ namespace MudBlazor
                 if (_textEnd == value)
                     return;
                 _textEnd = value;
-                Text = RangeConverter<T>.Join(_textStart, _textEnd);
+                SetTextAsync(RangeConverter<T>.Join(_textStart, _textEnd), true).AndForget();
             }
         }
 

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -144,17 +144,17 @@ namespace MudBlazor
             return selected_item.ChildContent;
         }
 
-        protected override void UpdateValueProperty(bool updateText)
+        protected override Task UpdateValuePropertyAsync(bool updateText)
         {
             // Select does not support updating the value through the Text property at all!
+            return Task.CompletedTask;
         }
 
-        protected override void UpdateTextProperty(bool updateValue)
+        protected override Task UpdateTextPropertyAsync(bool updateValue)
         {
             // when multiselection is true, we don't update the text when the value changes. 
             // instead the Text will be set with a comma separated list of selected values
-            if (!MultiSelection)
-                base.UpdateTextProperty(updateValue);
+            return MultiSelection ? Task.CompletedTask : base.UpdateTextPropertyAsync(updateValue);
         }
 
         internal event Action<HashSet<T>> SelectionChangedFromOutside;

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -68,9 +68,9 @@ namespace MudBlazor
                 _selectedValues = new HashSet<T>(set);
                 SelectionChangedFromOutside?.Invoke(_selectedValues);
                 if (!MultiSelection)
-                    SetValueAsync(_selectedValues.FirstOrDefault(), true).AndForget();
+                    SetValueAsync(_selectedValues.FirstOrDefault()).AndForget();
                 else
-                    SetTextAsync(string.Join(", ", SelectedValues.Select(x => Converter.Set(x))), true).AndForget();
+                    SetTextAsync(string.Join(", ", SelectedValues.Select(x => Converter.Set(x)))).AndForget();
                 SelectedValuesChanged.InvokeAsync(new HashSet<T>(SelectedValues));
             }
         }
@@ -214,7 +214,7 @@ namespace MudBlazor
             if (!MultiSelection)
             {
                 // single selection
-                await SetValueAsync(value, true);
+                await SetValueAsync(value);
                 _isOpen = false;
                 UpdateIcon();
                 SelectedValues.Clear();
@@ -227,7 +227,7 @@ namespace MudBlazor
                     SelectedValues.Add(value);
                 else
                     SelectedValues.Remove(value);
-                await SetTextAsync(string.Join(", ", SelectedValues.Select(x => Converter.Set(x))), true);
+                await SetTextAsync(string.Join(", ", SelectedValues.Select(x => Converter.Set(x))));
             }
             StateHasChanged();
             await SelectedValuesChanged.InvokeAsync(SelectedValues);

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -68,9 +68,9 @@ namespace MudBlazor
                 _selectedValues = new HashSet<T>(set);
                 SelectionChangedFromOutside?.Invoke(_selectedValues);
                 if (!MultiSelection)
-                    Value = _selectedValues.FirstOrDefault();
+                    SetValueAsync(_selectedValues.FirstOrDefault(), true).AndForget();
                 else
-                    Text = string.Join(", ", SelectedValues.Select(x => Converter.Set(x)));
+                    SetTextAsync(string.Join(", ", SelectedValues.Select(x => Converter.Set(x))), true).AndForget();
                 SelectedValuesChanged.InvokeAsync(new HashSet<T>(SelectedValues));
             }
         }
@@ -214,7 +214,7 @@ namespace MudBlazor
             if (!MultiSelection)
             {
                 // single selection
-                Value = value;
+                await SetValueAsync(value, true);
                 _isOpen = false;
                 UpdateIcon();
                 SelectedValues.Clear();
@@ -227,7 +227,7 @@ namespace MudBlazor
                     SelectedValues.Add(value);
                 else
                     SelectedValues.Remove(value);
-                Text = string.Join(", ", SelectedValues.Select(x => Converter.Set(x)));
+                await SetTextAsync(string.Join(", ", SelectedValues.Select(x => Converter.Set(x))), true);
             }
             StateHasChanged();
             await SelectedValuesChanged.InvokeAsync(SelectedValues);

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -243,14 +243,8 @@ namespace MudBlazor
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
             if (firstRender)
-            {
-                if (!Context.HasPager)
-                {
-                    await InvokeServerLoadFunc();
-                    //await Task.Delay(1);
-                    //StateHasChanged();
-                }
-            }
+                await InvokeServerLoadFunc();
+
             TableContext.UpdateRowCheckBoxes();
             await base.OnAfterRenderAsync(firstRender);
         }
@@ -303,7 +297,5 @@ namespace MudBlazor
         {
             return InvokeServerLoadFunc();
         }
-
-
     }
 }

--- a/src/MudBlazor/Components/TextField/MudTextField.razor
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor
@@ -5,10 +5,9 @@
 <CascadingValue Name="Standalone" Value="false" IsFixed="true">
     <MudInputControl Label="@Label" Variant="@Variant" HelperText="@HelperText" FullWidth="@FullWidth" Error="@HasErrors" ErrorText="@GetErrorText()" Disabled="@Disabled" Margin="@Margin" Required="@Required">
         <InputContent>
-            <MudInput @ref="_elementReference" @attributes="UserAttributes" InputType="@InputType" Lines="@Lines" Class="@Classname" Style="@Style" Variant="@Variant" @bind-Value="@Text" Placeholder="@Placeholder" Disabled=@Disabled DisableUnderLine="@DisableUnderLine" ReadOnly="@ReadOnly"
+            <MudInput T="string" @ref="_elementReference" @attributes="UserAttributes" InputType="@InputType" Lines="@Lines" Class="@Classname" Style="@Style" Variant="@Variant" Value="@Text" ValueChanged="(s) => SetTextAsync(s)" Placeholder="@Placeholder" Disabled=@Disabled DisableUnderLine="@DisableUnderLine" ReadOnly="@ReadOnly"
                       Adornment="@Adornment" AdornmentText="@AdornmentText" AdornmentIcon="@AdornmentIcon" IconSize="@IconSize" OnAdornmentClick="@OnAdornmentClick" Error="@Error" Immediate="@Immediate" Margin="@Margin"
                       OnBlur="@OnBlurred" OnKeyDown="@onKeyDown" OnKeyPress="@onKeyPress" OnKeyUp="@onKeyUp" />
         </InputContent>
     </MudInputControl>
 </CascadingValue>
-

--- a/src/MudBlazor/Extensions/ParameterViewExtensions.cs
+++ b/src/MudBlazor/Extensions/ParameterViewExtensions.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.AspNetCore.Components;
+
+namespace MudBlazor
+{
+    internal static class ParameterViewExtensions
+    {
+        public static bool Contains<T>(this ParameterView view, string parameterName)
+        {
+            return view.TryGetValue<T>(parameterName, out var _);
+        }
+    }
+}


### PR DESCRIPTION
Like #662, refactored to avoid async calls in some property setters.

Same technique: bound DOM element event to separate handler and fixed automated tests to avoid direct property access.