### PR TITLE
Make a correction to documentation for Wireframe2

### DIFF
--- a/src/MudBlazor.Docs/Pages/Getting Started/Wireframes/Wireframes/Examples/Layout2WireframeExample.razor
+++ b/src/MudBlazor.Docs/Pages/Getting Started/Wireframes/Wireframes/Examples/Layout2WireframeExample.razor
@@ -11,7 +11,7 @@
         <MudAppBarSpacer />
         <MudIconButton Icon="@Icons.Material.Filled.MoreVert" Color="Color.Inherit" Edge="Edge.End" />
     </MudAppBar>
-    <MudDrawer @bind-Open="_drawerOpen" Clipped="true" Elevation="2">
+    <MudDrawer @bind-Open="_drawerOpen" ClipMode="DrawerClipMode.Always" Elevation="2">
         @*NavMenu*@
     </MudDrawer>
     <MudMainContent>


### PR DESCRIPTION
This makes the wireframe2 example behave like the thumbnail looks like it should.