### PR TITLE
Added option to pass custom HTML to a MudTooltip

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Tooltip/Examples/TooltipHtmlExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tooltip/Examples/TooltipHtmlExample.razor
@@ -1,0 +1,12 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudTooltip>
+    <ChildContent>
+        <MudIconButton Icon="@Icons.Material.Filled.Delete" />
+    </ChildContent>
+    <TooltipContent>
+        <MudText Typo="Typo.h6">h6 title</MudText>
+        <MudText Typo="Typo.body2">body2 content</MudText>
+        <MudIcon Icon="@Icons.Material.Filled.Star" />
+    </TooltipContent>
+</MudTooltip>

--- a/src/MudBlazor.Docs/Pages/Components/Tooltip/TooltipPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tooltip/TooltipPage.razor
@@ -33,5 +33,15 @@
             </SectionContent>
             <SectionSource Code="TooltipPostionExample" GitHubFolderName="Tooltip"  />
         </DocsPageSection>
+        <DocsPageSection>
+            <SectionHeader>
+                <Title>HTML Tooltips</Title>
+                <Description>With <CodeInline>TooltipContent</CodeInline> render fragment, you can specify custom HTML content for your tooltip.</Description>
+            </SectionHeader>
+            <SectionContent Outlined="true" Class="py-8">
+                <TooltipHtmlExample />
+            </SectionContent>
+            <SectionSource Code="TooltipHtmlExample" GitHubFolderName="Tooltip"  />
+        </DocsPageSection>
     </DocsPageContent>
 </DocsPage>

--- a/src/MudBlazor/Components/Tooltip/MudTooltip.razor
+++ b/src/MudBlazor/Components/Tooltip/MudTooltip.razor
@@ -1,54 +1,18 @@
 ﻿@namespace MudBlazor
-@using MudBlazor.Utilities
-@using MudBlazor.Extensions
-@using System.Globalization
 
 <div class="mud-tooltip-root">
     @ChildContent
-    @if (!String.IsNullOrEmpty(Text))
+    @if (!String.IsNullOrEmpty(Text) || TooltipContent != null)
     {
-<span class="@Classname" style="@GetTimeDelay()">
-    @Text
-</span>
-}
-</div>
-
-@code {
-
-    protected string Classname =>
-   new CssBuilder("mud-tooltip")
-     .AddClass($"mud-tooltip-placement-{Placement.ToDescriptionString()}")
-     .AddClass(Class)
-   .Build();
-
-    /// <summary>
-    /// Sets the text to be displayed inside the tooltip.
-    /// </summary>
-    [Parameter] public string Text { get; set; }
-
-
-    /// <summary>
-    /// User class names, separated by space
-    /// </summary>
-    [Parameter] public string Class { get; set; }
-
-    /// <summary>
-    /// Changes the default transition delay in seconds.
-    /// </summary>
-    [Parameter] public double Delayed { get; set; } = 0.2;
-
-    /// <summary>
-    /// Tooltip placement.
-    /// </summary>
-    [Parameter] public Placement Placement { get; set; } = Placement.Bottom;
-
-    /// <summary>
-    /// Child content of component.
-    /// </summary>
-    [Parameter] public RenderFragment ChildContent { get; set; }
-
-    protected string GetTimeDelay()
-    {
-        return $"transition-delay: {Delayed.ToString(CultureInfo.InvariantCulture)}s;";
+        <div class="@Classname" style="@GetTimeDelay()">
+            @if (TooltipContent != null)
+            {
+                @TooltipContent
+            }
+            else
+            {
+                @Text
+            }
+        </div>
     }
-}
+</div>

--- a/src/MudBlazor/Components/Tooltip/MudTooltip.razor.cs
+++ b/src/MudBlazor/Components/Tooltip/MudTooltip.razor.cs
@@ -1,0 +1,52 @@
+﻿using System.Globalization;
+using Microsoft.AspNetCore.Components;
+using MudBlazor.Extensions;
+using MudBlazor.Utilities;
+
+namespace MudBlazor
+{
+
+    public partial class MudTooltip : ComponentBase
+    {
+        protected string Classname => new CssBuilder("mud-tooltip")
+            .AddClass($"mud-tooltip-placement-{Placement.ToDescriptionString()}")
+            .AddClass(Class)
+            .Build();
+
+        /// <summary>
+        /// Sets the text to be displayed inside the tooltip.
+        /// </summary>
+        [Parameter] public string Text { get; set; }
+
+
+        /// <summary>
+        /// User class names, separated by space
+        /// </summary>
+        [Parameter] public string Class { get; set; }
+
+        /// <summary>
+        /// Changes the default transition delay in seconds.
+        /// </summary>
+        [Parameter] public double Delayed { get; set; } = 0.2;
+
+        /// <summary>
+        /// Tooltip placement.
+        /// </summary>
+        [Parameter] public Placement Placement { get; set; } = Placement.Bottom;
+
+        /// <summary>
+        /// Child content of component.
+        /// </summary>
+        [Parameter] public RenderFragment ChildContent { get; set; }
+
+        /// <summary>
+        /// Tooltip content. May contain any valid html
+        /// </summary>
+        [Parameter] public RenderFragment TooltipContent { get; set; }
+
+        protected string GetTimeDelay()
+        {
+            return $"transition-delay: {Delayed.ToString(CultureInfo.InvariantCulture)}s;";
+        }
+    }
+}


### PR DESCRIPTION
I had a use case where I needed to be able to pass custom HTML content to insert <br /> inside the tooltips. I added a way to pass custom HTML (or Blazor) content to the tooltip content via a RenderFragment.