### PR TITLE
Compiler fix intermediate css and js issues

### DIFF
--- a/src/MudBlazor.Docs/MudBlazor.Docs.csproj
+++ b/src/MudBlazor.Docs/MudBlazor.Docs.csproj
@@ -88,6 +88,7 @@
       <FilesToClean Include="./NewFilesToBuild.txt" />
       <FilesToClean Include="./Models/Snippets.generated.cs" />
       <FilesToClean Include="./Models/DocStrings.generated.cs" />
+      <FilesToClean Include="./wwwroot/MudBlazorDocs.min.css" />
     </ItemGroup>
     <Delete Files="@(FilesToClean)" />
   </Target>

--- a/src/MudBlazor.Docs/excubowebcompiler.json
+++ b/src/MudBlazor.Docs/excubowebcompiler.json
@@ -50,7 +50,7 @@
     }
   },
   "Output": {
-    "Preserve": true,
+    "Preserve": false,
     "Directory": "./wwwroot"
   }
 }

--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -38,6 +38,23 @@
     <None Include="..\..\content\Nuget.png" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>
 
+  <!--Is this a rebuild - Dont clean generated files as this breaks rebuild behaviour-->
+  <Target Name="ShouldCleanGeneratedFiles" BeforeTargets="BeforeRebuild">
+    <PropertyGroup>
+      <CleanGeneratedFiles>false</CleanGeneratedFiles>
+    </PropertyGroup>
+  </Target>
+  
+  <!--Cleanup old ExampleCode files-->
+  <Target Name="CleanGeneratedFiles" BeforeTargets="Clean" Condition="'$(CleanGeneratedFiles)' != 'false'">
+    <ItemGroup>
+      <FilesToClean Include="./TScripts/combined/MudBlazor.js" />
+      <FilesToClean Include="./wwwroot/MudBlazor.min.js" />
+      <FilesToClean Include="./wwwroot/MudBlazor.min.css" />
+    </ItemGroup>
+    <Delete Files="@(FilesToClean)" />
+  </Target>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.8" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.8" />

--- a/src/MudBlazor/excubowebcompiler.json
+++ b/src/MudBlazor/excubowebcompiler.json
@@ -50,7 +50,7 @@
     }
   },
   "Output": {
-    "Preserve": true,
+    "Preserve": false,
     "Directory": "./wwwroot"
   }
 }


### PR DESCRIPTION
- Fixes #731 
- Remove the intermediate files from excubo builds as they were causing the final output to not be updated in certain circumstances.
- Add all the generated css and js to the clean process