### PR TITLE
Swipe support

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/SwipeArea/Examples/SwipeDatePickerExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/SwipeArea/Examples/SwipeDatePickerExample.razor
@@ -1,0 +1,23 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudSwipeArea OnSwipe="@OnSwipe">
+    <MudDatePicker PickerVariant="PickerVariant.Static" Date="@(DateTime.Today.AddDays(1))" @bind-PickerMonth="@_pickerMonth" />
+</MudSwipeArea>
+
+@code{ 
+    DateTime? _pickerMonth = DateTime.Now;
+
+    public void OnSwipe(SwipeDirection direction)
+    {
+        if (direction == SwipeDirection.LeftToRight)
+        {
+            _pickerMonth = _pickerMonth.Value.AddMonths(-1);
+            StateHasChanged();
+        }
+        else if (direction == SwipeDirection.RightToLeft)
+        {
+            _pickerMonth = _pickerMonth.Value.AddMonths(1);
+            StateHasChanged();
+        }
+    }
+}

--- a/src/MudBlazor.Docs/Pages/Components/SwipeArea/Examples/SwipeDirectionsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/SwipeArea/Examples/SwipeDirectionsExample.razor
@@ -1,0 +1,7 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudSwipeArea OnSwipe="@((d) => _swipeDirection = d)" Style="width: 100%; height: 300px">
+    <MudText Typo="@Typo.body1">@_swipeDirection</MudText>
+</MudSwipeArea>
+
+@code{ SwipeDirection _swipeDirection; }

--- a/src/MudBlazor.Docs/Pages/Components/SwipeArea/Examples/SwipeDrawerExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/SwipeArea/Examples/SwipeDrawerExample.razor
@@ -1,0 +1,34 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudSwipeArea OnSwipe="@OnSwipe" Style="width: 100%;">
+    <MudPaper Class="demo-drawer">
+        <MudDrawer @bind-Open="@_drawerOpen" Fixed="false" Elevation="1" Variant="@DrawerVariant.Persistent">
+            <MudDrawerHeader>
+                <MudText Typo="Typo.h6">My App</MudText>
+            </MudDrawerHeader>
+            <MudNavMenu>
+                <MudNavLink Match="NavLinkMatch.All">Store</MudNavLink>
+                <MudNavLink Match="NavLinkMatch.All">Library</MudNavLink>
+                <MudNavLink Match="NavLinkMatch.All">Community</MudNavLink>
+            </MudNavMenu>
+        </MudDrawer>
+    </MudPaper>
+</MudSwipeArea>
+
+@code{
+    bool _drawerOpen;
+
+    public void OnSwipe(SwipeDirection direction)
+    {
+        if (direction == SwipeDirection.LeftToRight && !_drawerOpen)
+        {
+            _drawerOpen = true;
+            StateHasChanged();
+        }
+        else if (direction == SwipeDirection.RightToLeft && _drawerOpen)
+        {
+            _drawerOpen = false;
+            StateHasChanged();
+        }
+    }
+}

--- a/src/MudBlazor.Docs/Pages/Components/SwipeArea/SwipeAreaPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/SwipeArea/SwipeAreaPage.razor
@@ -1,0 +1,39 @@
+﻿@page "/components/swipearea"
+
+<DocsPage>
+    <DocsPageHeader Title="Swipe area">
+        <Description>Note: these examples only works on devices where touch events are supported.</Description>
+    </DocsPageHeader>
+    <DocsPageContent>
+        <DocsPageSection>
+            <SectionHeader>
+                <Title>Swipe directions</Title>
+                <Description>Swipe your finger in different direction to see how the component works.</Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" DisplayFlex="true" Class="demo-list">
+                <SwipeDirectionsExample />
+            </SectionContent>
+            <SectionSource Code="SwipeDirectionsExample" GitHubFolderName="Tree" />
+        </DocsPageSection>
+        <DocsPageSection>
+            <SectionHeader>
+                <Title>Usage: open and close drawer</Title>
+                <Description></Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" DisplayFlex="true" Class="demo-list">
+                <SwipeDrawerExample />
+            </SectionContent>
+            <SectionSource Code="SwipeDrawerExample" GitHubFolderName="Tree" />
+        </DocsPageSection>
+        <DocsPageSection>
+            <SectionHeader>
+                <Title>Usage: navigate a date picker</Title>
+                <Description></Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" DisplayFlex="true" Class="demo-list">
+                <SwipeDatePickerExample />
+            </SectionContent>
+            <SectionSource Code="SwipeDatePickerExample" GitHubFolderName="Tree" />
+        </DocsPageSection>
+    </DocsPageContent>
+</DocsPage>

--- a/src/MudBlazor.Docs/Services/MenuService.cs
+++ b/src/MudBlazor.Docs/Services/MenuService.cs
@@ -67,6 +67,7 @@ namespace MudBlazor.Docs.Services
             .AddItem("Breadcrumbs", typeof(MudBreadcrumbs))
             .AddItem("ScrollToTop", typeof(MudScrollToTop))
             .AddItem("Popover", typeof(MudPopover))
+            .AddItem("SwipeArea", typeof(MudSwipeArea))
 
             //GROUPS
 

--- a/src/MudBlazor.Docs/Shared/MainLayout.razor
+++ b/src/MudBlazor.Docs/Shared/MainLayout.razor
@@ -6,62 +6,62 @@
 <MudDialogProvider FullWidth="true" MaxWidth="MaxWidth.ExtraSmall" />
 <MudSnackbarProvider />
 
-
-<MudLayout RightToLeft="@_rightToLeft">
-    <MudAppBar Elevation="25">
-        <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@((e) => DrawerToggle())" />
-        <MudHidden Breakpoint="Breakpoint.SmAndUp" Invert="true">
-            <MudText Typo="Typo.h5" Class="mudblazor-appbar-brand-text">Mudblazor</MudText>
-        </MudHidden>
-        <MudAppBarSpacer />
-        <MudAutocomplete T="ApiLinkServiceEntry" Placeholder="Search" SearchFunc="Search" Variant="Variant.Outlined" ValueChanged="OnSearchResult" Class="docs-search-bar">
-            <ItemTemplate Context="result">
-                <MudText>@result.Title</MudText> <MudText Typo="Typo.body2">@result.SubTitle</MudText>
-            </ItemTemplate>
-        </MudAutocomplete>
-        <MudAppBarSpacer />
-        <MudHidden Breakpoint="Breakpoint.MdAndUp" Invert="true">
-            <MudMenu EndIcon="@Icons.Filled.KeyboardArrowDown" Label="Support" Color="Color.Inherit" Dense="true" Direction="Direction.Right" OffsetY="true">
-                <MudText Typo="Typo.body2" Class="px-4 py-2"><b>Community Support</b></MudText>
-                <MudMenuItem Link="https://discord.gg/mudblazor" Target="_blank">Discord</MudMenuItem>
-                <MudMenuItem Link="https://gitter.im/MudBlazor/community" Target="_blank">Gitter</MudMenuItem>
-                <MudText Typo="Typo.body2" Class="px-4 py-2"><b>Tools and resources</b></MudText>
-                <MudMenuItem Link="https://try.mudblazor.com/snippet" Target="_blank">TryMudBlazor</MudMenuItem>
-                <MudMenuItem Link="https://github.com/Garderoben/MudBlazor.Templates" Target="_blank">Templates</MudMenuItem>
-            </MudMenu>
-            <MudDivider Vertical="true" FlexItem="true" DividerType="DividerType.Middle" Class="mx-4 my-5" />
-            <MudTooltip Text="Toggle light/dark theme">
-                <MudIconButton Icon="@Icons.Material.Filled.Brightness4" Color="Color.Inherit" OnClick="@((e) => DarkMode())" />
-            </MudTooltip>
-            <MudTooltip Text="GitHub repository">
-                <MudIconButton Icon="@Icons.Custom.Brands.GitHub" Color="Color.Inherit" Link="https://github.com/Garderoben/MudBlazor" Target="_blank" />
-            </MudTooltip>
-            <MudTooltip Text="Toggle right-to-left/left-to-right">
-                <MudIconButton Icon="@Icons.Material.Filled.FormatTextdirectionRToL" Color="Color.Inherit" OnClick="@((e) => RightToLeftToggle())" />
-            </MudTooltip>
-        </MudHidden>
-        <MudHidden Breakpoint="Breakpoint.SmAndDown" Invert="true">
-            <MudMenu Icon="@Icons.Filled.Settings" Color="Color.Inherit" Dense="true" Direction="Direction.Right" OffsetY="true">
-                <div class="px-2">
+<MudSwipeArea OnSwipe="@OnSwipe">
+    <MudLayout RightToLeft="@_rightToLeft">
+        <MudAppBar Elevation="25">
+            <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@((e) => DrawerToggle())" />
+            <MudHidden Breakpoint="Breakpoint.SmAndUp" Invert="true">
+                <MudText Typo="Typo.h5" Class="mudblazor-appbar-brand-text">Mudblazor</MudText>
+            </MudHidden>
+            <MudAppBarSpacer />
+            <MudAutocomplete T="ApiLinkServiceEntry" Placeholder="Search" SearchFunc="Search" Variant="Variant.Outlined" ValueChanged="OnSearchResult" Class="docs-search-bar">
+                <ItemTemplate Context="result">
+                    <MudText>@result.Title</MudText> <MudText Typo="Typo.body2">@result.SubTitle</MudText>
+                </ItemTemplate>
+            </MudAutocomplete>
+            <MudAppBarSpacer />
+            <MudHidden Breakpoint="Breakpoint.MdAndUp" Invert="true">
+                <MudMenu EndIcon="@Icons.Filled.KeyboardArrowDown" Label="Support" Color="Color.Inherit" Dense="true" Direction="Direction.Right" OffsetY="true">
+                    <MudText Typo="Typo.body2" Class="px-4 py-2"><b>Community Support</b></MudText>
+                    <MudMenuItem Link="https://discord.gg/mudblazor" Target="_blank">Discord</MudMenuItem>
+                    <MudMenuItem Link="https://gitter.im/MudBlazor/community" Target="_blank">Gitter</MudMenuItem>
+                    <MudText Typo="Typo.body2" Class="px-4 py-2"><b>Tools and resources</b></MudText>
+                    <MudMenuItem Link="https://try.mudblazor.com/snippet" Target="_blank">TryMudBlazor</MudMenuItem>
+                    <MudMenuItem Link="https://github.com/Garderoben/MudBlazor.Templates" Target="_blank">Templates</MudMenuItem>
+                </MudMenu>
+                <MudDivider Vertical="true" FlexItem="true" DividerType="DividerType.Middle" Class="mx-4 my-5" />
+                <MudTooltip Text="Toggle light/dark theme">
                     <MudIconButton Icon="@Icons.Material.Filled.Brightness4" Color="Color.Inherit" OnClick="@((e) => DarkMode())" />
+                </MudTooltip>
+                <MudTooltip Text="GitHub repository">
                     <MudIconButton Icon="@Icons.Custom.Brands.GitHub" Color="Color.Inherit" Link="https://github.com/Garderoben/MudBlazor" Target="_blank" />
+                </MudTooltip>
+                <MudTooltip Text="Toggle right-to-left/left-to-right">
                     <MudIconButton Icon="@Icons.Material.Filled.FormatTextdirectionRToL" Color="Color.Inherit" OnClick="@((e) => RightToLeftToggle())" />
-                </div>
-                <MudText Typo="Typo.body2" Class="px-4 py-2"><b>Community Support</b></MudText>
-                <MudMenuItem Link="https://discord.gg/mudblazor" Target="_blank">Discord</MudMenuItem>
-                <MudMenuItem Link="https://gitter.im/MudBlazor/community" Target="_blank">Gitter</MudMenuItem>
-                <MudText Typo="Typo.body2" Class="px-4 py-2"><b>Tools and resources</b></MudText>
-                <MudMenuItem Link="https://try.mudblazor.com/snippet" Target="_blank">TryMudBlazor</MudMenuItem>
-                <MudMenuItem Link="https://github.com/Garderoben/MudBlazor.Templates" Target="_blank">Templates</MudMenuItem>
-            </MudMenu>
-        </MudHidden>
-    </MudAppBar>
-    
+                </MudTooltip>
+            </MudHidden>
+            <MudHidden Breakpoint="Breakpoint.SmAndDown" Invert="true">
+                <MudMenu Icon="@Icons.Filled.Settings" Color="Color.Inherit" Dense="true" Direction="Direction.Right" OffsetY="true">
+                    <div class="px-2">
+                        <MudIconButton Icon="@Icons.Material.Filled.Brightness4" Color="Color.Inherit" OnClick="@((e) => DarkMode())" />
+                        <MudIconButton Icon="@Icons.Custom.Brands.GitHub" Color="Color.Inherit" Link="https://github.com/Garderoben/MudBlazor" Target="_blank" />
+                        <MudIconButton Icon="@Icons.Material.Filled.FormatTextdirectionRToL" Color="Color.Inherit" OnClick="@((e) => RightToLeftToggle())" />
+                    </div>
+                    <MudText Typo="Typo.body2" Class="px-4 py-2"><b>Community Support</b></MudText>
+                    <MudMenuItem Link="https://discord.gg/mudblazor" Target="_blank">Discord</MudMenuItem>
+                    <MudMenuItem Link="https://gitter.im/MudBlazor/community" Target="_blank">Gitter</MudMenuItem>
+                    <MudText Typo="Typo.body2" Class="px-4 py-2"><b>Tools and resources</b></MudText>
+                    <MudMenuItem Link="https://try.mudblazor.com/snippet" Target="_blank">TryMudBlazor</MudMenuItem>
+                    <MudMenuItem Link="https://github.com/Garderoben/MudBlazor.Templates" Target="_blank">Templates</MudMenuItem>
+                </MudMenu>
+            </MudHidden>
+        </MudAppBar>
+
         <MudDrawer @bind-Open=_drawerOpen Elevation="25" Class="mudblazor-appbar-band">
             <MudDrawerHeader Class="mudblazor-brand" LinkToIndex="true">
                 <MudBlazorLogo />
             </MudDrawerHeader>
-            <NavMenu @ref="@_navMenuRef"/>
+            <NavMenu @ref="@_navMenuRef" />
         </MudDrawer>
         <MudMainContent Class="mudblazor-main-content">
             @Body
@@ -70,7 +70,6 @@
             </MudScrollToTop>
             <NavigationFooter Section=_section Previous="@_previous" Next="@_next" />
         </MudMainContent>
-    
-</MudLayout>
 
-
+    </MudLayout>
+</MudSwipeArea>

--- a/src/MudBlazor.Docs/Shared/MainLayout.razor.cs
+++ b/src/MudBlazor.Docs/Shared/MainLayout.razor.cs
@@ -68,6 +68,20 @@ namespace MudBlazor.Docs.Shared
             NavigationManager.NavigateTo(entry.Link);
         }
 
+        private void OnSwipe(SwipeDirection direction)
+        {
+            if (direction == SwipeDirection.LeftToRight && !_drawerOpen)
+            {
+                _drawerOpen = true;
+                StateHasChanged();
+            }
+            else if (direction == SwipeDirection.RightToLeft && _drawerOpen)
+            {
+                _drawerOpen = false;
+                StateHasChanged();
+            }
+        }
+
         #region Theme        
 
         private void DarkMode()

--- a/src/MudBlazor.UnitTests/Mocks/MockDomService.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockDomService.cs
@@ -23,8 +23,11 @@ namespace MudBlazor.UnitTests.Mocks
         public ValueTask<BoundingClientRect> GetBoundingClientRect(ElementReference elementReference)
             => new ValueTask<BoundingClientRect>(new BoundingClientRect());
 
-        public ValueTask AddEventListener<T>(ElementReference element, DotNetObjectReference<T> dotnet, string @event, string callback) where T : class =>
-            new ValueTask();
+        public ValueTask<int> AddEventListener<T>(ElementReference element, DotNetObjectReference<T> dotnet, string @event, string callback, bool stopPropagation = false) where T : class 
+            => new ValueTask<int>(0);
+
+        public ValueTask RemoveEventListener(ElementReference element, string @event, int eventId)
+            => new ValueTask();
         
         public ValueTask OpenInNewTab(string url) =>
             new ValueTask();

--- a/src/MudBlazor/Components/SwipeArea/MudSwipeArea.razor
+++ b/src/MudBlazor/Components/SwipeArea/MudSwipeArea.razor
@@ -1,0 +1,6 @@
+﻿@namespace MudBlazor
+@inherits MudComponentBase
+
+<div @ref="_swipeArea" @attributes="UserAttributes" class="@Class" style="@Style">
+    @ChildContent
+</div>

--- a/src/MudBlazor/Components/SwipeArea/MudSwipeArea.razor.cs
+++ b/src/MudBlazor/Components/SwipeArea/MudSwipeArea.razor.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+using MudBlazor.Interop;
+using MudBlazor.Services;
+
+namespace MudBlazor
+{
+    public partial class MudSwipeArea : MudComponentBase, IDisposable
+    {
+        private double? _xDown, _yDown;
+        private ElementReference _swipeArea;
+        private DotNetObjectReference<MudSwipeArea> _dotnet;
+        private int _touchStartId, _touchEndId, _touchCancelId;
+
+        [Inject]
+        private IDomService DomService { get; set; }
+
+        [Parameter]
+        public RenderFragment ChildContent { get; set; }
+
+        [Parameter]
+        public EventCallback<SwipeDirection> OnSwipe { get; set; }
+
+        protected override void OnInitialized()
+        {
+            base.OnInitialized();
+            _dotnet = DotNetObjectReference.Create(this);
+        }
+
+        protected override async Task OnAfterRenderAsync(bool firstRender)
+        {
+            if (firstRender)
+            {
+                _touchStartId = await DomService.AddEventListener(_swipeArea, _dotnet, "touchstart", nameof(OnTouchStart), true);
+                _touchEndId = await DomService.AddEventListener(_swipeArea, _dotnet, "touchend", nameof(OnTouchEnd), true);
+                _touchCancelId = await DomService.AddEventListener(_swipeArea, _dotnet, "touchcancel", nameof(OnTouchCancel), true);
+            }
+            await base.OnAfterRenderAsync(firstRender);
+        }
+        
+        public void Dispose()
+        {
+            DomService.RemoveEventListener(_swipeArea, "touchstart", _touchStartId);
+            DomService.RemoveEventListener(_swipeArea, "touchend", _touchEndId);
+            DomService.RemoveEventListener(_swipeArea, "touchcancel", _touchCancelId);
+        }
+
+        [JSInvokable]
+        public void OnTouchStart(TouchEvent arg)
+        {
+            _xDown = arg.Touches[0].ClientX;
+            _yDown = arg.Touches[0].ClientY;
+        }
+
+        [JSInvokable]
+        public void OnTouchEnd(TouchEvent arg)
+        {
+            if (_xDown == null || _yDown == null)
+                return;
+
+            var xDiff = _xDown.Value - arg.ChangedTouches[0].ClientX;
+            var yDiff = _yDown.Value - arg.ChangedTouches[0].ClientY;
+
+            if (Math.Abs(xDiff) < 100 && Math.Abs(yDiff) < 100)
+            {
+                _xDown = _yDown = null;
+                return;
+            }
+
+            if (Math.Abs(xDiff) > Math.Abs(yDiff))
+            {
+                if (xDiff > 0)
+                {
+                    OnSwipe.InvokeAsync(SwipeDirection.RightToLeft);
+                }
+                else
+                {
+                    OnSwipe.InvokeAsync(SwipeDirection.LeftToRight);
+                }
+            }
+            else
+            {
+                if (yDiff > 0)
+                {
+                    OnSwipe.InvokeAsync(SwipeDirection.BottomToTop);
+                }
+                else
+                {
+                    OnSwipe.InvokeAsync(SwipeDirection.TopToBottom);
+                }
+            }
+
+            _xDown = _yDown = null;
+        }
+
+        [JSInvokable]
+        public void OnTouchCancel(TouchEvent arg)
+        {
+            _xDown = _yDown = null;
+        }
+    }
+}

--- a/src/MudBlazor/Enums/SwipeDirection.cs
+++ b/src/MudBlazor/Enums/SwipeDirection.cs
@@ -1,0 +1,11 @@
+﻿namespace MudBlazor
+{
+    public enum SwipeDirection
+    {
+        None,
+        LeftToRight,
+        RightToLeft,
+        TopToBottom,
+        BottomToTop
+    }
+}

--- a/src/MudBlazor/Interop/Touch.cs
+++ b/src/MudBlazor/Interop/Touch.cs
@@ -1,0 +1,21 @@
+﻿// Not Used
+
+namespace MudBlazor.Interop
+{
+    public class Touch
+    {
+        public int Identifier { get; set; }
+
+        public double ScreenX { get; set; }
+
+        public double ScreenY { get; set; }
+
+        public double ClientX { get; set; }
+
+        public double ClientY { get; set; }
+
+        public double PageX { get; set; }
+
+        public double PageY { get; set; }
+    }
+}

--- a/src/MudBlazor/Interop/TouchEvent.cs
+++ b/src/MudBlazor/Interop/TouchEvent.cs
@@ -1,0 +1,25 @@
+﻿// Not Used
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MudBlazor.Interop
+{
+    public class TouchEvent
+    {
+        public bool AltKey { get; set; }
+
+        public Touch[] ChangedTouches { get; set; }
+
+        public bool CtrlKey { get; set; }
+
+        public bool MetaKey { get; set; }
+
+        public bool ShiftKey { get; set; }
+
+        public Touch[] TargetTouches { get; set; }
+
+        public Touch[] Touches { get; set; }
+    }
+}

--- a/src/MudBlazor/Services/DomService.cs
+++ b/src/MudBlazor/Services/DomService.cs
@@ -1,4 +1,8 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
 using MudBlazor.Interop;
@@ -12,8 +16,8 @@ namespace MudBlazor.Services
         ValueTask<BoundingClientRect> GetBoundingClientRect(ElementReference elementReference);
         ValueTask ChangeGlobalCssVariable(string variableName, int value);
         ValueTask ChangeCssVariable(ElementReference element, string variableName, int value);
-        ValueTask AddEventListener<T>(ElementReference element, DotNetObjectReference<T> dotnet, string @event, string callback) where T : class;
-
+        ValueTask<int> AddEventListener<T>(ElementReference element, DotNetObjectReference<T> dotnet, string @event, string callback, bool stopPropagation = false) where T : class;
+        ValueTask RemoveEventListener(ElementReference element, string @event, int eventId);
         ValueTask OpenInNewTab(string url);
     }
 
@@ -27,24 +31,59 @@ namespace MudBlazor.Services
         }
 
         public ValueTask ChangeCssById(string id, string css) =>
-            _jsRuntime.InvokeVoidAsync("changeCssById", id, css);
+            _jsRuntime.InvokeVoidAsync("domService.changeCssById", id, css);
 
         public ValueTask ChangeCss(ElementReference elementReference, string css) =>
-            _jsRuntime.InvokeVoidAsync("changeCss", elementReference, css);
+            _jsRuntime.InvokeVoidAsync("domService.changeCss", elementReference, css);
 
         public ValueTask<BoundingClientRect> GetBoundingClientRect(ElementReference elementReference) =>
-            _jsRuntime.InvokeAsync<BoundingClientRect>("getMudBoundingClientRect", elementReference);
+            _jsRuntime.InvokeAsync<BoundingClientRect>("domService.getMudBoundingClientRect", elementReference);
 
         public ValueTask ChangeGlobalCssVariable(string variableName, int value) =>
-            _jsRuntime.InvokeVoidAsync("changeGlobalCssVariable", variableName, value);
+            _jsRuntime.InvokeVoidAsync("domService.changeGlobalCssVariable", variableName, value);
 
         public ValueTask ChangeCssVariable(ElementReference element, string variableName, int value) =>
-            _jsRuntime.InvokeVoidAsync("changeCssVariable", element, variableName, value);
+            _jsRuntime.InvokeVoidAsync("domService.changeCssVariable", element, variableName, value);
 
-        public ValueTask AddEventListener<T>(ElementReference element, DotNetObjectReference<T> dotnet, string @event, string callback) where T : class =>
-            _jsRuntime.InvokeVoidAsync("addMudEventListener", element, dotnet, @event, callback);
+		public ValueTask OpenInNewTab(string url) =>
+            _jsRuntime.InvokeVoidAsync("domService.mudOpen", new object[2] { url, "_blank" }); 
+  
+        public ValueTask<int> AddEventListener<T>(ElementReference element, DotNetObjectReference<T> dotnet, string @event, string callback, bool stopPropagation = false) where T : class
+        {
+            var parameters = dotnet.Value.GetType().GetMethods().First(m => m.Name == callback).GetParameters().Select(p => p.ParameterType);
+            var parameterSpecs = new object[parameters.Count()];
+            for (int i = 0; i < parameters.Count(); ++i)
+            {
+                parameterSpecs[i] = GetSerializationSpec(parameters.ElementAt(i));
+            }
+            return _jsRuntime.InvokeAsync<int>("domService.addMudEventListener", element, dotnet, @event, callback, parameterSpecs, stopPropagation);
+        }
 
-        public ValueTask OpenInNewTab(string url) =>
-            _jsRuntime.InvokeVoidAsync("mudOpen", new object[2] { url, "_blank" }); 
+        public ValueTask RemoveEventListener(ElementReference element, string @event, int eventId) =>
+            _jsRuntime.InvokeVoidAsync("domService.removeMudEventListener", element, eventId);
+
+        private object GetSerializationSpec(Type type)
+        {
+            var props = type.GetProperties();
+            var propsSpec = new Dictionary<string, object>();
+            foreach(var prop in props)
+            {
+                if (prop.PropertyType.IsPrimitive || prop.PropertyType == typeof(string))
+                {
+                    propsSpec.Add(ToJsString(prop.Name), "*");
+                }
+                else if (prop.PropertyType.IsArray)
+                {
+                    propsSpec.Add(ToJsString(prop.Name), GetSerializationSpec(prop.PropertyType.GetElementType()));
+                }
+                else if (prop.PropertyType.IsClass)
+                {
+                    propsSpec.Add(ToJsString(prop.Name), GetSerializationSpec(prop.PropertyType));
+                }
+            }
+            return propsSpec;
+        }
+
+        private string ToJsString(string s) => char.ToLower(s[0]) + s.Substring(1);
     }
 }

--- a/src/MudBlazor/TScripts/DOM.js
+++ b/src/MudBlazor/TScripts/DOM.js
@@ -1,33 +1,120 @@
-﻿window.getMudBoundingClientRect = (element) => {
-    return element.getBoundingClientRect();
-};
+﻿window.domService = {
+    listenerId: 0,
+    eventListeners: {},
 
-window.changeCss = (element, css) => {
-    element.className = css;
-};
+    getMudBoundingClientRect: function(element) {
+        return element.getBoundingClientRect();
+    },
 
-window.changeCssById = (id, css) => {
-    var element = document.getElementById(id);
-    if (element) {
+    changeCss: function (element, css) {
         element.className = css;
-    }
-};
+    },
 
-window.changeGlobalCssVariable = (name, newValue) => {
-    document.documentElement.style.setProperty(name, newValue);
-};
+    changeCssById: function (id, css) {
+        var element = document.getElementById(id);
+        if (element) {
+            element.className = css;
+        }
+    },
 
-window.changeCssVariable = (element, name, newValue) => {
-    element.style.setProperty(name, newValue);
-};
+    changeGlobalCssVariable: function (name, newValue) {
+        document.documentElement.style.setProperty(name, newValue);
+    },
 
-window.addMudEventListener = (element, dotnet, event, callback) => {
-    element.addEventListener(event, function () {
-        dotnet.invokeMethodAsync(callback);
-    });
-};
+    changeCssVariable: function (element, name, newValue) {
+        element.style.setProperty(name, newValue);
+    },
 
-// Needed as per https://stackoverflow.com/questions/62769031/how-can-i-open-a-new-window-without-using-js
-window.mudOpen = (args) => {
-    window.open(args);
+    addMudEventListener: function (element, dotnet, event, callback, spec, stopPropagation) {
+        var me = this;
+        var listener = function (e) {
+            const args = Array.from(spec, x => me.serializeParameter(e, x));
+            dotnet.invokeMethodAsync(callback, ...args);
+            if (stopPropagation) {
+                e.stopPropagation();
+            }
+        };
+        element.addEventListener(event, listener);
+        this.eventListeners[++this.listenerId] = listener;
+        return this.listenerId;
+    },
+
+    removeMudEventListener: function (element, event, eventId) {
+        element.removeEventListener(event, this.eventListeners[eventId]);
+        delete this.eventListeners[eventId];
+    },
+
+    //from: https://github.com/RemiBou/BrowserInterop
+    serializeParameter: function (data, spec) {
+        if (typeof data == "undefined" ||
+            data === null) {
+            return null;
+        }
+        if (typeof data === "number" ||
+            typeof data === "string" ||
+            typeof data == "boolean") {
+            return data;
+        }
+
+        var res = (Array.isArray(data)) ? [] : {};
+        if (!spec) {
+            spec = "*";
+        }
+
+        for (var i in data) {
+            var currentMember = data[i];
+
+            if (typeof currentMember === 'function' || currentMember === null) {
+                continue;
+            }
+
+            var currentMemberSpec;
+            if (spec != "*") {
+                currentMemberSpec = Array.isArray(data) ? spec : spec[i];
+                if (!currentMemberSpec) {
+                    continue;
+                }
+            } else {
+                currentMemberSpec = "*"
+            }
+
+            if (typeof currentMember === 'object') {
+                if (Array.isArray(currentMember) || currentMember.length) {
+                    res[i] = [];
+                    for (var j = 0; j < currentMember.length; j++) {
+                        const arrayItem = currentMember[j];
+                        if (typeof arrayItem === 'object') {
+                            res[i].push(this.serializeParameter(arrayItem, currentMemberSpec));
+                        } else {
+                            res[i].push(arrayItem);
+                        }
+                    }
+                } else {
+                    //the browser provides some member (like plugins) as hash with index as key, if length == 0 we shall not convert it
+                    if (currentMember.length === 0) {
+                        res[i] = [];
+                    } else {
+                        res[i] = this.serializeParameter(currentMember, currentMemberSpec);
+                    }
+                }
+
+
+            } else {
+                // string, number or boolean
+                if (currentMember === Infinity) { //inifity is not serialized by JSON.stringify
+                    currentMember = "Infinity";
+                }
+                if (currentMember !== null) { //needed because the default json serializer in jsinterop serialize null values
+                    res[i] = currentMember;
+                }
+            }
+        }
+
+        return res;
+    },
+
+	// Needed as per https://stackoverflow.com/questions/62769031/how-can-i-open-a-new-window-without-using-js
+    mudOpen: function (args) {
+        window.open(args);
+    },
 };


### PR DESCRIPTION
In this PR I would like to share my idea how to add swipe support for MudBlazor. Basically I created a new component, called MudSwipeArea, which is simple a div with inner content. This component registers for `touchstart`, `touchend`, `touchcancel `JS events and listens for them. `touchmove `is not added, because it can generate an enormous amount of JS-Blazor calls. The main logic is on Blazor side, so I tried to avoid as much JS as possible.
On JS and Blazor side I had to add some serialization, because event arguments cannot be serialized to Blazor by default.
I also created some examples, for now just to show the main functionality.
Tests are not included, for now I have no idea how to do it.