### PR TITLE
Use native MSBuild tasks

### DIFF
--- a/src/MudBlazor.Docs/MudBlazor.Docs.csproj
+++ b/src/MudBlazor.Docs/MudBlazor.Docs.csproj
@@ -84,10 +84,11 @@
 
   <!--Cleanup old ExampleCode files-->
   <Target Name="CleanGeneratedFiles" BeforeTargets="Clean" >
-    <Exec Command='find ./Pages -type f -name *ExampleCode.* -delete' Condition=" '$(OS)' != 'Windows_NT' " />
-    <Exec Command='find . -type f -name NewFilesToBuild.txt -delete' Condition=" '$(OS)' != 'Windows_NT' " />
-    <Exec Command='powershell -noprofile -c &quot;Remove-Item -path ./Pages/ -recurse -include *ExampleCode.razor,*ExampleCode.html&quot;' Condition=" '$(OS)' == 'Windows_NT' " />
-    <Exec Command='powershell -noprofile -c &quot;if (test-path ./NewFilesToBuild.txt) {Remove-Item ./NewFilesToBuild.txt}&quot;' Condition=" '$(OS)' == 'Windows_NT' " />
+    <ItemGroup>
+      <FilesToClean Include="./Pages/**/*ExampleCode.*" />
+      <FilesToClean Include="./NewFilesToBuild.txt" />
+    </ItemGroup>
+    <Delete Files="@(FilesToClean)" />
   </Target>
 
   <!--Packages-->

--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -47,13 +47,20 @@
     <Exec Command="dotnet tool restore" StandardOutputImportance="high" />
   </Target>
 
-  <Target Name="WebCompiler" DependsOnTargets="ToolRestore">
+  <!--combine js files-->
+  <Target Name="CombineJS">
+    <CreateItem Include="./TScripts/*.js">
+      <Output TaskParameter="Include" ItemName="jsFilesToCombine" />
+    </CreateItem>
+    <ReadLinesFromFile File="%(jsFilesToCombine.FullPath)">
+      <Output TaskParameter="Lines" ItemName="jsLines" />
+    </ReadLinesFromFile>
+    <WriteLinesToFile File="./TScripts/combined/MudBlazor.js" Lines="@(jsLines)" Overwrite="true" />
+  </Target>
+
+  <Target Name="WebCompiler" DependsOnTargets="ToolRestore;CombineJS">
     <!--compile and minify scss-->
     <Exec Command="dotnet webcompiler ./Styles/MudBlazor.scss -c excubowebcompiler.json" StandardOutputImportance="high" />
-    <!--concatenate js files-->
-    <Exec Command="mkdir combined" WorkingDirectory="TScripts" IgnoreExitCode="true" StandardErrorImportance="low" />
-    <Exec Command="cat ./TScripts/*.js &gt; ./TScripts/combined/MudBlazor.js" Condition=" '$(OS)' != 'Windows_NT' " StandardOutputImportance="high" />
-    <Exec Command="powershell -noprofile -c &quot;cat ./TScripts/*.js &gt; ./TScripts/combined/MudBlazor.js&quot;" Condition=" '$(OS)' == 'Windows_NT' " StandardOutputImportance="high" />
     <!--minify js-->
     <Exec Command="dotnet webcompiler ./TScripts/combined/MudBlazor.js -c excubowebcompiler.json" StandardOutputImportance="high" />
   </Target>


### PR DESCRIPTION
- Remove awkward scripting and replace with native MSBuild tasks
- Didn't realise MSBuild had these native tasks.  This is much better for XPlat as it doesn't rely on the script host