### PR TITLE
Add all generated files to the clean process

### DIFF
--- a/src/MudBlazor.Docs/MudBlazor.Docs.csproj
+++ b/src/MudBlazor.Docs/MudBlazor.Docs.csproj
@@ -86,6 +86,8 @@
     <ItemGroup>
       <FilesToClean Include="./Pages/**/*ExampleCode.*" />
       <FilesToClean Include="./NewFilesToBuild.txt" />
+      <FilesToClean Include="./Models/Snippets.generated.cs" />
+      <FilesToClean Include="./Models/DocStrings.generated.cs" />
     </ItemGroup>
     <Delete Files="@(FilesToClean)" />
   </Target>

--- a/src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj
+++ b/src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj
@@ -12,6 +12,21 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <!--Is this a rebuild - Dont clean generated files as this breaks rebuild behaviour-->
+  <Target Name="ShouldCleanGeneratedFiles" BeforeTargets="BeforeRebuild">
+    <PropertyGroup>
+      <CleanGeneratedFiles>false</CleanGeneratedFiles>
+    </PropertyGroup>
+  </Target>
+  
+  <!--Cleanup old ExampleCode files-->
+  <Target Name="CleanGeneratedFiles" BeforeTargets="Clean" Condition="'$(CleanGeneratedFiles)' != 'false'">
+    <ItemGroup>
+      <FilesToClean Include="./Generated/*.cs" />
+    </ItemGroup>
+    <Delete Files="@(FilesToClean)" />
+  </Target>
+
   <ItemGroup>
     <PackageReference Include="bunit" Version="1.0.0-preview-01" />
     <PackageReference Include="coverlet.msbuild" Version="3.0.2">


### PR DESCRIPTION
- In certain circumstances when switching branches we need to clean generated files as they are outside git and wont switch with branch changes.
- This adds the 4 remaining generated files to the clean process to allow a full clean in that senario.