### PR TITLE
Features/progress linear backgrounds

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Tooltip/Examples/TooltipHtmlExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tooltip/Examples/TooltipHtmlExample.razor
@@ -1,0 +1,12 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudTooltip>
+    <ChildContent>
+        <MudIconButton Icon="@Icons.Material.Filled.Delete" />
+    </ChildContent>
+    <TooltipContent>
+        <MudText Typo="Typo.h6">h6 title</MudText>
+        <MudText Typo="Typo.body2">body2 content</MudText>
+        <MudIcon Icon="@Icons.Material.Filled.Star" />
+    </TooltipContent>
+</MudTooltip>

--- a/src/MudBlazor.Docs/Pages/Components/Tooltip/TooltipPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tooltip/TooltipPage.razor
@@ -33,5 +33,15 @@
             </SectionContent>
             <SectionSource Code="TooltipPostionExample" GitHubFolderName="Tooltip"  />
         </DocsPageSection>
+        <DocsPageSection>
+            <SectionHeader>
+                <Title>HTML Tooltips</Title>
+                <Description>With <CodeInline>TooltipContent</CodeInline> render fragment, you can specify custom HTML content for your tooltip.</Description>
+            </SectionHeader>
+            <SectionContent Outlined="true" Class="py-8">
+                <TooltipHtmlExample />
+            </SectionContent>
+            <SectionSource Code="TooltipHtmlExample" GitHubFolderName="Tooltip"  />
+        </DocsPageSection>
     </DocsPageContent>
 </DocsPage>

--- a/src/MudBlazor/Components/Tooltip/MudTooltip.razor
+++ b/src/MudBlazor/Components/Tooltip/MudTooltip.razor
@@ -1,54 +1,18 @@
 ﻿@namespace MudBlazor
-@using MudBlazor.Utilities
-@using MudBlazor.Extensions
-@using System.Globalization
 
 <div class="mud-tooltip-root">
     @ChildContent
-    @if (!String.IsNullOrEmpty(Text))
+    @if (!String.IsNullOrEmpty(Text) || TooltipContent != null)
     {
-<span class="@Classname" style="@GetTimeDelay()">
-    @Text
-</span>
-}
-</div>
-
-@code {
-
-    protected string Classname =>
-   new CssBuilder("mud-tooltip")
-     .AddClass($"mud-tooltip-placement-{Placement.ToDescriptionString()}")
-     .AddClass(Class)
-   .Build();
-
-    /// <summary>
-    /// Sets the text to be displayed inside the tooltip.
-    /// </summary>
-    [Parameter] public string Text { get; set; }
-
-
-    /// <summary>
-    /// User class names, separated by space
-    /// </summary>
-    [Parameter] public string Class { get; set; }
-
-    /// <summary>
-    /// Changes the default transition delay in seconds.
-    /// </summary>
-    [Parameter] public double Delayed { get; set; } = 0.2;
-
-    /// <summary>
-    /// Tooltip placement.
-    /// </summary>
-    [Parameter] public Placement Placement { get; set; } = Placement.Bottom;
-
-    /// <summary>
-    /// Child content of component.
-    /// </summary>
-    [Parameter] public RenderFragment ChildContent { get; set; }
-
-    protected string GetTimeDelay()
-    {
-        return $"transition-delay: {Delayed.ToString(CultureInfo.InvariantCulture)}s;";
+        <div class="@Classname" style="@GetTimeDelay()">
+            @if (TooltipContent != null)
+            {
+                @TooltipContent
+            }
+            else
+            {
+                @Text
+            }
+        </div>
     }
-}
+</div>

--- a/src/MudBlazor/Components/Tooltip/MudTooltip.razor.cs
+++ b/src/MudBlazor/Components/Tooltip/MudTooltip.razor.cs
@@ -1,0 +1,52 @@
+﻿using System.Globalization;
+using Microsoft.AspNetCore.Components;
+using MudBlazor.Extensions;
+using MudBlazor.Utilities;
+
+namespace MudBlazor
+{
+
+    public partial class MudTooltip : ComponentBase
+    {
+        protected string Classname => new CssBuilder("mud-tooltip")
+            .AddClass($"mud-tooltip-placement-{Placement.ToDescriptionString()}")
+            .AddClass(Class)
+            .Build();
+
+        /// <summary>
+        /// Sets the text to be displayed inside the tooltip.
+        /// </summary>
+        [Parameter] public string Text { get; set; }
+
+
+        /// <summary>
+        /// User class names, separated by space
+        /// </summary>
+        [Parameter] public string Class { get; set; }
+
+        /// <summary>
+        /// Changes the default transition delay in seconds.
+        /// </summary>
+        [Parameter] public double Delayed { get; set; } = 0.2;
+
+        /// <summary>
+        /// Tooltip placement.
+        /// </summary>
+        [Parameter] public Placement Placement { get; set; } = Placement.Bottom;
+
+        /// <summary>
+        /// Child content of component.
+        /// </summary>
+        [Parameter] public RenderFragment ChildContent { get; set; }
+
+        /// <summary>
+        /// Tooltip content. May contain any valid html
+        /// </summary>
+        [Parameter] public RenderFragment TooltipContent { get; set; }
+
+        protected string GetTimeDelay()
+        {
+            return $"transition-delay: {Delayed.ToString(CultureInfo.InvariantCulture)}s;";
+        }
+    }
+}

--- a/src/MudBlazor/Styles/components/_progress.scss
+++ b/src/MudBlazor/Styles/components/_progress.scss
@@ -90,12 +90,20 @@
     position: relative;
 }
 
-.mud-progress-linear-color-primary {
-    background-color: rgba(89,74,226, 0.2);
-}
-
-.mud-progress-linear-color-secondary {
-    background-color: rgba(255,69,138, 0.2);
+@each $color in $mud-palette-colors {
+    .mud-progress-linear-color-#{$color} {
+        &::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            height: 100%;
+            width: 100%;
+            display: block;
+            background-color: var(--mud-palette-#{$color});
+            opacity: 0.2;
+        }
+    }
 }
 
 .mud-progress-linear-buffer {


### PR DESCRIPTION
I noticed that the background of the progress bar was not working for color other than primary and secondary. Also. the background would not change if you changed the default theme color. I wanted to fix that.

Before :
![image](https://user-images.githubusercontent.com/5131398/108573288-360e1500-72e2-11eb-940e-7e236fb0d0dd.png)

After :
![image](https://user-images.githubusercontent.com/5131398/108573344-5211b680-72e2-11eb-8886-ce821ba239b1.png)

I did it with a ::before pseudo element that I position absolutely. If you have a better idea to apply the transparency, I would change it gladly.