### PR TITLE
Allow item based css styles and classes for Tables

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableRowClassStyleTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableRowClassStyleTest.razor
@@ -1,0 +1,18 @@
+﻿@using MudBlazor;
+@namespace MudBlazor.UnitTests
+
+<MudTable T="int" Items="items" RowStyleFunc="@((item, index) => item > 1 ? "color: blue" : "color: red")" RowClassFunc="@((item, index) => index % 2 == 0 ? "even" : "odd")">
+    <HeaderContent>
+        <MudTh>#</MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd>@context</MudTd>
+    </RowTemplate>
+</MudTable>
+
+@code {
+    public static string __description__ = "The row style and row class should be placed on the row correctly.";
+
+    int[] items = new int[]{0,1,2,3};
+
+}

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -460,5 +460,33 @@ namespace MudBlazor.UnitTests
             comp.FindAll("td")[1].TextContent.Trim().Should().Be("2");
             comp.FindAll("td")[2].TextContent.Trim().Should().Be("1");
         }
+
+        /// <summary>
+        /// The table should render the classes and style to the tr using the RowStyleFunc and RowClassFunc parameters
+        /// </summary>
+        [Test]
+        public async Task TableRowClassStyleTest()
+        {
+            var comp = ctx.RenderComponent<TableRowClassStyleTest>();
+            Console.WriteLine(comp.Markup);
+            var trs = comp.FindAll("tr");
+            trs.Count.Should().Be(5); // four rows + header row
+            
+            var tds = comp.FindAll("td");
+            tds[0].TextContent.Trim().Should().Be("0");
+            tds[1].TextContent.Trim().Should().Be("1");
+            tds[2].TextContent.Trim().Should().Be("2");
+            tds[3].TextContent.Trim().Should().Be("3");
+
+            trs[1].GetAttribute("style").Contains("color: red");
+            trs[2].GetAttribute("style").Contains("color: red");
+            trs[3].GetAttribute("style").Contains("color: blue");
+            trs[4].GetAttribute("style").Contains("color: blue");
+
+            trs[1].GetAttribute("class").Contains("even");
+            trs[2].GetAttribute("class").Contains("odd");
+            trs[3].GetAttribute("class").Contains("even");
+            trs[4].GetAttribute("class").Contains("odd");
+        }
     }
 }

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -1,6 +1,7 @@
 ﻿@namespace MudBlazor
 @inherits MudTableBase
 @using MudBlazor.Extensions
+@using MudBlazor.Utilities
 @typeparam T
 
 <div @attributes="UserAttributes" class="@Classname" style="@Style">
@@ -42,23 +43,29 @@
                 <tbody class="mud-table-body">
                     @if (CurrentPageItems != null)
                     {
+                        var rowIndex = 0;
                         @foreach (var item in CurrentPageItems)
                         {
-                            <MudTr Class="@RowClass" Style="@RowStyle" Item="item" @key="item" IsCheckable="MultiSelection" IsEditable="RowEditingTemplate != null" 
+                            var rowClass = new CssBuilder(RowClass).AddClass(RowClassFunc?.Invoke(item, rowIndex)).Build();
+                            var rowStyle = new StyleBuilder().AddStyle(RowStyle).AddStyle(RowStyleFunc?.Invoke(item, rowIndex)).Build();
+                            <MudTr Class="@rowClass" Style="@rowStyle" Item="item" @key="item" IsCheckable="MultiSelection" IsEditable="RowEditingTemplate != null" 
                                    IsCheckedChanged="@((value) => { var x = item; OnRowCheckboxChanged(value, x); })">
-                               @if ((!ReadOnly) && RowEditingTemplate != null && object.Equals(_editingItem, item))
+                                @if ((!ReadOnly) && RowEditingTemplate != null && object.Equals(_editingItem, item))
                                 { 
                                     <CascadingValue Value="@Validator" IsFixed="true">
                                         @RowEditingTemplate(item)
                                     </CascadingValue>
                                 }
                                 else
+                                {
                                     @RowTemplate(item)
+                                }
                             </MudTr>
                             @if (ChildRowContent != null)
                             {
                                 @ChildRowContent(item)
                             }
+                            rowIndex++;
                         }
                     }
                 </tbody>

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -74,6 +74,18 @@ namespace MudBlazor
         }
 
         /// <summary>
+        /// Returns the class that will get joined with RowClass. Takes the current item and row index.
+        /// </summary>
+        [Parameter]
+        public Func<T, int, string> RowClassFunc {get;set;}
+
+        /// <summary>
+        /// Returns the style that will get joined with RowStyle. Takes the current item and row index.
+        /// </summary>
+        [Parameter]
+        public Func<T, int, string> RowStyleFunc {get;set;}
+
+        /// <summary>
         /// Returns the item which was last clicked on in single selection mode (that is, if MultiSelection is false)
         /// </summary>
         [Parameter]


### PR DESCRIPTION
Create extra parameters on the MudTable<T> to support item based classes and styles.

```html
 <MudTable ItemRowClass="@(item => item.Value > 350 ? "high" : "")" 
           ItemRowStyle="@(item => item.Value > 350 ? "background: blue" : "")"></MudTable>
```