### PR TITLE
Added test to ensure MudFab with no icon specified does not render an icon.

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ButtonsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ButtonsTests.cs
@@ -157,6 +157,18 @@ namespace MudBlazor.UnitTests
                 .Should()
                 .StartWith("<a");
         }
+
+        /// <summary>
+        /// MudFab should only render an icon if one is specified.
+        /// </summary>
+        [Test]
+        public void MudFabShouldNotRenderIconIfNoneSpecified()
+        {
+            var comp = ctx.RenderComponent<MudFab>();
+            comp.Markup
+                .Should()
+                .NotContainAny("mud-icon-root");
+        }
     }
 }
 


### PR DESCRIPTION
A MudFab with no icon specified should not render an icon.