### PR TITLE
Update _docssection.scss

### DIFF
--- a/src/MudBlazor.Docs/Styles/components/_docssection.scss
+++ b/src/MudBlazor.Docs/Styles/components/_docssection.scss
@@ -76,6 +76,14 @@
         & > .mud-tooltip-root .mud-icon-button .mud-svg-icon {
             font-size: 1.25rem;
         }
+        
+        @media(max-width: 1280px) {
+            .mud-tooltip-root:last-child .mud-tooltip {
+                left: unset;
+                right: 0;
+                transform: translate(0%,calc(-100% - 10px));
+            }
+        }
     }
 
     & .docs-source-code {


### PR DESCRIPTION
On smaller screens (md and below) the horizontal scrollbar appears in all component pages. After some search I found, that this is caused by the tooltip for github icons above the source codes.