### PR TITLE
Proposal: Generic TableState with SortBy property.

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableLocalSidePaginateExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableLocalSidePaginateExample.razor
@@ -1,0 +1,74 @@
+@using System.Net.Http.Json
+@using MudBlazor.Examples.Data.Models
+@namespace MudBlazor.Docs.Examples
+@inject HttpClient httpClient
+
+<MudTable LocalData="@(new Func<TableState<Element>, Task<TableData<Element>>>(LocalReload))"  
+                        Dense="true" Hover="true" @ref="table">
+    <ToolBarContent>
+        <MudText Typo="Typo.h6">Periodic Elements</MudText>
+        <MudToolBarSpacer />
+        <MudTextField T="string" ValueChanged="@(s=>OnSearch(s))" Placeholder="Search" Adornment="Adornment.Start" 
+                        AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium" Class="mt-0"></MudTextField>
+    </ToolBarContent>
+    <HeaderContent>
+        <MudTh><MudTableSortLabel SortBy="(Element T) => T.Number">Nr</MudTableSortLabel></MudTh>
+        <MudTh><MudTableSortLabel SortBy="(Element T) => T.Sign">Sign</MudTableSortLabel></MudTh>
+        <MudTh><MudTableSortLabel SortBy="(Element T) => T.Sign">Name</MudTableSortLabel></MudTh>
+        <MudTh><MudTableSortLabel SortBy="(Element T) => T.Position">Position</MudTableSortLabel></MudTh>
+        <MudTh><MudTableSortLabel SortBy="(Element T) => T.Molar">Molar mass</MudTableSortLabel></MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd DataLabel="Nr">@context.Number</MudTd>
+        <MudTd DataLabel="Sign">@context.Sign</MudTd>
+        <MudTd DataLabel="Name">@context.Name</MudTd>
+        <MudTd DataLabel="Position">@context.Position</MudTd>
+        <MudTd DataLabel="Molar mass">@context.Molar</MudTd>
+    </RowTemplate>
+    <PagerContent>
+        <MudTablePager />
+    </PagerContent>
+</MudTable>
+
+@code {
+    private IEnumerable<Element> pagedData;
+    private MudTable<Element> table;
+
+    private int totalItems;
+    private string searchString = null;
+
+    /// <summary>
+    /// Here we simulate getting the paged, filtered and ordered data from the server
+    /// </summary>
+    private async Task<TableData<Element>> LocalReload(TableState<Element> state)
+    {
+        IEnumerable<Element> data = await httpClient.GetFromJsonAsync<List<Element>>("webapi/periodicTable");
+        data = data.Where(element =>
+        {
+            if (string.IsNullOrWhiteSpace(searchString))
+                return true;
+            if (element.Sign.Contains(searchString, StringComparison.OrdinalIgnoreCase))
+                return true;
+            if (element.Name.Contains(searchString, StringComparison.OrdinalIgnoreCase))
+                return true;
+            if ($"{element.Number} {element.Position} {element.Molar}".Contains(searchString))
+                return true;
+            return false;
+        }).ToArray();
+        totalItems = data.Count();
+
+        if (state.SortBy != null)
+          data = data.OrderByDirection(state.SortDirection, state.SortBy);
+
+        pagedData = data.Skip(state.Page * state.PageSize).Take(state.PageSize).ToArray();
+        return new TableData<Element>() {TotalItems = totalItems, Items = pagedData};
+    }
+
+    private void OnSearch(string text)
+    {
+        searchString = text;
+        table.ReloadServerData();
+    }
+}
+
+

--- a/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
@@ -119,6 +119,23 @@
 
         <DocsPageSection>
             <SectionHeader>
+                <Title>Local Side Filtering, Sorting and Pagination</Title>
+                <Description>
+                    Set <CodeInline>LocalData</CodeInline> to load data from the local data that is filtered, sorted and paginated. Table will call this async function whenever the user navigates
+                    the pager or changes sorting by clicking on the sort header icons. In this example we also show how to force the table to update when the search textfield blurs, so that the table reloads clientside-filtered data.
+                    <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">
+                        Note: with a <CodeInline>LocalData</CodeInline> func you don't need <CodeInline>Items</CodeInline> and <CodeInline>Filter</CodeInline>.
+                    </MudAlert>
+                </Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" FullWidth="true">
+                <TableLocalSidePaginateExample />
+            </SectionContent>
+            <SectionSource Code="TableLocalSidePaginateExample" ShowCode="false" GitHubFolderName="Table" />
+        </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader>
                 <Title>Table With related data</Title>
                 <Description>
                     Making use of the <CodeInline>&lt;ChildRowContent&gt;</CodeInline> allows more control over the layout for scenarios such as showing the related address data for each person below.

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -309,6 +309,7 @@ namespace MudBlazor
                 {
                     Page = CurrentPage,
                     PageSize = RowsPerPage,
+                    SortLabel = label?.SortLabel,
                     SortDirection = Context.SortDirection,
                     SortBy = label?.SortBy
                 };

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -230,7 +230,7 @@ namespace MudBlazor
                 .AddStyle($"height", Height, !string.IsNullOrWhiteSpace(Height))
                 .Build();
 
-        internal abstract bool HasServerData { get; }
+        internal abstract bool HasCallbackData { get; }
 
         internal abstract Task InvokeServerLoadFunc();
 

--- a/src/MudBlazor/Components/Table/MudTableSortLabel.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTableSortLabel.razor.cs
@@ -42,7 +42,7 @@ namespace MudBlazor
                     return;
                 _direction = value;
                 SortDirectionChanged.InvokeAsync(_direction);
-                if (SortBy != null || Table.HasServerData)
+                if (SortBy != null || Table.HasCallbackData)
                     Context?.SetSortFunc(this);
                 Table.InvokeServerLoadFunc();
             }

--- a/src/MudBlazor/Components/Table/TableState.cs
+++ b/src/MudBlazor/Components/Table/TableState.cs
@@ -19,6 +19,7 @@ namespace MudBlazor
         public int Page { get; set; }
 
         public int PageSize { get; set; }
+        public string SortLabel { get; set; }
 
         public Func<T, object> SortBy { get; set; } = null;
 

--- a/src/MudBlazor/Components/Table/TableState.cs
+++ b/src/MudBlazor/Components/Table/TableState.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace MudBlazor
 {
@@ -9,6 +10,17 @@ namespace MudBlazor
         public int PageSize { get; set; }
 
         public string SortLabel { get; set; }
+
+        public SortDirection SortDirection { get; set; }
+    }
+
+    public class TableState<T>
+    {
+        public int Page { get; set; }
+
+        public int PageSize { get; set; }
+
+        public Func<T, object> SortBy { get; set; } = null;
 
         public SortDirection SortDirection { get; set; }
     }


### PR DESCRIPTION
ServerData parameter on MudTable is designed for sending TableDate to the server. Sorting the data is done by using text property SortLabel. 
An other scenario is when the data is stored at client side but you still want to use ServerData callback instead of the Items parameter. In that scenario it would be better to use the typed SortBy property in the header and let it be passed into TableData class. That would require TableData to be generic and that would be a breaking change. One solution could be to add a LocalData parameter parallel to ServerData that uses a generic TableData as in my exemple.
