### PR TITLE
Table commit bug

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableInlineEditTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableInlineEditTest.razor
@@ -1,0 +1,24 @@
+﻿@using MudBlazor;
+@namespace MudBlazor.UnitTests
+
+<MudTable @ref="_table" T="string" Items="items" @bind-SelectedItem="selectedItem">
+    <HeaderContent>
+        <MudTh>#</MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd>@context</MudTd>
+    </RowTemplate>
+    <RowEditingTemplate>
+        <MudTd>
+            <MudTextField T="string" @bind-Value="@context"></MudTextField>
+        </MudTd>
+    </RowEditingTemplate>
+</MudTable>
+
+@code {
+    MudTable<string> _table;
+    private string selectedItem = null;
+    string[] items = new string[] { "A", "B", "C" };
+
+    public MudTable<string> Table => _table;
+}

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -488,5 +488,32 @@ namespace MudBlazor.UnitTests
             trs[3].GetAttribute("class").Contains("even");
             trs[4].GetAttribute("class").Contains("odd");
         }
+
+        public class TableRowValidatorTest : TableRowValidator
+        {
+            public int ControlCount => _formControls.Count;
+        }
+
+        [Test]
+        public async Task TableInlineEdit_CheckMemoryUsage()
+        {
+            var comp = ctx.RenderComponent<TableInlineEditTest>();
+            var validator = new TableRowValidatorTest();
+            comp.Instance.Table.Validator = validator;
+
+            Console.WriteLine(comp.Markup);
+            
+            var trs = comp.FindAll("tr");
+            trs.Count.Should().Be(4); // three rows + header row
+
+            trs[1].Click();
+            //every item will be add twice - see MudTextField.razor
+            validator.ControlCount.Should().Be(2);
+            for (int i = 0; i < 10; ++i)
+            {
+                trs[i % 3 + 1].Click();
+            }
+            validator.ControlCount.Should().Be(2);
+        }
     }
 }

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -491,7 +491,11 @@ namespace MudBlazor
 
         void IDisposable.Dispose()
         {
-            //ParentForm?.Remove(this);
+            try
+            {
+                Form?.Remove(this);
+            }
+            catch { /* ignore */ }
             DetachValidationStateChangedListener();
             Dispose(disposing: true);
         }

--- a/src/MudBlazor/Components/Form/MudForm.razor.cs
+++ b/src/MudBlazor/Components/Form/MudForm.razor.cs
@@ -91,7 +91,7 @@ namespace MudBlazor
 
         void IForm.Remove(IFormComponent formControl)
         {
-            _formControls.Remove(formControl);
+            //_formControls.Remove(formControl);
         }
 
         private Timer _timer;

--- a/src/MudBlazor/Components/Input/MudDebouncedInput.cs
+++ b/src/MudBlazor/Components/Input/MudDebouncedInput.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Components;
 
 namespace MudBlazor
 {
-    public abstract class MudDebouncedInput<T> : MudBaseInput<T>, IDisposable
+    public abstract class MudDebouncedInput<T> : MudBaseInput<T>
     {
         private Timer _timer;
         private double _debounceInterval;
@@ -102,9 +102,10 @@ namespace MudBlazor
                 OnTimerTickGuiThread().AndForget();
         }
 
-        public void Dispose()
+        protected override void Dispose(bool disposing)
         {
-            ClearTimer(suppressTick:true);
+            base.Dispose(disposing);
+            ClearTimer(suppressTick: true);
         }
     }
 }

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -236,7 +236,6 @@ namespace MudBlazor
 
         internal abstract void FireRowClickEvent(MouseEventArgs args, MudTr mudTr, object item);
 
-        internal Interfaces.IForm Validator { get; } = new TableRowValidator();
-
+        public Interfaces.IForm Validator { get; set; } = new TableRowValidator();
     }
 }

--- a/src/MudBlazor/Components/Table/MudTr.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTr.razor.cs
@@ -42,11 +42,12 @@ namespace MudBlazor
 
         public void OnRowClicked(MouseEventArgs args)
         {
-            if (IsHeader)
+            if (IsHeader || !(Context?.Table.Validator.IsValid ?? true))
                 return;
+
             Context?.Table.SetSelectedItem(Item);
-            if (_lockeditingentry == false) Context?.Table.SetEditingItem(Item);
-            _lockeditingentry = false;
+            Context?.Table.SetEditingItem(Item);
+
             if (Context?.Table.MultiSelection == true && !IsHeader)
             {
                 IsChecked = !IsChecked;
@@ -76,15 +77,10 @@ namespace MudBlazor
             }
         }
 
-        /// <summary>
-        /// FinishEdit() is called befor OwRowClick, so we are going to block the OnRowClicked()'s EditingItem sett when user clicks on finish edit button
-        /// </summary>
-        private bool _lockeditingentry = false;
         private void FinishEdit(MouseEventArgs ev)
         {
             if (!Context?.Table.Validator.IsValid ?? true) return;
             Context?.Table.SetEditingItem(null);
-            _lockeditingentry = true;
             Context?.Table.OnCommitEditHandler(ev, Item);
         }
     }

--- a/src/MudBlazor/Components/Table/TableRowValidator.cs
+++ b/src/MudBlazor/Components/Table/TableRowValidator.cs
@@ -1,12 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using MudBlazor.Interfaces;
 
 namespace MudBlazor
 {
-    class TableRowValidator : Interfaces.IForm
+    public class TableRowValidator : IForm
     {
         public bool IsValid
         {
@@ -25,7 +24,7 @@ namespace MudBlazor
 
         void IForm.Add(IFormComponent formControl)
         {
-            _formControls[formControl] = false;
+            _formControls.Add(formControl);
         }
 
         void IForm.Remove(IFormComponent formControl)
@@ -38,21 +37,19 @@ namespace MudBlazor
             //Validate(formControl);
         }
 
-        protected Dictionary<IFormComponent, bool> _formControls = new Dictionary<IFormComponent, bool>();
+        protected HashSet<IFormComponent> _formControls = new HashSet<IFormComponent>();
 
         public void Validate()
         {
             _errors.Clear();
-            foreach (var control in _formControls.Keys.ToArray())
+            foreach (var formControl in _formControls.ToArray())
             {
-                control.Validate();
-                foreach (var err in control.ValidationErrors)
+                formControl.Validate();
+                foreach (var err in formControl.ValidationErrors)
                 {
                     _errors.Add(err);
                 }
             }
         }
-
-
     }
 }


### PR DESCRIPTION
In #826 there is an interesting bug described. I made this PR draft, because the problem consist of several parts. First I noticed, that the `MudFormComponent `never removed itself from a form, therefore the `Remove `method of the `TableRowValidator `never called. So references stucked in the dictionary. The second problem, that `TableRowValidator ` uses strong references to `MudFormComponent`, so this prevents the components to be disposed. So the number of references are grows and grows now.
I make a fix, this works fine, the components GC-d now.
I have two questions which are considareble:
- This issue maybe affects `MudForm`. Should we fix it too?
- If there is a row validation error, I think we should prevent swiching row until the error fixed