### PR TITLE
Construct api links from generic types automatically

### DIFF
--- a/src/MudBlazor.Docs/Models/ApiLink.cs
+++ b/src/MudBlazor.Docs/Models/ApiLink.cs
@@ -10,7 +10,7 @@ namespace MudBlazor.Docs.Models
         public static string GetApiLinkFor(Type type)
         {
             if (!s_specialCaseComponents.TryGetValue(type, out var component))
-                component = type.ToString().Replace("MudBlazor.Mud", "").ToLowerInvariant();
+                component = new string(type.ToString().Replace("MudBlazor.Mud", "").TakeWhile(c => c != '`').ToArray()).ToLowerInvariant();
             var href = $"/api/{component}";
             return href;
         }
@@ -18,7 +18,7 @@ namespace MudBlazor.Docs.Models
         public static string GetComponentLinkFor(Type type)
         {
             if (!s_specialCaseComponents.TryGetValue(type, out var component))
-                component = type.ToString().Replace("MudBlazor.Mud", "").ToLowerInvariant();
+                component = new string(type.ToString().Replace("MudBlazor.Mud", "").TakeWhile(c => c != '`').ToArray()).ToLowerInvariant();
             if (s_componentLinkTranslation.ContainsKey(component))
                 component = s_componentLinkTranslation[component];
             var href = $"/components/{component}";
@@ -38,29 +38,29 @@ namespace MudBlazor.Docs.Models
                 return null;
             if (s_inverseSpecialCase.TryGetValue(component, out var type))
                 return type;
+
             var assembly = typeof(MudComponentBase).Assembly;
-            var lookup = new Dictionary<string, Type>();
             foreach (var x in assembly.GetTypes())
-                lookup[x.Name.ToLowerInvariant()] = x;
-            var type_lower = $"mud{component}".ToLowerInvariant();
-            if (!lookup.TryGetValue(type_lower, out type))
-                return null;
-            return type;
+            {
+                if (new string(x.Name.ToLowerInvariant().TakeWhile(c => c != '`').ToArray()) == $"mud{component}".ToLowerInvariant())
+                {
+                    if (x.Name.Contains('`'))
+                    {
+                        return x.MakeGenericType(typeof(T));
+                    }
+                    else if (x.Name.ToLowerInvariant() == $"mud{component}".ToLowerInvariant())
+                    {
+                        return x;
+                    }
+                }
+            }
+
+            return null;
         }
 
         private static Dictionary<Type, string> s_specialCaseComponents =
             new Dictionary<Type, string>()
             {
-                [typeof(MudTable<T>)] = "table",
-                [typeof(MudTextField<T>)] = "textfield",
-                [typeof(MudSelect<T>)] = "select",
-                [typeof(MudInput<T>)] = "input",
-                [typeof(MudAutocomplete<T>)] = "autocomplete",
-                [typeof(MudSlider<T>)] = "slider",
-                [typeof(MudCheckBox<T>)] = "checkbox",
-                [typeof(MudRadio<T>)] = "radio",
-                [typeof(MudSwitch<T>)] = "switch",
-                [typeof(MudTreeView<T>)] = "treeview",
                 [typeof(MudFab)] = "buttonfab",
                 [typeof(MudIcon)] = "icons",
                 [typeof(MudProgressCircular)] = "progress",


### PR DESCRIPTION
In `ApiLink.cs` file there is a `s_specialCaseComponents` dictionary, which contains api link names for generic components. The problem with this, if someone add new generic component, maybe forget extending the list here and navigation to API pages break. In this PR I made the current logic able to handle generic types too.