### PR TITLE
Wireframe code dialog

### DIFF
--- a/src/MudBlazor.Docs/Styles/components/_docssection.scss
+++ b/src/MudBlazor.Docs/Styles/components/_docssection.scss
@@ -101,7 +101,7 @@
 }
 
 .docs-section-wireframe {
-    height:600px;
+    height: calc(80vh - 124px);
 }
 
 .docs-section-black {


### PR DESCRIPTION
Code dialog are not visible entirely on smaller screens like 1366x768 (header and action bar are out of viewport).