### PR TITLE
Optimise build

### DIFF
--- a/src/MudBlazor.Docs.Compiler/ExamplesMarkup.cs
+++ b/src/MudBlazor.Docs.Compiler/ExamplesMarkup.cs
@@ -29,14 +29,15 @@ namespace MudBlazor.Docs.Compiler
 
                 var directoryInfo = new DirectoryInfo(paths.DocsDirPath);
 
-                foreach (var entry in directoryInfo.GetFileSystemInfos("*.razor", SearchOption.AllDirectories)
-                    .OrderBy(e => e.FullName.Replace("\\", "/"), StringComparer.Ordinal))
+                foreach (var entry in directoryInfo.GetFiles("*.razor", SearchOption.AllDirectories))
                 {
                     if (entry.Name.EndsWith("Code.razor"))
+                    {
                         continue;
+                    }
                     if (!entry.Name.Contains(Paths.ExampleDiscriminator))
                         continue;
-                    var markupPath = entry.FullName.Replace("Examples", "Code").Replace(".razor", "Code.razor");
+                    var markupPath = entry.FullName.Replace("Examples", "Code").Replace(".razor", "Code.html");
                     if (entry.LastWriteTime < lastCheckedTime && File.Exists(markupPath))
                     {
                         continue;
@@ -65,8 +66,8 @@ namespace MudBlazor.Docs.Compiler
                     }
 
                     var cb = new CodeBuilder();
-                    cb.AddLine("@* Auto-generated markup. Any changes will be overwritten *@");
-                    cb.AddLine("@namespace MudBlazor.Docs.Examples.Markup");
+                    // cb.AddLine("@* Auto-generated markup. Any changes will be overwritten *@");
+                    // cb.AddLine("@namespace MudBlazor.Docs.Examples.Markup");
                     cb.AddLine("<div class=\"mud-codeblock\">");
                     cb.AddLine(html.ToLfLineEndings());
                     if (blocks.Length == 2)

--- a/src/MudBlazor.Docs/Components/SectionSource.razor
+++ b/src/MudBlazor.Docs/Components/SectionSource.razor
@@ -1,4 +1,5 @@
-﻿@using MudBlazor.Utilities
+﻿@using System.IO
+@using MudBlazor.Utilities
 
 @inject IJSRuntime JSRuntime
 
@@ -99,8 +100,12 @@
     {
         try
         {
-            builder.OpenComponent(0, CodeType);
-            builder.CloseComponent();
+            var key = typeof(SectionSource).Assembly.GetManifestResourceNames().FirstOrDefault(x => x.Contains($"{Code}Code.html"));
+            using (var stream = typeof(SectionSource).Assembly.GetManifestResourceStream(key))
+            using (var reader = new StreamReader(stream))
+            {
+                builder.AddMarkupContent(0, reader.ReadToEnd());
+            }
         }
         catch (Exception)
         {

--- a/src/MudBlazor.Docs/MudBlazor.Docs.csproj
+++ b/src/MudBlazor.Docs/MudBlazor.Docs.csproj
@@ -2,27 +2,13 @@
 <!--Use: dotnet msbuild -preprocess:<fileName>.xml to evaluate this project-->
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
+  <!--Hook for the generated static content-->
   <PropertyGroup>
     <ResolveStaticWebAssetsInputsDependsOn>
       IncludeGeneratedStaticFiles;
       $(ResolveStaticWebAssetsInputsDependsOn)
     </ResolveStaticWebAssetsInputsDependsOn>
   </PropertyGroup>
-
-  <!--Outside Visual Studio SolutionDir is not available-->  
-  <PropertyGroup>
-    <SolutionDir Condition=" '$(SolutionDir)' == '' ">$(MSBuildThisFileDirectory)..\</SolutionDir>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <RunCommand>dotnet run --configuration release --project "$(SolutionDir)MudBlazor.Docs.Compiler/MudBlazor.Docs.Compiler.csproj"</RunCommand>
-  </PropertyGroup>   
-
-  <!--Execute the code generator-->
-  <Target Name="CompileDocs" BeforeTargets="BeforeBuild;BeforeRebuild">
-    <Message Text="Generating Docs and Tests using $(RunCommand)" Importance="high" />
-    <Exec Command="$(RunCommand)" />
-  </Target>
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -38,6 +24,34 @@
     <DefineConstants>TRACE;LIVESHARP_DISABLE</DefineConstants>
   </PropertyGroup>
 
+  <!--Outside Visual Studio SolutionDir is not available-->  
+  <PropertyGroup>
+    <SolutionDir Condition=" '$(SolutionDir)' == '' ">$(MSBuildThisFileDirectory)../</SolutionDir>
+  </PropertyGroup>
+
+  <!--Binary path for the code generator-->
+  <Choose>
+    <When Condition="'$(TargetFramework)' == 'netstandard2.1'">
+      <PropertyGroup><BinDocsCompiler>$(SolutionDir)MudBlazor.Docs.Compiler/bin/Debug/netcoreapp3.1/MudBlazor.Docs.Compiler.dll</BinDocsCompiler></PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup><BinDocsCompiler>$(SolutionDir)MudBlazor.Docs.Compiler/bin/Debug/net5.0/MudBlazor.Docs.Compiler.dll</BinDocsCompiler></PropertyGroup>
+    </Otherwise>
+  </Choose>
+
+  <!--Project path for code generator-->
+  <PropertyGroup>
+    <ProjectDocsCompiler>dotnet run --configuration release --project "$(SolutionDir)MudBlazor.Docs.Compiler/MudBlazor.Docs.Compiler.csproj"</ProjectDocsCompiler>
+  </PropertyGroup>
+
+  <!--Execute the code generator-->
+  <Target Name="CompileDocs" BeforeTargets="BeforeBuild">
+    <!--Command-line for the code generator-->
+    <Message Text="Generating Docs and Tests" Importance="high" />
+    <Exec Command='dotnet "$(BinDocsCompiler)"' Condition="Exists('$(BinDocsCompiler)')" />
+    <Exec Command="dotnet run $(ProjectDocsCompiler)" Condition="!Exists('$(BinDocsCompiler)')" />
+  </Target>
+
   <!--This file contains any ExampleCode that is new and needs including in the build -->
   <Target Name="ReadFromFile" DependsOnTargets="CompileDocs">
     <ItemGroup>
@@ -48,19 +62,35 @@
     </ReadLinesFromFile>
   </Target>
 
-  <!--Because we have a dynamic content .cs and .razor files comming from the code generator we need to add them -->  
-  <Target Name="IncludeGeneratedFiles" BeforeTargets="BeforeBuild;BeforeRebuild" DependsOnTargets="CompileDocs;ReadFromFile">
+  <!--Add Content that is being generated as part of the build cycle-->
+  <!--We need to do this because the project is not yet aware of files that were generated after the build started-->  
+  <Target Name="IncludeGeneratedFiles" BeforeTargets="BeforeBuild" DependsOnTargets="CompileDocs;ReadFromFile">
     <ItemGroup>
       <Compile Include="Models/Snippets.generated.cs" Condition="!Exists('Models/Snippets.generated.cs')" />
       <Compile Include="Models/DocStrings.generated.cs" Condition="!Exists('Models/DocStrings.generated.cs')" />
-      <RazorComponent Include="@(NewExampleCodeToBuild)" Condition="@(NewExampleCodeToBuild-&gt;Count()) != 0" />
+      <EmbeddedResource Include="@(NewExampleCodeToBuild)" Condition="@(NewExampleCodeToBuild-&gt;Count()) != 0" />
     </ItemGroup>
   </Target>
+ 
+  <!--Update ExampleCode-->
+  <ItemGroup>
+    <EmbeddedResource Update="Pages\**\*.html" />
+  </ItemGroup>
 
+  <!--Used for the periodic table examples-->
   <ItemGroup>
     <EmbeddedResource Include="Data/Elements.json" />
   </ItemGroup>
 
+  <!--Cleanup old ExampleCode files-->
+  <Target Name="CleanGeneratedFiles" BeforeTargets="Clean" >
+    <Exec Command='find ./Pages -type f -name *ExampleCode.* -delete' Condition=" '$(OS)' != 'Windows_NT' " />
+    <Exec Command='find . -type f -name NewFilesToBuild.txt -delete' Condition=" '$(OS)' != 'Windows_NT' " />
+    <Exec Command='powershell -noprofile -c &quot;Remove-Item -path ./Pages/ -recurse -include *ExampleCode.razor,*ExampleCode.html&quot;' Condition=" '$(OS)' == 'Windows_NT' " />
+    <Exec Command='powershell -noprofile -c &quot;if (test-path ./NewFilesToBuild.txt) {Remove-Item ./NewFilesToBuild.txt}&quot;' Condition=" '$(OS)' == 'Windows_NT' " />
+  </Target>
+
+  <!--Packages-->
   <ItemGroup>
     <PackageReference Include="BlazorInputFile" Version="0.2.0" />
     <PackageReference Include="FluentValidation" Version="9.3.0" />
@@ -70,10 +100,12 @@
     <PackageReference Include="Toolbelt.Blazor.HeadElement" Version="5.0.0" />
   </ItemGroup>
 
+  <!--Project dependencies-->
   <ItemGroup>
     <ProjectReference Include="../MudBlazor/MudBlazor.csproj" />
   </ItemGroup>
 
+  <!--Excubo  webcompiler -  used for scss and js compilation-->
   <Target Name="ToolRestore">
       <Exec Command="dotnet tool restore" StandardOutputImportance="high" />
   </Target>
@@ -82,6 +114,7 @@
       <Exec Command="dotnet webcompiler ./Styles/MudBlazorDocs.scss -c excubowebcompiler.json" StandardOutputImportance="high" />
   </Target>
 
+  <!--Output of Excubo webcompiler-->
   <Target Name="IncludeGeneratedStaticFiles" DependsOnTargets="WebCompiler">
     <Error Condition="!Exists('wwwroot/MudBlazorDocs.min.css')" Text="Missing MudBlazorDocs.min.css in wwwroot" />
     <!--If we ever bundle js  for the docs site uncomment the below check-->


### PR DESCRIPTION
- Cuts full build time typically by about 30%.  So for example on my machine I go from 40-43secs to 27-30secs.
- Adds Clean and Rebuild Support for the ExampleCode files.
- Also big speed gains on incremental builds.
- Tested on macOS windows vscode Visual Studio including spaces in paths.
- NOTE: when testing do a clean first if your are not a fresh clone.
- @tungi52 @henon  Would you be willing to test this in your environment?