### PR TITLE
MudFab hides the icon if none is specified

### DIFF
--- a/src/MudBlazor/Components/Button/MudFab.razor
+++ b/src/MudBlazor/Components/Button/MudFab.razor
@@ -14,7 +14,10 @@
             rel="@(Target=="_blank"?"noopener":null)"
             disabled="@Disabled">
     <span class="mud-fab-label">
-        <MudIcon Icon="@Icon" Color="@IconColor" Size="@IconSize"></MudIcon>
+        @if (!string.IsNullOrWhiteSpace(Icon))
+        {
+            <MudIcon Icon="@Icon" Color="@IconColor" Size="@IconSize"></MudIcon>
+        }
         @Label
     </span>
 </MudElement>


### PR DESCRIPTION
This preserves the old behavior before the MudIcon rework.