### PR TITLE
Refactoring naming scheme MudBaseInput.onKey[X] to follow .NET standard

### DIFF
--- a/src/MudBlazor.Docs/Shared/MainLayout.razor.cs
+++ b/src/MudBlazor.Docs/Shared/MainLayout.razor.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.Docs.Extensions;
@@ -59,7 +60,7 @@ namespace MudBlazor.Docs.Shared
         private Task<IEnumerable<ApiLinkServiceEntry>> Search(string text)
         {
             if (string.IsNullOrWhiteSpace(text))
-                return Task.FromResult<IEnumerable<ApiLinkServiceEntry>>(new ApiLinkServiceEntry[0]);
+                return Task.FromResult<IEnumerable<ApiLinkServiceEntry>>(Array.Empty<ApiLinkServiceEntry>());
             return ApiLinkService.Search(text);
         }
 

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -144,15 +144,15 @@ namespace MudBlazor
 
         [Parameter] public EventCallback<KeyboardEventArgs> OnKeyDown { get; set; }
 
-        protected virtual void onKeyDown(KeyboardEventArgs obj) => OnKeyDown.InvokeAsync(obj).AndForget();
+        protected virtual void InvokeKeyDown(KeyboardEventArgs obj) => OnKeyDown.InvokeAsync(obj).AndForget();
 
         [Parameter] public EventCallback<KeyboardEventArgs> OnKeyPress { get; set; }
 
-        protected virtual void onKeyPress(KeyboardEventArgs obj) => OnKeyPress.InvokeAsync(obj).AndForget();
+        protected virtual void InvokeKeyPress(KeyboardEventArgs obj) => OnKeyPress.InvokeAsync(obj).AndForget();
 
         [Parameter] public EventCallback<KeyboardEventArgs> OnKeyUp { get; set; }
 
-        protected virtual void onKeyUp(KeyboardEventArgs obj) => OnKeyUp.InvokeAsync(obj).AndForget();
+        protected virtual void InvokeKeyUp(KeyboardEventArgs obj) => OnKeyUp.InvokeAsync(obj).AndForget();
 
         /// <summary>
         /// Fired when the Value property changes. 

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -9,7 +9,7 @@
             <InputContent>
                 <MudInput T="string" @ref="_elementReference" InputType="InputType.Text" Variant="@Variant" @attributes="UserAttributes" Value="@Text" TextChanged="OnTextChanged" DisableUnderLine="@DisableUnderLine" Placeholder="@Placeholder" Disabled=@Disabled ReadOnly="@ReadOnly"
                           Immediate="true" Margin="@Margin" Class="mud-select-input" Error="@Error" AdornmentIcon="@CurrentIcon" Adornment="Adornment.End" IconSize="Size.Medium" OnKeyDown="@this.OnInputKeyDown"
-                          OnBlur="@OnInputBlurred" OnKeyUp="@base.onKeyUp" OnKeyPress="@base.onKeyPress" />
+                          OnBlur="@OnInputBlurred" OnKeyUp="@base.InvokeKeyUp" OnKeyPress="@base.InvokeKeyPress" />
             </InputContent>
         </MudInputControl>
         <MudPopover Open="@IsOpen" MaxHeight="@MaxHeight" OffsetY="true">

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -129,7 +129,7 @@ namespace MudBlazor
             await SetValueAsync(value);
             if (_items != null)
                 _selectedListItemIndex = Array.IndexOf(_items, value);
-            await SetTextAsync( GetItemString(value), false);
+            await SetTextAsync(GetItemString(value), false);
             _timer?.Dispose();
             IsOpen = false;
             UpdateIcon();
@@ -192,7 +192,7 @@ namespace MudBlazor
             _timer?.Dispose();
             if (ResetValueOnEmptyText && string.IsNullOrWhiteSpace(Text))
                 await SetValueAsync(default(T), updateText);
-            if (DebounceInterval<=0)
+            if (DebounceInterval <= 0)
                 OnSearch();
             else
                 _timer = new Timer(OnTimerComplete, null, DebounceInterval, Timeout.Infinite);
@@ -209,10 +209,10 @@ namespace MudBlazor
                 return;
             }
             _selectedListItemIndex = 0;
-            IEnumerable<T> searched_items = new T[0];
+            IEnumerable<T> searched_items = Array.Empty<T>();
             try
             {
-                searched_items = (await SearchFunc(Text)) ?? new T[0];
+                searched_items = (await SearchFunc(Text)) ?? Array.Empty<T>();
             }
             catch (Exception e)
             {
@@ -222,7 +222,7 @@ namespace MudBlazor
                 searched_items = searched_items.Take(MaxItems.Value);
             _items = searched_items.ToArray();
 
-            if (_items?.Count() == 0)
+            if (_items?.Length == 0)
             {
                 IsOpen = false;
                 UpdateIcon();
@@ -261,7 +261,7 @@ namespace MudBlazor
                     await SelectNextItem(-1);
                     break;
             }
-            base.onKeyDown(args);
+            base.InvokeKeyDown(args);
         }
 
         private async Task SelectNextItem(int increment)
@@ -371,7 +371,7 @@ namespace MudBlazor
         {
             if (text == null)
                 return;
-           _= SetTextAsync( text, true);
+            _ = SetTextAsync(text, true);
 
         }
     }

--- a/src/MudBlazor/Components/Chart/MudChart.razor.cs
+++ b/src/MudBlazor/Components/Chart/MudChart.razor.cs
@@ -10,11 +10,11 @@ namespace MudBlazor
 {
     public class MudChartBase : MudComponentBase
     {
-        [Parameter] public double[] InputData { get; set; } = new double[0];
+        [Parameter] public double[] InputData { get; set; } = Array.Empty<double>();
 
-        [Parameter] public string[] InputLabels { get; set; } = new string[0];
+        [Parameter] public string[] InputLabels { get; set; } = Array.Empty<string>();
 
-        [Parameter] public string[] XAxisLabels { get; set; } = new string[0];
+        [Parameter] public string[] XAxisLabels { get; set; } = Array.Empty<string>();
 
         [Parameter] public List<ChartSeries> ChartSeries { get; set; } = new List<ChartSeries>();
 
@@ -52,7 +52,7 @@ namespace MudBlazor
         protected double[] GetNormalizedData()
         {
             if (InputData == null)
-                return new double[0];
+                return Array.Empty<double>();
             var total = InputData.Sum();
             return InputData.Select(x => Math.Abs(x) / total).ToArray();
         }

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -10,10 +10,12 @@ namespace MudBlazor
 {
     public abstract partial class MudBaseDatePicker : MudPicker<DateTime?>
     {
-        protected MudBaseDatePicker() : base(new DefaultConverter<DateTime?>{
+        protected MudBaseDatePicker() : base(new DefaultConverter<DateTime?>
+        {
             Format = "yyyy-MM-dd",
             Culture = CultureInfo.CurrentCulture
-        }) { }
+        })
+        { }
 
         [Inject] protected IScrollManager ScrollManager { get; set; }
 
@@ -44,8 +46,7 @@ namespace MudBlazor
             }
             set
             {
-                var defaultConverter = Converter as DefaultConverter<DateTime?>;
-                if (defaultConverter!=null)
+                if (Converter is DefaultConverter<DateTime?> defaultConverter)
                     defaultConverter.Format = value;
             }
         }
@@ -323,9 +324,9 @@ namespace MudBlazor
         {
             var current = GetMonthStart(0);
             var calendarYear = Culture.Calendar.GetYear(current);
-            var firstOfCalendarYear = Culture.Calendar.ToDateTime(calendarYear, 1, 1,0,0,0,0);
+            var firstOfCalendarYear = Culture.Calendar.ToDateTime(calendarYear, 1, 1, 0, 0, 0, 0);
             for (var i = 0; i < Culture.Calendar.GetMonthsInYear(calendarYear); i++)
-                yield return Culture.Calendar.AddMonths(firstOfCalendarYear,i);
+                yield return Culture.Calendar.AddMonths(firstOfCalendarYear, i);
         }
 
         private string GetAbbreviatedMontName(in DateTime month)

--- a/src/MudBlazor/Components/Input/MudDebouncedInput.cs
+++ b/src/MudBlazor/Components/Input/MudDebouncedInput.cs
@@ -25,7 +25,7 @@ namespace MudBlazor
                 if (_debounceInterval == 0)
                 {
                     // not debounced, dispose timer if any
-                    ClearTimer(suppressTick:false);
+                    ClearTimer(suppressTick: false);
                     return;
                 }
                 SetTimer();
@@ -49,7 +49,7 @@ namespace MudBlazor
                 return base.UpdateValuePropertyAsync(updateText);
             }
             // if debounce interval is 0 we update immediately
-            if (DebounceInterval <= 0 || _timer==null)
+            if (DebounceInterval <= 0 || _timer == null)
                 return base.UpdateValuePropertyAsync(updateText);
             // If a debounce interval is defined, we want to delay the update of Value property.
             _timer.Stop();
@@ -89,7 +89,7 @@ namespace MudBlazor
             await OnDebounceIntervalElapsed.InvokeAsync(Text);
         }
 
-        private void ClearTimer(bool suppressTick=false)
+        private void ClearTimer(bool suppressTick = false)
         {
             if (_timer == null)
                 return;

--- a/src/MudBlazor/Components/Input/MudInput.razor
+++ b/src/MudBlazor/Components/Input/MudInput.razor
@@ -13,7 +13,7 @@
     {
         @*note: the value="@Text" is absolutely essential here. the inner html @Text is kept only for compatibility*@
         <textarea @ref="_elementReference" rows="@Lines" @attributes="UserAttributes" type="@InputTypeString" class="@InputClassname" placeholder="@Placeholder" disabled=@Disabled readonly="@ReadOnly"
-                  @oninput="OnInput" @onchange="OnChange" @onblur="@OnBlurred" @onkeydown="@onKeyDown" @onkeypress="@onKeyPress" @onkeyup="@onKeyUp"  value="@Text">@Text</textarea>
+                  @oninput="OnInput" @onchange="OnChange" @onblur="@OnBlurred" @onkeydown="@InvokeKeyDown" @onkeypress="@InvokeKeyPress" @onkeyup="@InvokeKeyUp" value="@Text">@Text</textarea>
     }
     else
     {
@@ -25,7 +25,7 @@
         }
 
         <input @ref="_elementReference" @attributes="UserAttributes" type="@InputTypeString" class="@InputClassname" value="@Text" @oninput="OnInput" @onchange="OnChange"
-               placeholder="@Placeholder" disabled=@Disabled readonly="@ReadOnly" @onblur="@OnBlurred" @onkeydown="@onKeyDown" @onkeypress="@onKeyPress" @onkeyup="@onKeyUp" />
+               placeholder="@Placeholder" disabled=@Disabled readonly="@ReadOnly" @onblur="@OnBlurred" @onkeydown="@InvokeKeyDown" @onkeypress="@InvokeKeyPress" @onkeyup="@InvokeKeyUp" />
     }
 
     @if (Adornment == Adornment.End)

--- a/src/MudBlazor/Components/Input/MudRangeInput.razor
+++ b/src/MudBlazor/Components/Input/MudRangeInput.razor
@@ -17,10 +17,10 @@
     }
 
     <input @attributes="UserAttributes" type="@InputTypeString" class="@InputClassname" @bind-value="@TextStart" @bind-value:event="@((Immediate ? "oninput" : "onchange"))"
-           placeholder="@PlaceholderStart" disabled=@Disabled readonly="@ReadOnly" @onblur="@OnBlurred" @onkeydown="@onKeyDown" @onkeypress="@onKeyPress" @onkeyup="@onKeyUp" />
+           placeholder="@PlaceholderStart" disabled=@Disabled readonly="@ReadOnly" @onblur="@OnBlurred" @onkeydown="@InvokeKeyDown" @onkeypress="@InvokeKeyPress" @onkeyup="@InvokeKeyUp" />
     <MudIcon Class="mud-range-input-separator" Icon="@Icons.Material.Filled.ArrowRightAlt" Color="@Color.Default" />
     <input @attributes="UserAttributes" type="@InputTypeString" class="@InputClassname" @bind-value="@TextEnd" @bind-value:event="@((Immediate ? "oninput" : "onchange"))"
-           placeholder="@PlaceholderEnd" disabled=@Disabled readonly="@ReadOnly" @onblur="@OnBlurred" @onkeydown="@onKeyDown" @onkeypress="@onKeyPress" @onkeyup="@onKeyUp" />
+           placeholder="@PlaceholderEnd" disabled=@Disabled readonly="@ReadOnly" @onblur="@OnBlurred" @onkeydown="@InvokeKeyDown" @onkeypress="@InvokeKeyPress" @onkeyup="@InvokeKeyUp" />
 
     @if (Adornment == Adornment.End)
     {

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -77,13 +77,13 @@ namespace MudBlazor
         /// Returns the class that will get joined with RowClass. Takes the current item and row index.
         /// </summary>
         [Parameter]
-        public Func<T, int, string> RowClassFunc {get;set;}
+        public Func<T, int, string> RowClassFunc { get; set; }
 
         /// <summary>
         /// Returns the style that will get joined with RowStyle. Takes the current item and row index.
         /// </summary>
         [Parameter]
-        public Func<T, int, string> RowStyleFunc {get;set;}
+        public Func<T, int, string> RowStyleFunc { get; set; }
 
         /// <summary>
         /// Returns the item which was last clicked on in single selection mode (that is, if MultiSelection is false)
@@ -117,7 +117,7 @@ namespace MudBlazor
             {
                 if (!MultiSelection)
                     if (_selectedItem is null)
-                        return new HashSet<T>(new T[] { });
+                        return new HashSet<T>(Array.Empty<T>());
                     else
                         return new HashSet<T>(new T[] { _selectedItem });
                 else
@@ -182,7 +182,7 @@ namespace MudBlazor
         protected IEnumerable<T> GetItemsOfPage(int n, int pageSize)
         {
             if (n < 0 || pageSize <= 0)
-                return new T[0];
+                return Array.Empty<T>();
 
             if (ServerData != null)
                 return _server_data.Items;
@@ -274,7 +274,7 @@ namespace MudBlazor
         internal override bool HasServerData => ServerData != null;
 
 
-        TableData<T> _server_data = new TableData<T>() { TotalItems = 0, Items = new T[0] };
+        TableData<T> _server_data = new TableData<T>() { TotalItems = 0, Items = Array.Empty<T>() };
         private IEnumerable<T> _items;
 
         internal override async Task InvokeServerLoadFunc()

--- a/src/MudBlazor/Components/TextField/MudTextField.razor
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor
@@ -7,7 +7,7 @@
         <InputContent>
             <MudInput T="string" @ref="_elementReference" @attributes="UserAttributes" InputType="@InputType" Lines="@Lines" Style="@Style" Variant="@Variant" Value="@Text" ValueChanged="(s) => SetTextAsync(s)" Placeholder="@Placeholder" Disabled=@Disabled DisableUnderLine="@DisableUnderLine" ReadOnly="@ReadOnly"
                       Adornment="@Adornment" AdornmentText="@AdornmentText" AdornmentIcon="@AdornmentIcon" AdornmentColor="@AdornmentColor" IconSize="@IconSize" OnAdornmentClick="@OnAdornmentClick" Error="@Error" Immediate="@Immediate" Margin="@Margin"
-                      OnBlur="@OnBlurred" OnKeyDown="@onKeyDown" OnKeyPress="@onKeyPress" OnKeyUp="@onKeyUp" />
+                      OnBlur="@OnBlurred" OnKeyDown="@InvokeKeyDown" OnKeyPress="@InvokeKeyPress" OnKeyUp="@InvokeKeyUp" />
         </InputContent>
     </MudInputControl>
 </CascadingValue>


### PR DESCRIPTION
Committed refactoring on the protected events `onKeyDown`, `onKeyPress`, and `onKeyUp` inside `MudBaseInput` to follow standard nomenclature.
It also includes minor refactoring, like using `Array.Empty<T>()` instead of initializing new empty array (https://docs.microsoft.com/it-it/dotnet/fundamentals/code-analysis/quality-rules/ca1825).

This change was discussed here: https://docs.microsoft.com/it-it/dotnet/fundamentals/code-analysis/quality-rules/ca1825