### PR TITLE
Half the ci build time

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -4,20 +4,18 @@ trigger:
 - net5
 
 stages:
-- stage: Build
+- stage: Build_Test
   jobs:
-  - job: Build_Default
-    displayName: Build Default
+  - job: Build
+    displayName: Build
     pool:
       vmImage: ubuntu-latest
     steps:
       - template: jobs/default-build.yml
-
-- stage: Test
-  jobs:
-  - job: Test_Default
-    displayName: Test Default
+  - job: Test
+    displayName: Test
     pool:
       vmImage: ubuntu-latest
     steps:
       - template: jobs/default-test.yml
+


### PR DESCRIPTION
- Stages force sequencial processing
- Since build and test are not interdependent they shouldn't be forced to run in series
- This PR allows the jobs (on a public devops project) to run in parallel and hence halve the CI build time
- On my devops this PR took 2 mins 36 secs