### PR TITLE
Fixed background color of linear progress bars

### DIFF
--- a/src/MudBlazor/Styles/components/_progress.scss
+++ b/src/MudBlazor/Styles/components/_progress.scss
@@ -90,12 +90,20 @@
     position: relative;
 }
 
-.mud-progress-linear-color-primary {
-    background-color: rgba(89,74,226, 0.2);
-}
-
-.mud-progress-linear-color-secondary {
-    background-color: rgba(255,69,138, 0.2);
+@each $color in $mud-palette-colors {
+    .mud-progress-linear-color-#{$color} {
+        &::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            height: 100%;
+            width: 100%;
+            display: block;
+            background-color: var(--mud-palette-#{$color});
+            opacity: 0.2;
+        }
+    }
 }
 
 .mud-progress-linear-buffer {


### PR DESCRIPTION
I noticed that the background of the progress bar was not working for color other than primary and secondary. Also. the background would not change if you changed the default theme color. I wanted to fix that.

Before :
![image](https://user-images.githubusercontent.com/5131398/108573288-360e1500-72e2-11eb-940e-7e236fb0d0dd.png)

After :
![image](https://user-images.githubusercontent.com/5131398/108573344-5211b680-72e2-11eb-8886-ce821ba239b1.png)

I did it with a ::before pseudo element that I position absolutely. If you have a better idea to apply the transparency, I would change it gladly.