### PR TITLE
Switch to url transfer of snippets

### DIFF
--- a/src/MudBlazor.Docs/Components/SectionSource.razor
+++ b/src/MudBlazor.Docs/Components/SectionSource.razor
@@ -1,9 +1,4 @@
-﻿@using System.IO
-@using MudBlazor.Utilities
-
-@inject IJSRuntime JSRuntime
-
-<div class="docs-section-source @Class">
+﻿<div class="docs-section-source @Class">
     @if (!NoToolbar)
     {
     <div class="docs-content-toolbar">
@@ -17,12 +12,11 @@
             <MudTooltip Text="@TooltipSourceCodeText" Placement="Placement.Top">
                 <MudIconButton Icon="@Icons.Material.Filled.Code" OnClick="OnShowCode" />
             </MudTooltip>
-            @if (!String.IsNullOrEmpty(SnippetId))
-            {
-                <MudTooltip Text="Edit on TryMudBlazor" Placement="Placement.Top">
-                    <MudIconButton Icon="@Icons.Material.Filled.Create" Link="@TryMudBlazorSnippetLink" Target="_blank" />
-                </MudTooltip>
-            }
+
+            <MudTooltip Text="Edit on TryMudBlazor" Placement="Placement.Top">
+                <MudIconButton Icon="@Icons.Material.Filled.Create" OnClick="EditOnTryMudBlazor" />
+            </MudTooltip>
+
             @if (!String.IsNullOrEmpty(Code))
             {
                 <MudTooltip Text="Copy Code" Placement="Placement.Top">
@@ -43,95 +37,3 @@
         @CodeComponent()
     </div>
 </div>
-
-@code {
-
-    [Parameter] public string Title { get; set; }
-
-    [Parameter] public string Code { get; set; }
-
-    [Parameter] public string Class { get; set; }
-
-    [Parameter] public string GitHubFolderName { get; set; }
-
-    [Parameter] public string SnippetId { get; set; }
-
-    [Parameter] public bool ShowCode { get; set; } = true;
-
-    [Parameter] public bool HideButtons { get; set; }
-
-    [Parameter] public bool NoToolbar { get; set; }
-
-    private string GitHubSourceCode { get; set; }
-
-    private string TryMudBlazorSnippetLink { get; set; }
-
-    public string TooltipSourceCodeText { get; set; }
-
-    private string showCodeExampleString { get; set; } = "Show code example";
-    private string hideCodeExampleString { get; set; } = "Hide code example";
-    private string showComponentCodeExampleString { get; set; } = "Show component code example";
-    private string hideComponentCodeExampleString { get; set; } = "Hide component code example";
-
-    private async Task CopyTextToClipboard()
-    {
-        await JSRuntime.InvokeVoidAsync("clipboardCopy.copyText", @Snippets.GetCode(Code));
-    }
-
-    public void OnShowCode()
-    {
-        if (!String.IsNullOrEmpty(Code))
-        {
-            ShowCode = !ShowCode;
-            if (ShowCode)
-            {
-                TooltipSourceCodeText = hideCodeExampleString;
-            }
-            else
-            {
-                TooltipSourceCodeText = showCodeExampleString;
-            }
-        }
-    }
-
-    private Type CodeType => Type.GetType("MudBlazor.Docs.Examples.Markup." + Code + "Code");
-
-    RenderFragment CodeComponent() => builder =>
-    {
-        try
-        {
-            var key = typeof(SectionSource).Assembly.GetManifestResourceNames().FirstOrDefault(x => x.Contains($"{Code}Code.html"));
-            using (var stream = typeof(SectionSource).Assembly.GetManifestResourceStream(key))
-            using (var reader = new StreamReader(stream))
-            {
-                builder.AddMarkupContent(0, reader.ReadToEnd());
-            }
-        }
-        catch (Exception)
-        {
-            // todo: log this
-        }
-    };
-
-    protected override void OnInitialized()
-    {
-        if (!String.IsNullOrEmpty(SnippetId))
-        {
-            string TryMudBlazorLink = "https://try.mudblazor.com/";
-            TryMudBlazorSnippetLink = $"{TryMudBlazorLink}snippet/{SnippetId}";
-        }
-        if (!String.IsNullOrEmpty(GitHubFolderName))
-        {
-            string GitHubLink = "https://github.com/";
-            GitHubSourceCode = $"{GitHubLink}Garderoben/MudBlazor/blob/master/src/MudBlazor.Docs/Pages/Components/{GitHubFolderName}/Examples/{Code}.razor";
-        }
-        if (ShowCode)
-        {
-            TooltipSourceCodeText = hideCodeExampleString;
-        }
-        else
-        {
-            TooltipSourceCodeText = showCodeExampleString;
-        }
-    }
-}

--- a/src/MudBlazor.Docs/Components/SectionSource.razor.cs
+++ b/src/MudBlazor.Docs/Components/SectionSource.razor.cs
@@ -1,0 +1,110 @@
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+
+using MudBlazor.Docs.Models;
+using MudBlazor.Docs.Extensions;
+
+using System;
+using Microsoft.JSInterop;
+using System.Linq;
+
+namespace MudBlazor.Docs.Components
+{
+    public partial class SectionSource
+    {
+        [Inject]
+        protected IJSRuntime _jsRuntime { get; set; }
+
+        [Parameter] public string Title { get; set; }
+
+        [Parameter] public string Code { get; set; }
+
+        [Parameter] public string Class { get; set; }
+
+        [Parameter] public string GitHubFolderName { get; set; }
+
+        [Parameter] public bool ShowCode { get; set; } = true;
+
+        [Parameter] public bool HideButtons { get; set; }
+
+        [Parameter] public bool NoToolbar { get; set; }
+
+        private string GitHubSourceCode { get; set; }
+
+        public string TooltipSourceCodeText { get; set; }
+
+        private string showCodeExampleString { get; set; } = "Show code example";
+        private string hideCodeExampleString { get; set; } = "Hide code example";
+        private string showComponentCodeExampleString { get; set; } = "Show component code example";
+        private string hideComponentCodeExampleString { get; set; } = "Hide component code example";
+
+        private async Task CopyTextToClipboard()
+        {
+            await _jsRuntime.InvokeVoidAsync("clipboardCopy.copyText", Snippets.GetCode(Code));
+        }
+
+        public void OnShowCode()
+        {
+            if (!string.IsNullOrEmpty(Code))
+            {
+                ShowCode = !ShowCode;
+                if (ShowCode)
+                {
+                    TooltipSourceCodeText = hideCodeExampleString;
+                }
+                else
+                {
+                    TooltipSourceCodeText = showCodeExampleString;
+                }
+            }
+        }
+
+        private Type CodeType => Type.GetType("MudBlazor.Docs.Examples.Markup." + Code + "Code");
+
+        RenderFragment CodeComponent() => builder =>
+        {
+            try
+            {
+                var key = typeof(SectionSource).Assembly.GetManifestResourceNames().FirstOrDefault(x => x.Contains($"{Code}Code.html"));
+                using (var stream = typeof(SectionSource).Assembly.GetManifestResourceStream(key))
+                using (var reader = new StreamReader(stream))
+                {
+                    builder.AddMarkupContent(0, reader.ReadToEnd());
+                }
+            }
+            catch (Exception)
+            {
+                // todo: log this
+            }
+        };
+
+        protected virtual async void EditOnTryMudBlazor()
+        {
+            // We use a seperator that wont be in code so we can send 2 files later
+            var codeFile = "__Main.razor" + (char)31 + Snippets.GetCode(Code);
+            var codeFileEncoded = codeFile.ToCompressedEncodedUrl();
+            // var tryMudBlazorLocation = "https://localhost:5001/";
+            var tryMudBlazorLocation = "https://try.mudblazor.com/";
+            var url = $"{tryMudBlazorLocation}snippet/{codeFileEncoded}";
+            await _jsRuntime.InvokeAsync<string>("open", url, "_blank");
+        }
+
+        protected override void OnInitialized()
+        {
+            if (!string.IsNullOrEmpty(GitHubFolderName))
+            {
+                var gitHubLink = "https://github.com/";
+                GitHubSourceCode = $"{gitHubLink}Garderoben/MudBlazor/blob/master/src/MudBlazor.Docs/Pages/Components/{GitHubFolderName}/Examples/{Code}.razor";
+            }
+            if (ShowCode)
+            {
+                TooltipSourceCodeText = hideCodeExampleString;
+            }
+            else
+            {
+                TooltipSourceCodeText = showCodeExampleString;
+            }
+        }
+    }
+}

--- a/src/MudBlazor.Docs/Extensions/StringExtensions.cs
+++ b/src/MudBlazor.Docs/Extensions/StringExtensions.cs
@@ -1,6 +1,10 @@
-﻿using System.Linq;
+﻿using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.WebUtilities;
 
 namespace MudBlazor.Docs.Extensions
 {
@@ -64,6 +68,24 @@ namespace MudBlazor.Docs.Extensions
             if (str.Length > 1)
                 return char.ToUpper(str[0]) + str.Substring(1);
             return str.ToUpper();
+        }
+
+        public static string ToCompressedEncodedUrl(this string code)
+        {
+            string urlEncodedBase64compressedCode;
+            byte[] bytes;
+
+            using (var uncompressed = new MemoryStream(Encoding.UTF8.GetBytes(code)))
+            using (var compressed = new MemoryStream())
+            using (var compressor = new DeflateStream(compressed, CompressionMode.Compress))
+            {
+                uncompressed.CopyTo(compressor);
+                compressor.Close();
+                bytes = compressed.ToArray();
+                urlEncodedBase64compressedCode = WebEncoders.Base64UrlEncode(bytes);
+
+                return urlEncodedBase64compressedCode;
+            }
         }
     }
 }

--- a/src/MudBlazor.Docs/MudBlazor.Docs.csproj
+++ b/src/MudBlazor.Docs/MudBlazor.Docs.csproj
@@ -97,6 +97,7 @@
     <PackageReference Include="FluentValidation" Version="9.5.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="5.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="5.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Toolbelt.Blazor.HeadElement" Version="5.4.1" />
   </ItemGroup>

--- a/src/MudBlazor.Docs/Pages/Components/Alert/AlertPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Alert/AlertPage.razor
@@ -11,7 +11,7 @@
             <SectionContent Outlined="true" FullWidth="true" Class="demo-alert">
                 <AlertSimpleExample />
             </SectionContent>
-            <SectionSource Code="AlertSimpleExample" GitHubFolderName="Alert" SnippetId="wkbuPNFB24rylh7q05" />
+            <SectionSource Code="AlertSimpleExample" GitHubFolderName="Alert"  />
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>
@@ -24,14 +24,14 @@
             <SectionContent Outlined="true" FullWidth="true" Class="demo-alert">
                 <AlertOutlinedExample />
             </SectionContent>
-            <SectionSource Code="AlertOutlinedExample" GitHubFolderName="Alert" SnippetId="GubEljbB262uQFmq50" />
+            <SectionSource Code="AlertOutlinedExample" GitHubFolderName="Alert"  />
             <SectionHeader>
                 <SubTitle>Filled</SubTitle>
             </SectionHeader>
             <SectionContent Outlined="true" FullWidth="true" Class="demo-alert">
                 <AlertFilledExample />
             </SectionContent>
-            <SectionSource Code="AlertFilledExample" GitHubFolderName="Alert" SnippetId="wObuFDPL27j5J1d335" />
+            <SectionSource Code="AlertFilledExample" GitHubFolderName="Alert"  />
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>
@@ -51,7 +51,7 @@
                     </MudItem>
                 </MudGrid>
             </SectionContent>
-            <SectionSource Code="AlertDenseExample" ShowCode="false" GitHubFolderName="Alert" SnippetId="GYbYlZvr31xGqvnV56" />
+            <SectionSource Code="AlertDenseExample" ShowCode="false" GitHubFolderName="Alert"  />
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>
@@ -71,7 +71,7 @@
                     </MudItem>
                 </MudGrid>
             </SectionContent>
-            <SectionSource Code="AlertNoIconExample" ShowCode="false" GitHubFolderName="Alert" SnippetId="waPalXbh33wKQNel11" />
+            <SectionSource Code="AlertNoIconExample" ShowCode="false" GitHubFolderName="Alert"  />
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>
@@ -101,7 +101,7 @@
             <SectionContent Outlined="true">
                 <AlertElevationExample />
             </SectionContent>
-            <SectionSource Code="AlertElevationExample" ShowCode="true" GitHubFolderName="Alert" SnippetId="wEbYbXbh39MhqxpG40" />
+            <SectionSource Code="AlertElevationExample" ShowCode="true" GitHubFolderName="Alert"  />
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>

--- a/src/MudBlazor.Docs/Pages/Components/AppBar/AppBarPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/AppBar/AppBarPage.razor
@@ -19,7 +19,7 @@
             <SectionContent DarkenBackground="true" DisplayFlex="true">
                 <AppBarSimpleExample />
             </SectionContent>
-            <SectionSource Code="AppBarSimpleExample" GitHubFolderName="AppBar" SnippetId="mOFaPtka53xCrNWW09" />
+            <SectionSource Code="AppBarSimpleExample" GitHubFolderName="AppBar"  />
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>
@@ -29,7 +29,7 @@
             <SectionContent DarkenBackground="true" DisplayFlex="true">
                 <AppBarElevationExample />
             </SectionContent>
-            <SectionSource Code="AppBarElevationExample" GitHubFolderName="AppBar" SnippetId="GYPklNuY54EouQ3o21" />
+            <SectionSource Code="AppBarElevationExample" GitHubFolderName="AppBar"  />
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>
@@ -39,7 +39,7 @@
             <SectionContent DarkenBackground="true" DisplayFlex="true">
                 <AppBarDenseExample />
             </SectionContent>
-            <SectionSource Code="AppBarDenseExample" GitHubFolderName="AppBar" SnippetId="QObYPXEu55XhmIv000" />
+            <SectionSource Code="AppBarDenseExample" GitHubFolderName="AppBar"  />
         </DocsPageSection>
     </DocsPageContent>
 </DocsPage>

--- a/src/MudBlazor.Docs/Pages/Components/Avatar/AvatarPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Avatar/AvatarPage.razor
@@ -11,7 +11,7 @@
             <SectionContent Outlined="true" DisplayFlex="true">
                 <AvatarLetterExample />
             </SectionContent>
-            <SectionSource Code="AvatarLetterExample" GitHubFolderName="Avatar" SnippetId="ckvaPMPV45ToD6NA01" />
+            <SectionSource Code="AvatarLetterExample" GitHubFolderName="Avatar"  />
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>
@@ -21,7 +21,7 @@
             <SectionContent Outlined="true" DisplayFlex="true">
                 <AvatarIconExample />
             </SectionContent>
-            <SectionSource Code="AvatarIconExample" GitHubFolderName="Avatar" SnippetId="wYbEFWvL47q3eTt923" />
+            <SectionSource Code="AvatarIconExample" GitHubFolderName="Avatar"  />
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>
@@ -31,7 +31,7 @@
             <SectionContent Outlined="true" DisplayFlex="true">
                 <AvatarImageExample />
             </SectionContent>
-            <SectionSource Code="AvatarImageExample" GitHubFolderName="Avatar" SnippetId="waPEPXYO1123ifsj17" />
+            <SectionSource Code="AvatarImageExample" GitHubFolderName="Avatar"  />
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>
@@ -41,7 +41,7 @@
             <SectionContent Outlined="true">
                 <AvatarSizeExample />
             </SectionContent>
-            <SectionSource Code="AvatarSizeExample" GitHubFolderName="Avatar" SnippetId="QEPElXkY09D3uk9y53" />
+            <SectionSource Code="AvatarSizeExample" GitHubFolderName="Avatar"  />
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>
@@ -51,7 +51,7 @@
             <SectionContent Outlined="true" DisplayFlex="true">
                 <AvatarVariantsExample />
             </SectionContent>
-            <SectionSource Code="AvatarVariantsExample" GitHubFolderName="Avatar" SnippetId="mElubWbM34KiP3qd46" />
+            <SectionSource Code="AvatarVariantsExample" GitHubFolderName="Avatar"  />
         </DocsPageSection>
     </DocsPageContent>
 </DocsPage>

--- a/src/MudBlazor.Docs/Pages/Components/Breadcrumbs/BreadcrumbsPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Breadcrumbs/BreadcrumbsPage.razor
@@ -13,7 +13,7 @@
             <SectionContent Outlined="true">
                 <BreadcrumbsBasicExample />
             </SectionContent>
-            <SectionSource Code="BreadcrumbsBasicExample" GitHubFolderName="Breadcrumbs" SnippetId="TODO" />
+            <SectionSource Code="BreadcrumbsBasicExample" GitHubFolderName="Breadcrumbs"  />
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>
@@ -23,12 +23,12 @@
             <SectionContent Outlined="true">
                 <BreadcrumbsSeparatorExample />
             </SectionContent>
-            <SectionSource Code="BreadcrumbsSeparatorExample" GitHubFolderName="Breadcrumbs" SnippetId="TODO" />
+            <SectionSource Code="BreadcrumbsSeparatorExample" GitHubFolderName="Breadcrumbs"  />
             <MudText Class="mt-6" GutterBottom="true">It is also possible to provide a <CodeInline>RenderFragment</CodeInline> as a template.</MudText>
             <SectionContent Outlined="true">
                 <BreadcrumbsSeparatorTemplateExample />
             </SectionContent>
-            <SectionSource Code="BreadcrumbsSeparatorTemplateExample" GitHubFolderName="Breadcrumbs" SnippetId="TODO" />
+            <SectionSource Code="BreadcrumbsSeparatorTemplateExample" GitHubFolderName="Breadcrumbs"  />
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>
@@ -38,7 +38,7 @@
             <SectionContent Outlined="true">
                 <BreadcrumbsItemIconsExample />
             </SectionContent>
-            <SectionSource Code="BreadcrumbsItemIconsExample" GitHubFolderName="Breadcrumbs" SnippetId="TODO" />
+            <SectionSource Code="BreadcrumbsItemIconsExample" GitHubFolderName="Breadcrumbs"  />
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>
@@ -48,7 +48,7 @@
             <SectionContent Outlined="true">
                 <BreadcrumbsItemTemplateExample />
             </SectionContent>
-            <SectionSource Code="BreadcrumbsItemTemplateExample" GitHubFolderName="Breadcrumbs" SnippetId="TODO" />
+            <SectionSource Code="BreadcrumbsItemTemplateExample" GitHubFolderName="Breadcrumbs"  />
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>
@@ -58,7 +58,7 @@
             <SectionContent Outlined="true">
                 <BreadcrumbsCollapsedExample />
             </SectionContent>
-            <SectionSource Code="BreadcrumbsCollapsedExample" GitHubFolderName="Breadcrumbs" SnippetId="TODO" />
+            <SectionSource Code="BreadcrumbsCollapsedExample" GitHubFolderName="Breadcrumbs"  />
         </DocsPageSection>
     </DocsPageContent>
 </DocsPage>

--- a/src/MudBlazor.Docs/Pages/Components/Button/ButtonPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Button/ButtonPage.razor
@@ -14,12 +14,12 @@
             <SectionContent Outlined="true">
                 <ButtonFilledExample />
             </SectionContent>
-            <SectionSource Code="ButtonFilledExample" GitHubFolderName="Button" SnippetId="mObaPsvH27AGoDOC39" />
+            <SectionSource Code="ButtonFilledExample" GitHubFolderName="Button"  />
             <MudText Class="mt-6" GutterBottom="true">Elevation can be removed with the <CodeInline>DisableElevation</CodeInline> bool.</MudText>
             <SectionContent Outlined="true">
                 <ButtonElevationExample />
             </SectionContent>
-            <SectionSource Code="ButtonElevationExample" GitHubFolderName="Button" SnippetId="GYPYPWbx43vBOU5a02" />
+            <SectionSource Code="ButtonElevationExample" GitHubFolderName="Button"  />
         </DocsPageSection>
 
         <DocsPageSection>
@@ -30,7 +30,7 @@
             <SectionContent Outlined="true">
                 <ButtonTextExample />
             </SectionContent>
-            <SectionSource Code="ButtonTextExample" GitHubFolderName="Button" SnippetId="wulklNOO194rB6nG16" />
+            <SectionSource Code="ButtonTextExample" GitHubFolderName="Button"  />
         </DocsPageSection>
 
         <DocsPageSection>
@@ -41,7 +41,7 @@
             <SectionContent Outlined="true">
                 <ButtonOutlinedExample />
             </SectionContent>
-            <SectionSource Code="ButtonOutlinedExample" GitHubFolderName="Button" SnippetId="QOPEFDOY20EAuFzE02" />
+            <SectionSource Code="ButtonOutlinedExample" GitHubFolderName="Button"  />
         </DocsPageSection>
 
         <DocsPageSection>
@@ -52,7 +52,7 @@
             <SectionContent Outlined="true">
                 <ButtonSizeExample />
             </SectionContent>
-            <SectionSource Code="ButtonSizeExample" ShowCode="false" GitHubFolderName="Button" SnippetId="ckPavXua20X5dRXF43" />
+            <SectionSource Code="ButtonSizeExample" ShowCode="false" GitHubFolderName="Button"  />
         </DocsPageSection>
 
         <DocsPageSection>
@@ -63,7 +63,7 @@
             <SectionContent Outlined="true">
                 <ButtonIconLabelExample />
             </SectionContent>
-            <SectionSource Code="ButtonIconLabelExample" ShowCode="false" GitHubFolderName="Button" SnippetId="QEFaPZka22tznIYS55" />
+            <SectionSource Code="ButtonIconLabelExample" ShowCode="false" GitHubFolderName="Button"  />
         </DocsPageSection>
 
         <DocsPageSection>
@@ -74,7 +74,7 @@
             <SectionContent Outlined="true">
                 <ButtonCustomizedExample />
             </SectionContent>
-            <SectionSource Code="ButtonCustomizedExample" ShowCode="false" GitHubFolderName="Button" SnippetId="GuPYFNEY23jaQ3gK26" />
+            <SectionSource Code="ButtonCustomizedExample" ShowCode="false" GitHubFolderName="Button"  />
         </DocsPageSection>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/ButtonFAB/FabPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ButtonFAB/FabPage.razor
@@ -11,7 +11,7 @@
             <SectionContent Outlined="true">
                 <FabSimpleExample />
             </SectionContent>
-            <SectionSource Code="FabSimpleExample" GitHubFolderName="Fab" SnippetId="cYPaFjOO05lZ8eBo39"></SectionSource>
+            <SectionSource Code="FabSimpleExample" GitHubFolderName="Fab" ></SectionSource>
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>
@@ -21,7 +21,7 @@
             <SectionContent Outlined="true">
                 <FabSizeExample />
             </SectionContent>
-            <SectionSource Code="FabSizeExample" GitHubFolderName="Fab" SnippetId="cklYFjuk07DCv2rA35"></SectionSource>
+            <SectionSource Code="FabSizeExample" GitHubFolderName="Fab" ></SectionSource>
         </DocsPageSection>
     </DocsPageContent>
 </DocsPage>

--- a/src/MudBlazor.Docs/Pages/Components/Card/CardPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Card/CardPage.razor
@@ -16,7 +16,7 @@
             <SectionContent DarkenBackground="true">
                 <CardSimpleExample />
             </SectionContent>
-            <SectionSource Code="CardSimpleExample" GitHubFolderName="Card" SnippetId="QulEmuba17txN3RH15"></SectionSource>
+            <SectionSource Code="CardSimpleExample" GitHubFolderName="Card" ></SectionSource>
         </DocsPageSection>
 
         <DocsPageSection>
@@ -27,7 +27,7 @@
             <SectionContent DarkenBackground="true">
                 <CardOutlinedExample />
             </SectionContent>
-            <SectionSource Code="CardOutlinedExample" GitHubFolderName="Card" SnippetId="QuPYcOFu18jfodh920"></SectionSource>
+            <SectionSource Code="CardOutlinedExample" GitHubFolderName="Card" ></SectionSource>
         </DocsPageSection>
 
         <DocsPageSection>
@@ -38,7 +38,7 @@
             <SectionContent DarkenBackground="true">
                 <CardHeaderExample />
             </SectionContent>
-            <SectionSource Code="CardHeaderExample" GitHubFolderName="Card" SnippetId="mOlEGYvO18VuFTUb55">
+            <SectionSource Code="CardHeaderExample" GitHubFolderName="Card" >
             </SectionSource>
         </DocsPageSection>
 
@@ -50,7 +50,7 @@
             <SectionContent DarkenBackground="true">
                 <CardMediaExample />
             </SectionContent>
-            <SectionSource Code="CardMediaExample" GitHubFolderName="Card" SnippetId="QklaQubk22unMGdy30"></SectionSource>
+            <SectionSource Code="CardMediaExample" GitHubFolderName="Card" ></SectionSource>
         </DocsPageSection>
 
         <DocsPageSection>
@@ -61,7 +61,7 @@
             <SectionContent DarkenBackground="true">
                 <CardCombinedExample />
             </SectionContent>
-            <SectionSource Code="CardCombinedExample" GitHubFolderName="Card" SnippetId="QuvYQYFa23x3NUAJ36"></SectionSource>
+            <SectionSource Code="CardCombinedExample" GitHubFolderName="Card" ></SectionSource>
         </DocsPageSection>
     </DocsPageContent>
 </DocsPage>

--- a/src/MudBlazor.Docs/Pages/Components/Checkbox/CheckboxPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Checkbox/CheckboxPage.razor
@@ -15,7 +15,7 @@
             <SectionContent Outlined="true">
                 <CheckboxBasicExample />
             </SectionContent>
-            <SectionSource Code="CheckboxBasicExample" GitHubFolderName="Checkbox" SnippetId="wabuFtku57JoZq4T13"></SectionSource>
+            <SectionSource Code="CheckboxBasicExample" GitHubFolderName="Checkbox" ></SectionSource>
         </DocsPageSection>
 
         <DocsPageSection>
@@ -26,7 +26,7 @@
             <SectionContent Outlined="true">
                 <CheckboxLabelExample />
             </SectionContent>
-            <SectionSource Code="CheckboxLabelExample" GitHubFolderName="Checkbox" SnippetId="QaPubtak57NxJlnH55"></SectionSource>
+            <SectionSource Code="CheckboxLabelExample" GitHubFolderName="Checkbox" ></SectionSource>
         </DocsPageSection>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/Divider/DividerPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Divider/DividerPage.razor
@@ -11,7 +11,7 @@
             <SectionContent DarkenBackground="true" DisplayFlex="true" Class="demo-divider">
                 <DividerListExample />
             </SectionContent>
-            <SectionSource Code="DividerListExample" GitHubFolderName="Divider" SnippetId="QYPYwkPa52fNY8tU29" />
+            <SectionSource Code="DividerListExample" GitHubFolderName="Divider"  />
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>
@@ -21,7 +21,7 @@
             <SectionContent DarkenBackground="true" DisplayFlex="true" Class="demo-divider">
                 <DividerInsertExample />
             </SectionContent>
-            <SectionSource Code="DividerInsertExample" GitHubFolderName="Divider" SnippetId="GkbEmYbu53700GhF27" />
+            <SectionSource Code="DividerInsertExample" GitHubFolderName="Divider"  />
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>
@@ -31,7 +31,7 @@
             <SectionContent DarkenBackground="true" DisplayFlex="true">
                 <DividerMiddleExample />
             </SectionContent>
-            <SectionSource Code="DividerMiddleExample" GitHubFolderName="Divider" SnippetId="QubYmOFa28ijp2gd05" />
+            <SectionSource Code="DividerMiddleExample" GitHubFolderName="Divider"  />
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>
@@ -41,7 +41,7 @@
             <SectionContent DarkenBackground="true" DisplayFlex="true" Class="demo-divider-vertical">
                 <DividerVerticalExample />
             </SectionContent>
-            <SectionSource Code="DividerVerticalExample" GitHubFolderName="Divider" SnippetId="" />
+            <SectionSource Code="DividerVerticalExample" GitHubFolderName="Divider"  />
         </DocsPageSection>
     </DocsPageContent>
 </DocsPage>

--- a/src/MudBlazor.Docs/Pages/Components/ExpansionPanel/ExpansionPanelPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ExpansionPanel/ExpansionPanelPage.razor
@@ -11,7 +11,7 @@
             <SectionContent DarkenBackground="true" FullWidth="true">
                 <ExpansionPanelSimpleExample />
             </SectionContent>
-            <SectionSource Code="ExpansionPanelSimpleExample" ShowCode="false" GitHubFolderName="ExpansionPanel" SnippetId="ckPkmkPu329EmuTg21" />
+            <SectionSource Code="ExpansionPanelSimpleExample" ShowCode="false" GitHubFolderName="ExpansionPanel"  />
         </DocsPageSection>
 
         <DocsPageSection>
@@ -22,7 +22,7 @@
             <SectionContent DarkenBackground="true" FullWidth="true">
                 <ExpansionPanelMultiExample />
             </SectionContent>
-            <SectionSource Code="ExpansionPanelMultiExample" GitHubFolderName="ExpansionPanel" SnippetId="cOFEwkbu33egg5Hy55" />
+            <SectionSource Code="ExpansionPanelMultiExample" GitHubFolderName="ExpansionPanel"  />
         </DocsPageSection>
 
         <DocsPageSection>
@@ -33,7 +33,7 @@
             <SectionContent DarkenBackground="true" FullWidth="true">
                 <ExpansionPanelDisabledExample />
             </SectionContent>
-            <SectionSource Code="ExpansionPanelDisabledExample" GitHubFolderName="ExpansionPanel" SnippetId="mYvYwOFu34nF5sRW34" />
+            <SectionSource Code="ExpansionPanelDisabledExample" GitHubFolderName="ExpansionPanel"  />
         </DocsPageSection>
 
         <DocsPageSection>
@@ -44,7 +44,7 @@
             <SectionContent DarkenBackground="true" FullWidth="true">
                 <ExpansionPanelTitleExample />
             </SectionContent>
-            <SectionSource Code="ExpansionPanelTitleExample" GitHubFolderName="ExpansionPanel" SnippetId="mYvYwOFu34nF5sRW35" />
+            <SectionSource Code="ExpansionPanelTitleExample" GitHubFolderName="ExpansionPanel"  />
         </DocsPageSection>
         
     </DocsPageContent>

--- a/src/MudBlazor.Docs/Pages/Components/FileUpload/FileUploadPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/FileUpload/FileUploadPage.razor
@@ -90,7 +90,7 @@
             <SectionContent FullWidth="true" DarkenBackground="true">
                 <FileUploadValidationExample />
             </SectionContent>
-            <SectionSource ShowCode="false"  Code="FileUploadValidationExample" GitHubFolderName="Button" SnippetId="" />
+            <SectionSource ShowCode="false"  Code="FileUploadValidationExample" GitHubFolderName="Button"  />
         </DocsPageSection>
 
         <DocsPageSection>
@@ -101,7 +101,7 @@
             <SectionContent FullWidth="true" DarkenBackground="true">
                 <DragAndDropFileUploadExample />
             </SectionContent>
-            <SectionSource ShowCode="false"  Code="DragAndDropFileUploadExample" GitHubFolderName="Button" SnippetId="" />
+            <SectionSource ShowCode="false"  Code="DragAndDropFileUploadExample" GitHubFolderName="Button"  />
         </DocsPageSection>
     </DocsPageContent>
 </DocsPage>

--- a/src/MudBlazor.Docs/Pages/Components/Grid/GridPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Grid/GridPage.razor
@@ -26,7 +26,7 @@
             <SectionContent DarkenBackground="true" FullWidth="true" Class="demo-grid-basic">
                 <GridBasicExample />
             </SectionContent>
-            <SectionSource Code="GridBasicExample" ShowCode="false" GitHubFolderName="Grid" SnippetId="cYbObDYk17gusra149" />
+            <SectionSource Code="GridBasicExample" ShowCode="false" GitHubFolderName="Grid"  />
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>

--- a/src/MudBlazor.Docs/Pages/Components/IconButton/IconButtonPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/IconButton/IconButtonPage.razor
@@ -15,7 +15,7 @@
             <SectionContent Outlined="true">
                 <IconButtonSimpleExample />
             </SectionContent>
-            <SectionSource Code="IconButtonSimpleExample" GitHubFolderName="IconButton" SnippetId="QulkltYk24i8BjV501" />
+            <SectionSource Code="IconButtonSimpleExample" GitHubFolderName="IconButton"  />
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>
@@ -25,7 +25,7 @@
             <SectionContent Outlined="true">
                 <IconButtonFontIconExample />
             </SectionContent>
-            <SectionSource Code="IconButtonFontIconExample" GitHubFolderName="IconButton" SnippetId="QulkltYk24i8BjV501" />
+            <SectionSource Code="IconButtonFontIconExample" GitHubFolderName="IconButton"  />
         </DocsPageSection>
     </DocsPageContent>
 </DocsPage>

--- a/src/MudBlazor.Docs/Pages/Components/Icons/IconsPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Icons/IconsPage.razor
@@ -21,7 +21,7 @@
             <SectionContent Outlined="true">
                 <IconsUsageExample />
             </SectionContent>
-            <SectionSource Code="IconsUsageExample" GitHubFolderName="Icons" SnippetId="wYPEbXuu25mdf72u44" />
+            <SectionSource Code="IconsUsageExample" GitHubFolderName="Icons"  />
         </DocsPageSection>
 
         <DocsPageSection>
@@ -31,7 +31,7 @@
             <SectionContent Outlined="true">
                 <IconsColorExample />
             </SectionContent>
-            <SectionSource Code="IconsColorExample" GitHubFolderName="Icons" SnippetId="QOlalDau26TxrT2b36" />
+            <SectionSource Code="IconsColorExample" GitHubFolderName="Icons"  />
         </DocsPageSection>
 
         <DocsPageSection>
@@ -41,7 +41,7 @@
             <SectionContent Outlined="true">
                 <IconsSizeExample />
             </SectionContent>
-            <SectionSource Code="IconsSizeExample" GitHubFolderName="Icons" SnippetId="cOvYFDuO27i9UmLR01" />
+            <SectionSource Code="IconsSizeExample" GitHubFolderName="Icons"  />
         </DocsPageSection>
 
         <DocsPageSection>
@@ -52,7 +52,7 @@
             <SectionContent Outlined="true">
                 <IconsFontAwesomeExample />
             </SectionContent>
-            <SectionSource Code="IconsFontAwesomeExample" GitHubFolderName="Icons" SnippetId="mYbYbjkO282nWT5Y23" />
+            <SectionSource Code="IconsFontAwesomeExample" GitHubFolderName="Icons"  />
         </DocsPageSection>
     </DocsPageContent>
 </DocsPage>

--- a/src/MudBlazor.Docs/Pages/Components/Link/LinkPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Link/LinkPage.razor
@@ -12,7 +12,7 @@
             <SectionContent Outlined="true">
                 <LinkSimpleExample />
             </SectionContent>
-            <SectionSource Code="LinkSimpleExample" GitHubFolderName="Link" SnippetId="GuvuPNuE33jjtyMO52" />
+            <SectionSource Code="LinkSimpleExample" GitHubFolderName="Link"  />
         </DocsPageSection>
 
         <DocsPageSection>
@@ -23,7 +23,7 @@
             <SectionContent Outlined="true">
                 <LinkUnderlineExample />
             </SectionContent>
-            <SectionSource Code="LinkUnderlineExample" GitHubFolderName="Link" SnippetId="https://try.mudblazor.com/snippet/QkbkvtEk34HtjX4C34" />
+            <SectionSource Code="LinkUnderlineExample" GitHubFolderName="Link"  />
         </DocsPageSection>
     </DocsPageContent>
 </DocsPage>

--- a/src/MudBlazor.Docs/Pages/Components/List/ListPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/List/ListPage.razor
@@ -14,7 +14,7 @@
             <SectionContent DarkenBackground="true" DisplayFlex="true" Class="demo-list">
                 <ListSimpleExample/>
             </SectionContent>
-            <SectionSource Code="ListSimpleExample" GitHubFolderName="List" SnippetId="cElumkPk35NwLcdp28"/>
+            <SectionSource Code="ListSimpleExample" GitHubFolderName="List" />
         </DocsPageSection>
 
         <DocsPageSection>
@@ -25,7 +25,7 @@
             <SectionContent DarkenBackground="true" DisplayFlex="true" Class="demo-list">
                 <ListNestedExample/>
             </SectionContent>
-            <SectionSource Code="ListNestedExample" GitHubFolderName="List" SnippetId="QOlEcklu37ICrdRU15"/>
+            <SectionSource Code="ListNestedExample" GitHubFolderName="List" />
         </DocsPageSection>
 
         <DocsPageSection>
@@ -36,7 +36,7 @@
             <SectionContent DarkenBackground="true" DisplayFlex="true" Class="demo-list">
                 <ListFolderExample/>
             </SectionContent>
-            <SectionSource Code="ListFolderExample" GitHubFolderName="List" SnippetId="QuPkQOlE386hIgjV06"/>
+            <SectionSource Code="ListFolderExample" GitHubFolderName="List" />
         </DocsPageSection>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/Menu/MenuPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Menu/MenuPage.razor
@@ -13,7 +13,7 @@
             <SectionContent Outlined="true" Class="demo-menu">
                 <MenuSimpleExample />
             </SectionContent>
-            <SectionSource Code="MenuSimpleExample" GitHubFolderName="Menu" SnippetId="mYbabDOu353hLxxb10" />
+            <SectionSource Code="MenuSimpleExample" GitHubFolderName="Menu"  />
         </DocsPageSection>
 
         <DocsPageSection>
@@ -24,7 +24,7 @@
             <SectionContent Outlined="true" DisplayFlex="true">
                 <MenuCustomizationExample />
             </SectionContent>
-            <SectionSource Code="MenuCustomizationExample" ShowCode="false" GitHubFolderName="Menu" SnippetId="wklulNYu36CeAorU52" />
+            <SectionSource Code="MenuCustomizationExample" ShowCode="false" GitHubFolderName="Menu"  />
         </DocsPageSection>
 
         <DocsPageSection>
@@ -79,7 +79,7 @@
             <SectionContent Outlined="true" DisplayFlex="true">
                 <MenuIconButtonsExample />
             </SectionContent>
-            <SectionSource Code="MenuIconButtonsExample" ShowCode="true" GitHubFolderName="Menu" SnippetId="wYFElDuu41LqNSJR49" />
+            <SectionSource Code="MenuIconButtonsExample" ShowCode="true" GitHubFolderName="Menu"  />
         </DocsPageSection>
 
         <DocsPageSection>
@@ -90,7 +90,7 @@
             <SectionContent Outlined="true" DisplayFlex="true">
                 <MenuUsageExample />
             </SectionContent>
-            <SectionSource Code="MenuUsageExample" ShowCode="true" GitHubFolderName="Menu" SnippetId="wOFkFjOE42WsCA3S31" />
+            <SectionSource Code="MenuUsageExample" ShowCode="true" GitHubFolderName="Menu"  />
         </DocsPageSection>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/NavMenu/NavMenuPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/NavMenu/NavMenuPage.razor
@@ -11,7 +11,7 @@
             <SectionContent DarkenBackground="true">
                 <NavMenuExample />
             </SectionContent>
-            <SectionSource Code="NavMenuExample" GitHubFolderName="NavMenu" SnippetId="mElOPNYO43eQEMvN19" />
+            <SectionSource Code="NavMenuExample" GitHubFolderName="NavMenu"  />
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>

--- a/src/MudBlazor.Docs/Pages/Components/Progress/ProgressPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Progress/ProgressPage.razor
@@ -33,14 +33,14 @@
             <SectionContent Outlined="true">
                 <ProgressCircularInterminateExample />
             </SectionContent>
-            <SectionSource Code="ProgressCircularInterminateExample" GitHubFolderName="Progress" SnippetId="GOlkFZvJ32BtrQXM07" />
+            <SectionSource Code="ProgressCircularInterminateExample" GitHubFolderName="Progress"  />
             <SectionHeader>
                 <SubTitle>Circular determinate</SubTitle>
             </SectionHeader>
             <SectionContent Outlined="true">
                 <ProgressCircularDeterminateExample />
             </SectionContent>
-            <SectionSource Code="ProgressCircularDeterminateExample" GitHubFolderName="Progress" SnippetId="GElaFtPf33k2IyzN18" />
+            <SectionSource Code="ProgressCircularDeterminateExample" GitHubFolderName="Progress"  />
             <SectionHeader>
                 <SubTitle>Circular Sizes</SubTitle>
                 <Description>You can change the size with the pre defined <CodeInline>Size</CodeInline> prop or change the <CodeInline>Width</CodeInline> and <CodeInline>Height</CodeInline> in css.</Description>

--- a/src/MudBlazor.Docs/Pages/Components/Radio/RadioPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Radio/RadioPage.razor
@@ -11,7 +11,7 @@
             <SectionContent Outlined="true">
                 <RadioGroupExample />
             </SectionContent>
-            <SectionSource Code="RadioGroupExample" GitHubFolderName="Radio" SnippetId="mEvOFZuO58RPdlZd38" />
+            <SectionSource Code="RadioGroupExample" GitHubFolderName="Radio"  />
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>

--- a/src/MudBlazor.Docs/Pages/Components/Rating/RatingPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Rating/RatingPage.razor
@@ -24,7 +24,7 @@
             <SectionContent Outlined="true">
                 <BasicRatingExample />
             </SectionContent>
-            <SectionSource Code="BasicRatingExample" GitHubFolderName="Rating" SnippetId="todo" />
+            <SectionSource Code="BasicRatingExample" GitHubFolderName="Rating"  />
         </DocsPageSection>
 
         <DocsPageSection>
@@ -35,7 +35,7 @@
             <SectionContent Outlined="true">
                 <RatingDisabledExample />
             </SectionContent>
-            <SectionSource Code="RatingDisabledExample" GitHubFolderName="Rating" SnippetId="todo" />
+            <SectionSource Code="RatingDisabledExample" GitHubFolderName="Rating"  />
         </DocsPageSection>
 
         <DocsPageSection>
@@ -46,7 +46,7 @@
             <SectionContent Outlined="true">
                 <RatingReadonlyExample />
             </SectionContent>
-            <SectionSource Code="RatingReadonlyExample" GitHubFolderName="Rating" SnippetId="todo" />
+            <SectionSource Code="RatingReadonlyExample" GitHubFolderName="Rating"  />
         </DocsPageSection>
 
         <DocsPageSection>
@@ -57,7 +57,7 @@
             <SectionContent Outlined="true">
                 <RaitngSizesExample />
             </SectionContent>
-            <SectionSource Code="RaitngSizesExample" GitHubFolderName="Rating" SnippetId="todo" />
+            <SectionSource Code="RaitngSizesExample" GitHubFolderName="Rating"  />
         </DocsPageSection>
 
         <DocsPageSection>
@@ -68,7 +68,7 @@
             <SectionContent Outlined="true">
                 <RaitngMaxValueExample />
             </SectionContent>
-            <SectionSource Code="RaitngMaxValueExample" GitHubFolderName="Rating" SnippetId="todo" />
+            <SectionSource Code="RaitngMaxValueExample" GitHubFolderName="Rating"  />
         </DocsPageSection>
 
         <DocsPageSection>
@@ -79,7 +79,7 @@
             <SectionContent Outlined="true">
                 <RaitngIconsAndColorExample />
             </SectionContent>
-            <SectionSource Code="RaitngIconsAndColorExample" GitHubFolderName="Rating" SnippetId="todo" />
+            <SectionSource Code="RaitngIconsAndColorExample" GitHubFolderName="Rating"  />
         </DocsPageSection>
 
         <DocsPageSection>
@@ -90,7 +90,7 @@
             <SectionContent Outlined="true">
                 <RatingBindingsExample />
             </SectionContent>
-            <SectionSource Code="RatingBindingsExample" GitHubFolderName="Rating" SnippetId="todo" />
+            <SectionSource Code="RatingBindingsExample" GitHubFolderName="Rating"  />
         </DocsPageSection>
 
 

--- a/src/MudBlazor.Docs/Pages/Components/SimpleTable/SimpleTablePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/SimpleTable/SimpleTablePage.razor
@@ -13,7 +13,7 @@
             <SectionContent DarkenBackground="true" FullWidth="true">
                 <SimpleTableExample />
             </SectionContent>
-            <SectionSource Code="SimpleTableExample" ShowCode="true" GitHubFolderName="SimpleTable" SnippetId="wYFOcuva457ngk8i25" />
+            <SectionSource Code="SimpleTableExample" ShowCode="true" GitHubFolderName="SimpleTable"  />
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>
@@ -25,7 +25,7 @@
             <SectionContent DarkenBackground="true" FullWidth="true">
                 <SimpleTableHoverDenseExample />
             </SectionContent>
-            <SectionSource Code="SimpleTableHoverDenseExample" ShowCode="false" GitHubFolderName="SimpleTable" SnippetId="mOlawkbk46xRYCSu34" />
+            <SectionSource Code="SimpleTableHoverDenseExample" ShowCode="false" GitHubFolderName="SimpleTable"  />
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>
@@ -37,7 +37,7 @@
             <SectionContent DarkenBackground="true" FullWidth="true">
                 <SimpleTableFixedHeaderExample />
             </SectionContent>
-            <SectionSource Code="SimpleTableFixedHeaderExample" ShowCode="false" GitHubFolderName="SimpleTable" SnippetId="QkbwbTEW01R5aqgf55" />
+            <SectionSource Code="SimpleTableFixedHeaderExample" ShowCode="false" GitHubFolderName="SimpleTable"  />
         </DocsPageSection>
     </DocsPageContent>
 </DocsPage>

--- a/src/MudBlazor.Docs/Pages/Components/Skeleton/SkeletonPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Skeleton/SkeletonPage.razor
@@ -11,7 +11,7 @@
             <SectionContent Outlined="true">
                 <SkeletonVariantsExample />
             </SectionContent>
-            <SectionSource Code="SkeletonVariantsExample" GitHubFolderName="Skeleton" SnippetId="wYlkwava40tJRYtu37" />
+            <SectionSource Code="SkeletonVariantsExample" GitHubFolderName="Skeleton"  />
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>
@@ -21,7 +21,7 @@
             <SectionContent Outlined="true" FullWidth="true">
                 <SkeletonAnimationsExample />
             </SectionContent>
-            <SectionSource Code="SkeletonAnimationsExample" GitHubFolderName="Skeleton" SnippetId="cObYwkPa421oxrQH12" />
+            <SectionSource Code="SkeletonAnimationsExample" GitHubFolderName="Skeleton"  />
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>
@@ -30,7 +30,7 @@
             <SectionContent DarkenBackground="true" Class="demo-skeleton-cards">
                 <SkeletonPulsateExample />
             </SectionContent>
-            <SectionSource Code="SkeletonPulsateExample" GitHubFolderName="Skeleton" ShowCode="false" SnippetId="wObYwEPY43dvECl643" />
+            <SectionSource Code="SkeletonPulsateExample" GitHubFolderName="Skeleton" ShowCode="false"  />
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>
@@ -39,7 +39,7 @@
             <SectionContent DarkenBackground="true" Class="demo-skeleton-cards">
                 <SkeletonWaveExample />
             </SectionContent>
-            <SectionSource Code="SkeletonWaveExample" GitHubFolderName="Skeleton" ShowCode="false" SnippetId="cYPYGkba44zJrztr40" />
+            <SectionSource Code="SkeletonWaveExample" GitHubFolderName="Skeleton" ShowCode="false"  />
         </DocsPageSection>
     </DocsPageContent>
 </DocsPage>

--- a/src/MudBlazor.Docs/Pages/Components/Slider/SliderPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Slider/SliderPage.razor
@@ -11,7 +11,7 @@
             <SectionContent Outlined="true">
                 <SliderBasicExample />
             </SectionContent>
-            <SectionSource Code="SliderBasicExample" GitHubFolderName="Slider" SnippetId="QEPYbDEb05LhPHu950" />
+            <SectionSource Code="SliderBasicExample" GitHubFolderName="Slider"  />
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>
@@ -21,7 +21,7 @@
             <SectionContent Outlined="true">
                 <SliderStepsExample />
             </SectionContent>
-            <SectionSource Code="SliderStepsExample" GitHubFolderName="Slider" SnippetId="cOFkPjEv062Jgpp529" />
+            <SectionSource Code="SliderStepsExample" GitHubFolderName="Slider"  />
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>
@@ -31,7 +31,7 @@
             <SectionContent Outlined="true">
                 <SliderMinMaxExample />
             </SectionContent>
-            <SectionSource Code="SliderMinMaxExample" GitHubFolderName="Slider" SnippetId="walaljOP07oYr7m441" />
+            <SectionSource Code="SliderMinMaxExample" GitHubFolderName="Slider"  />
         </DocsPageSection>
     </DocsPageContent>
 </DocsPage>

--- a/src/MudBlazor.Docs/Pages/Components/Switch/SwitchPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Switch/SwitchPage.razor
@@ -11,7 +11,7 @@
             <SectionContent Outlined="true">
                 <SwitchBasicExample />
             </SectionContent>
-            <SectionSource Code="SwitchBasicExample" GitHubFolderName="Switch" SnippetId="wObulXaP08SFAgqa16" />
+            <SectionSource Code="SwitchBasicExample" GitHubFolderName="Switch"  />
         </DocsPageSection>
 
         <DocsPageSection>
@@ -22,7 +22,7 @@
             <SectionContent Outlined="true">
                 <SwitchWithLabelExample />
             </SectionContent>
-            <SectionSource Code="SwitchWithLabelExample" GitHubFolderName="Switch" SnippetId="mYlalXEF0914H6Sn00" />
+            <SectionSource Code="SwitchWithLabelExample" GitHubFolderName="Switch"  />
         </DocsPageSection>
         
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/Tabs/TabsPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/TabsPage.razor
@@ -71,7 +71,7 @@
             <SectionContent Outlined="true" FullWidth="true">
                 <TabsWithBagdesExample />
             </SectionContent>
-            <SectionSource Code="TabsWithBagdesExample" ShowCode="false" GitHubFolderName="Tabs" SnippetId="QkvEFXuO47zds3aZ18" />
+            <SectionSource Code="TabsWithBagdesExample" ShowCode="false" GitHubFolderName="Tabs"  />
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>

--- a/src/MudBlazor.Docs/Pages/Components/TextField/TextFieldPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TextField/TextFieldPage.razor
@@ -12,7 +12,7 @@
             <SectionContent Outlined="true">
                 <TextFieldBasicExample />
             </SectionContent>
-            <SectionSource Code="TextFieldBasicExample" ShowCode="false" GitHubFolderName="TextField" SnippetId="mEFuvNkv09FIbSmx30" />
+            <SectionSource Code="TextFieldBasicExample" ShowCode="false" GitHubFolderName="TextField"  />
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>
@@ -32,7 +32,7 @@
             <SectionContent Outlined="true">
                 <TextFieldFormPropsExample />
             </SectionContent>
-            <SectionSource Code="TextFieldFormPropsExample" ShowCode="false" GitHubFolderName="TextField" SnippetId="muPuFDEv106GiSNh21" />
+            <SectionSource Code="TextFieldFormPropsExample" ShowCode="false" GitHubFolderName="TextField"  />
         </DocsPageSection>
 
         <DocsPageSection>
@@ -148,7 +148,7 @@
             <SectionContent Outlined="true">
                 <TextFieldInputsExample />
             </SectionContent>
-            <SectionSource Code="TextFieldInputsExample" ShowCode="false" GitHubFolderName="TextField" SnippetId="GOlYvXOl112JQXoB02" />
+            <SectionSource Code="TextFieldInputsExample" ShowCode="false" GitHubFolderName="TextField"  />
         </DocsPageSection>
     </DocsPageContent>
 </DocsPage>

--- a/src/MudBlazor.Docs/Pages/Components/Tooltip/TooltipPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tooltip/TooltipPage.razor
@@ -11,7 +11,7 @@
             <SectionContent Outlined="true" Class="py-8">
                 <TooltipSimpleExample />
             </SectionContent>
-            <SectionSource Code="TooltipSimpleExample" GitHubFolderName="Tooltip" SnippetId="GOvEGkvE47cm445z19" />
+            <SectionSource Code="TooltipSimpleExample" GitHubFolderName="Tooltip"  />
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>
@@ -21,7 +21,7 @@
             <SectionContent Outlined="true" Class="py-8">
                 <TooltipDelayedExample />
             </SectionContent>
-            <SectionSource Code="TooltipDelayedExample" ShowCode="false" GitHubFolderName="Tooltip" SnippetId="GEFaQYFk48iZdfc512" />
+            <SectionSource Code="TooltipDelayedExample" ShowCode="false" GitHubFolderName="Tooltip"  />
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>
@@ -31,7 +31,7 @@
             <SectionContent Outlined="true" Class="py-8">
                 <TooltipPostionExample />
             </SectionContent>
-            <SectionSource Code="TooltipPostionExample" GitHubFolderName="Tooltip" SnippetId="GEPkwYlE489JrtVG48" />
+            <SectionSource Code="TooltipPostionExample" GitHubFolderName="Tooltip"  />
         </DocsPageSection>
     </DocsPageContent>
 </DocsPage>

--- a/src/MudBlazor.Docs/Pages/Components/Typography/TypographyPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Typography/TypographyPage.razor
@@ -11,7 +11,7 @@
             <SectionContent Outlined="true">
                 <TextGeneralExample />
             </SectionContent>
-            <SectionSource Code="TextGeneralExample" GitHubFolderName="Typography" SnippetId="cuFYcaFE493UYPBX21" />
+            <SectionSource Code="TextGeneralExample" GitHubFolderName="Typography"  />
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>


### PR DESCRIPTION
- This is to be merged AFTER new version of try.mudblazor.com is deployed
- We use compressed url encoded code to transfer the code examples to try.mudblazor.com
- No more snippet ids to manage
- When this is merged to master we will need to think about things a bit.  Probably best to cherry pick this across