### PR TITLE
Move Example and Api tests to partial classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -376,8 +376,7 @@ FodyWeavers.xsd
 **/MudBlazorDocs.min.css
 **/MudBlazorDocs.css
 MudBlazor.xml
-src/MudBlazor.Docs/Models/DocStrings.generated.cs
-src/MudBlazor.Docs/Models/Snippets.generated.cs
+**/*.generated.cs
 src/MudBlazor.UnitTests/Generated/_AllApiPages.cs
 src/MudBlazor.UnitTests/Generated/_AllComponents.cs
 src/MudBlazor.Docs/NewFilesToBuild.txt

--- a/src/MudBlazor.Docs.Compiler/CodeBuilder.cs
+++ b/src/MudBlazor.Docs.Compiler/CodeBuilder.cs
@@ -48,38 +48,6 @@ namespace MudBlazor.Docs.Compiler
             AddLine();
         }
 
-        public void AddUsings()
-        {
-            AddLine("using System;");
-            AddLine("using System.Net.Http;");
-
-            AddLine("using Bunit;");
-            AddLine("using Bunit.Rendering;");
-            AddLine("using Bunit.TestDoubles;");
-
-            AddLine("using Microsoft.AspNetCore.Components;");
-            AddLine("using Microsoft.Extensions.DependencyInjection;");
-
-            AddLine("using MudBlazor.Charts;");
-            AddLine("using MudBlazor.Docs.Examples;");
-            AddLine("using MudBlazor.Docs.Components;");
-            AddLine("using MudBlazor.Docs.Wireframes;");
-            AddLine("using MudBlazor.Internal;");
-            AddLine("using MudBlazor.Services;");
-            AddLine("using MudBlazor.UnitTests;");
-            AddLine("using MudBlazor.UnitTests.Mocks;");
-
-            AddLine("using Toolbelt.Blazor.HeadElement;");
-
-            AddLine("using NUnit.Framework;");
-
-            AddLine();
-            AddLine("#if NET5_0");
-            AddLine("using ComponentParameter = Bunit.ComponentParameter;");
-            AddLine("#endif");
-            AddLine();
-        }
-
         public override string ToString()
         {
             return _code.ToString();

--- a/src/MudBlazor.Docs.Compiler/Paths.cs
+++ b/src/MudBlazor.Docs.Compiler/Paths.cs
@@ -9,8 +9,8 @@ namespace MudBlazor.Docs.Compiler
         private const string TestDirectory = "MudBlazor.UnitTests";
         private const string SnippetsFile = "Snippets.generated.cs";
         private const string DocStringsFile = "DocStrings.generated.cs";
-        private const string ComponentTestsFile = "_AllComponents.cs";
-        private const string ApiPageTestsFile = "_AllApiPages.cs";
+        private const string ComponentTestsFile = "ExampleDocsTests.generated.cs";
+        private const string ApiPageTestsFile = "ApiDocsTests.generated.cs";
         private const string NewFilesToBuild = "NewFilesToBuild.txt";
 
         public const string ExampleDiscriminator = "Example"; // example components must contain this string

--- a/src/MudBlazor.Docs.Compiler/TestsForApiPages.cs
+++ b/src/MudBlazor.Docs.Compiler/TestsForApiPages.cs
@@ -25,40 +25,20 @@ namespace MudBlazor.Docs.Compiler
                 var cb = new CodeBuilder();
 
                 cb.AddHeader();
-                cb.AddUsings();
+                cb.AddLine("using MudBlazor.Charts;");
+                cb.AddLine("using MudBlazor.Docs.Components;");
+                cb.AddLine("using MudBlazor.Internal;");
+                cb.AddLine("using NUnit.Framework;");
+                cb.AddLine("using ComponentParameter = Bunit.ComponentParameter;");
+                cb.AddLine();
 
                 cb.AddLine("namespace MudBlazor.UnitTests.Components");
                 cb.AddLine("{");
                 cb.IndentLevel++;
                 cb.AddLine("// These tests just check all the API pages to see if they throw any exceptions");
-                cb.AddLine("[TestFixture]");
-                cb.AddLine("public class _AllApiPages");
+                cb.AddLine("public partial class ApiDocsTests");
                 cb.AddLine("{");
                 cb.IndentLevel++;
-                cb.AddLine("private Bunit.TestContext ctx;");
-                cb.AddLine();
-                cb.AddLine("[SetUp]");
-                cb.AddLine("public void Setup()");
-                cb.AddLine("{");
-                cb.IndentLevel++;
-                cb.AddLine("ctx = new Bunit.TestContext();");
-                cb.AddLine("ctx.JSInterop.Mode = JSRuntimeMode.Loose;");
-                cb.AddLine("ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager());");
-                cb.AddLine("ctx.Services.AddSingleton<IDialogService>(new DialogService());");
-                cb.AddLine("ctx.Services.AddSingleton<ISnackbar>(new SnackbarService());");
-                cb.AddLine("ctx.Services.AddSingleton<IResizeListenerService>(new MockResizeListenerService());");
-                cb.AddLine("ctx.Services.AddTransient<IScrollManager, MockScrollManager>();");
-                cb.AddLine("ctx.Services.AddTransient<IScrollListener, MockScrollListener>();");
-                cb.AddLine("ctx.Services.AddSingleton<IHeadElementHelper>(new MockHeadElementHelper());");
-                cb.AddLine("ctx.Services.AddSingleton<IBrowserWindowSizeProvider>(new MockBrowserWindowSizeProvider());");
-                cb.AddLine("ctx.Services.AddSingleton<IDomService>(new MockDomService());");
-                cb.AddLine("ctx.Services.AddScoped(sp => new HttpClient());");
-                cb.IndentLevel--;
-                cb.AddLine("}");
-                cb.AddLine();
-                cb.AddLine("[TearDown]");
-                cb.AddLine("public void TearDown() => ctx.Dispose();");
-                cb.AddLine();
                 var mudBlazorComponents = typeof(MudAlert).Assembly.GetTypes().OrderBy(t => t.FullName).Where(t => t.IsSubclassOf(typeof(ComponentBase)));
                 foreach (var type in mudBlazorComponents)
                 {

--- a/src/MudBlazor.Docs.Compiler/TestsForExamples.cs
+++ b/src/MudBlazor.Docs.Compiler/TestsForExamples.cs
@@ -23,43 +23,18 @@ namespace MudBlazor.Docs.Compiler
                 var cb = new CodeBuilder();
 
                 cb.AddHeader();
-                cb.AddUsings();
+                cb.AddLine("using MudBlazor.Docs.Examples;");
+                cb.AddLine("using MudBlazor.Docs.Wireframes;");
+                cb.AddLine("using NUnit.Framework;");
+                cb.AddLine();
 
                 cb.AddLine("namespace MudBlazor.UnitTests.Components");
                 cb.AddLine("{");
                 cb.IndentLevel++;
-                cb.AddLine("// These tests just check if all the examples from the doc page render without errors");
-                cb.AddLine("[TestFixture]");
-                cb.AddLine("public class _AllComponents");
+                cb.AddLine("// These tests just check if all the examples from the doc page render without errors"); 
+                cb.AddLine("public partial class ExampleDocsTests");
                 cb.AddLine("{");
                 cb.IndentLevel++;
-                cb.AddLine("private Bunit.TestContext ctx;");
-                cb.AddLine();
-                cb.AddLine("[SetUp]");
-                cb.AddLine("public void Setup()");
-                cb.AddLine("{");
-                cb.IndentLevel++;
-                cb.AddLine("ctx = new Bunit.TestContext();");
-                cb.AddLine("ctx.JSInterop.Mode = JSRuntimeMode.Loose;");
-                cb.AddLine("ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager());");
-                cb.AddLine("ctx.Services.AddSingleton<IDialogService>(new DialogService());");
-                cb.AddLine("ctx.Services.AddSingleton<ISnackbar>(new SnackbarService());");
-                cb.AddLine("ctx.Services.AddSingleton<IResizeListenerService>(new MockResizeListenerService());");
-
-                cb.AddLine("ctx.Services.AddTransient<IScrollManager, MockScrollManager>();");
-                cb.AddLine("ctx.Services.AddTransient<IScrollListener, MockScrollListener>();");
-                cb.AddLine("ctx.Services.AddSingleton<IBrowserWindowSizeProvider>(new MockBrowserWindowSizeProvider());");
-                cb.AddLine("ctx.Services.AddSingleton<IDomService>(new MockDomService());");
-
-                cb.AddLine("ctx.Services.AddScoped(sp => new HttpClient());");
-                // options required for file upload
-                cb.AddLine("ctx.Services.AddOptions();");
-                cb.IndentLevel--;
-                cb.AddLine("}");
-                cb.AddLine();
-                cb.AddLine("[TearDown]");
-                cb.AddLine("public void TearDown() => ctx.Dispose();");
-                cb.AddLine();
 
                 foreach (var entry in Directory.EnumerateFiles(paths.DocsDirPath, "*.razor", SearchOption.AllDirectories)
                     .OrderBy(e => e.Replace("\\", "/"), StringComparer.Ordinal))

--- a/src/MudBlazor.Docs/Models/Snippets.cs
+++ b/src/MudBlazor.Docs/Models/Snippets.cs
@@ -14,5 +14,30 @@ namespace MudBlazor.Docs.Models
                 return $"Snippet for component '{component}' not found!";
             return (string)field.GetValue(null);
         }
+
+        // used for webapi examples
+        public const string Element = @"using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace MudBlazor.ExampleData.Models
+{
+    public class Element
+    {
+        public string Group { get; set; }
+        public int Position { get; set; }
+        public string Name { get; set; }
+        public int Number { get; set; }
+
+        [JsonPropertyName(""small"")]
+        public string Sign { get; set; }
+        public double Molar { get; set; }
+        public IList<int> Electrons { get; set; }
+
+        public override string ToString()
+        {
+            return $""{Sign} - {Name}"";
+        }
+    }
+}";
     }
 }

--- a/src/MudBlazor.UnitTests/Generated/ApiDocsTests.cs
+++ b/src/MudBlazor.UnitTests/Generated/ApiDocsTests.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Net.Http;
+using Bunit;
+using Bunit.Rendering;
+using Bunit.TestDoubles;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor.Charts;
+using MudBlazor.Docs.Examples;
+using MudBlazor.Docs.Components;
+using MudBlazor.Docs.Wireframes;
+using MudBlazor.Internal;
+using MudBlazor.Services;
+using MudBlazor.UnitTests;
+using MudBlazor.UnitTests.Mocks;
+using NUnit.Framework;
+using Toolbelt.Blazor.HeadElement;
+using ComponentParameter = Bunit.ComponentParameter;
+
+namespace MudBlazor.UnitTests.Components
+{
+    [TestFixture]
+    public partial class ApiDocsTests
+    {
+        private Bunit.TestContext ctx;
+
+        [SetUp]
+        public void Setup()
+        {
+            ctx = new Bunit.TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager());
+            ctx.Services.AddSingleton<IDialogService>(new DialogService());
+            ctx.Services.AddSingleton<ISnackbar>(new SnackbarService());
+            ctx.Services.AddSingleton<IResizeListenerService>(new MockResizeListenerService());
+            ctx.Services.AddTransient<IScrollManager, MockScrollManager>();
+            ctx.Services.AddTransient<IScrollListener, MockScrollListener>();
+            ctx.Services.AddSingleton<IHeadElementHelper>(new MockHeadElementHelper());
+            ctx.Services.AddSingleton<IBrowserWindowSizeProvider>(new MockBrowserWindowSizeProvider());
+            ctx.Services.AddSingleton<IDomService>(new MockDomService());
+            ctx.Services.AddScoped(sp => new HttpClient());
+        }
+        
+        [TearDown]
+        public void TearDown() => ctx.Dispose();
+    }
+}

--- a/src/MudBlazor.UnitTests/Generated/ApiDocsTests.cs
+++ b/src/MudBlazor.UnitTests/Generated/ApiDocsTests.cs
@@ -1,21 +1,11 @@
-using System;
 using System.Net.Http;
 using Bunit;
-using Bunit.Rendering;
-using Bunit.TestDoubles;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
-using MudBlazor.Charts;
-using MudBlazor.Docs.Examples;
-using MudBlazor.Docs.Components;
-using MudBlazor.Docs.Wireframes;
-using MudBlazor.Internal;
 using MudBlazor.Services;
-using MudBlazor.UnitTests;
 using MudBlazor.UnitTests.Mocks;
 using NUnit.Framework;
 using Toolbelt.Blazor.HeadElement;
-using ComponentParameter = Bunit.ComponentParameter;
 
 namespace MudBlazor.UnitTests.Components
 {
@@ -40,7 +30,7 @@ namespace MudBlazor.UnitTests.Components
             ctx.Services.AddSingleton<IDomService>(new MockDomService());
             ctx.Services.AddScoped(sp => new HttpClient());
         }
-        
+
         [TearDown]
         public void TearDown() => ctx.Dispose();
     }

--- a/src/MudBlazor.UnitTests/Generated/ExampleDocsTests.cs
+++ b/src/MudBlazor.UnitTests/Generated/ExampleDocsTests.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Net.Http;
+using Bunit;
+using Bunit.Rendering;
+using Bunit.TestDoubles;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor.Charts;
+using MudBlazor.Docs.Examples;
+using MudBlazor.Docs.Components;
+using MudBlazor.Docs.Wireframes;
+using MudBlazor.Internal;
+using MudBlazor.Services;
+using MudBlazor.UnitTests;
+using MudBlazor.UnitTests.Mocks;
+using NUnit.Framework;
+using Toolbelt.Blazor.HeadElement;
+using ComponentParameter = Bunit.ComponentParameter;
+
+namespace MudBlazor.UnitTests.Components
+{
+    [TestFixture]
+    public partial class ExampleDocsTests
+    {
+        private Bunit.TestContext ctx;
+
+        [SetUp]
+        public void Setup()
+        {
+            ctx = new Bunit.TestContext();
+            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager());
+            ctx.Services.AddSingleton<IDialogService>(new DialogService());
+            ctx.Services.AddSingleton<ISnackbar>(new SnackbarService());
+            ctx.Services.AddSingleton<IResizeListenerService>(new MockResizeListenerService());
+            ctx.Services.AddTransient<IScrollManager, MockScrollManager>();
+            ctx.Services.AddTransient<IScrollListener, MockScrollListener>();
+            ctx.Services.AddSingleton<IHeadElementHelper>(new MockHeadElementHelper());
+            ctx.Services.AddSingleton<IBrowserWindowSizeProvider>(new MockBrowserWindowSizeProvider());
+            ctx.Services.AddSingleton<IDomService>(new MockDomService());
+            ctx.Services.AddOptions();
+            ctx.Services.AddScoped(sp => new HttpClient());
+        }
+
+        [TearDown]
+        public void TearDown() => ctx.Dispose();
+    }
+}

--- a/src/MudBlazor.UnitTests/Generated/ExampleDocsTests.cs
+++ b/src/MudBlazor.UnitTests/Generated/ExampleDocsTests.cs
@@ -1,21 +1,12 @@
 using System;
 using System.Net.Http;
 using Bunit;
-using Bunit.Rendering;
-using Bunit.TestDoubles;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
-using MudBlazor.Charts;
-using MudBlazor.Docs.Examples;
-using MudBlazor.Docs.Components;
-using MudBlazor.Docs.Wireframes;
-using MudBlazor.Internal;
 using MudBlazor.Services;
-using MudBlazor.UnitTests;
 using MudBlazor.UnitTests.Mocks;
 using NUnit.Framework;
 using Toolbelt.Blazor.HeadElement;
-using ComponentParameter = Bunit.ComponentParameter;
 
 namespace MudBlazor.UnitTests.Components
 {
@@ -39,7 +30,7 @@ namespace MudBlazor.UnitTests.Components
             ctx.Services.AddSingleton<IBrowserWindowSizeProvider>(new MockBrowserWindowSizeProvider());
             ctx.Services.AddSingleton<IDomService>(new MockDomService());
             ctx.Services.AddOptions();
-            ctx.Services.AddScoped(sp => new HttpClient());
+            ctx.Services.AddScoped(sp => new HttpClient() { BaseAddress = new Uri("https://try.mudblazor.com/webapi/") });
         }
 
         [TearDown]

--- a/src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj
+++ b/src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj
@@ -2,8 +2,8 @@
 
   <Target Name="IncludeGeneratedFiles" BeforeTargets="BeforeBuild;BeforeRebuild">
     <ItemGroup>
-      <Compile Include="Generated\_AllApiPages.cs" Condition="!Exists('Generated\_AllApiPages.cs')" />
-      <Compile Include="Generated\_AllComponents.cs" Condition="!Exists('Generated\_AllComponents.cs')" />
+      <Compile Include="Generated\ApiDocsTests.generated.cs" Condition="!Exists('Generated\ApiDocsTests.generated.cs')" />
+      <Compile Include="Generated\ExampleDocsTests.generated.cs" Condition="!Exists('Generated\ExampleDocsTests.generated.cs')" />
     </ItemGroup>
   </Target>
 
@@ -22,7 +22,9 @@
   <!--Cleanup old ExampleCode files-->
   <Target Name="CleanGeneratedFiles" BeforeTargets="Clean" Condition="'$(CleanGeneratedFiles)' != 'false'">
     <ItemGroup>
-      <FilesToClean Include="./Generated/*.cs" />
+      <FilesToClean Include="./Generated/*.generated.cs" />
+      <FilesToClean Include="./Generated/_AllApiPages.cs" />
+      <FilesToClean Include="./Generated/_AllComponents.cs" /> 
     </ItemGroup>
     <Delete Files="@(FilesToClean)" />
   </Target>


### PR DESCRIPTION
- Because trying to do any changes to test setup requires painful strings
- Also clarifies test dependencies
- It will require a clean and build the first time this is installed