### PR TITLE
Prefer index over enumerable methods

### DIFF
--- a/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
@@ -143,11 +143,11 @@ namespace MudBlazor.UnitTests
         {
             var comp = ctx.RenderComponent<CheckBoxesBindAgainstArrayTest>();
             Console.WriteLine(comp.Markup);
-            comp.FindAll("p").Last().TrimmedText().Should().Be("A=True, B=False, C=True, D=False, E=True");
+            comp.FindAll("p")[^1].TrimmedText().Should().Be("A=True, B=False, C=True, D=False, E=True");
             comp.FindAll("input")[0].Change(false);
-            comp.FindAll("p").Last().TrimmedText().Should().Be("A=False, B=False, C=True, D=False, E=True");
+            comp.FindAll("p")[^1].TrimmedText().Should().Be("A=False, B=False, C=True, D=False, E=True");
             comp.FindAll("input")[1].Change(true);
-            comp.FindAll("p").Last().TrimmedText().Should().Be("A=False, B=True, C=True, D=False, E=True");
+            comp.FindAll("p")[^1].TrimmedText().Should().Be("A=False, B=True, C=True, D=False, E=True");
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -195,7 +195,7 @@ namespace MudBlazor.UnitTests
             comp.Instance.Date.Should().BeNull();
             // should show years
             comp.FindAll("div.mud-picker-year-container").Count.Should().Be(1);
-            comp.FindAll("div.mud-picker-year").First().Click();
+            comp.FindAll("div.mud-picker-year")[0].Click();
             comp.FindAll("div.mud-picker-month-container").Count.Should().Be(1);
         }
 
@@ -206,7 +206,7 @@ namespace MudBlazor.UnitTests
             comp.Instance.Date.Should().BeNull();
             // should show years
             comp.FindAll("div.mud-picker-year-container").Count.Should().Be(1);
-            comp.FindAll("div.mud-picker-year").First().Click();
+            comp.FindAll("div.mud-picker-year")[0].Click();
             comp.FindAll("div.mud-picker-month-container").Count.Should().Be(1);
             // clicking outside to close
             comp.Find("div.mud-overlay").Click();
@@ -232,7 +232,7 @@ namespace MudBlazor.UnitTests
         {
             var comp = OpenPicker();
             // should show months
-            comp.FindAll("div.mud-picker-calendar-header-transition").First().Click();
+            comp.FindAll("div.mud-picker-calendar-header-transition")[0].Click();
             comp.FindAll("div.mud-picker-month-container").Count.Should().Be(1);
         }
 
@@ -241,7 +241,7 @@ namespace MudBlazor.UnitTests
         {
             var comp = OpenPicker(Parameter("OpenTo", OpenTo.Month));
             // should show years
-            comp.FindAll("div.mud-picker-calendar-header-transition").First().Click();
+            comp.FindAll("div.mud-picker-calendar-header-transition")[0].Click();
             comp.FindAll("div.mud-picker-year-container").Count.Should().Be(1);
         }
 
@@ -253,7 +253,7 @@ namespace MudBlazor.UnitTests
             // should show months
             comp.FindAll("div.mud-picker-month-container").Count.Should().Be(1);
             comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-month-container > div.mud-picker-month")
-                .Skip(2).First().Click();
+                [2].Click();
             comp.FindAll("button.mud-picker-calendar-day")
                 .Where(x => x.TrimmedText().Equals("2")).First().Click();
             comp.Instance.Date.Value.Date.Should().Be(new DateTime(DateTime.Now.Year, 3, 2));
@@ -275,7 +275,7 @@ namespace MudBlazor.UnitTests
             // should show months
             comp.FindAll("div.mud-picker-month-container").Count.Should().Be(1);
             comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-month-container > div.mud-picker-month")
-                .Skip(3).First().Click();
+                [3].Click();
             comp.FindAll("button.mud-picker-calendar-day")
                 .Where(x => x.TrimmedText().Equals("23")).First().Click();
             comp.Instance.Date.Value.Date.Should().Be(new DateTime(DateTime.Now.Year, 4, 23));
@@ -310,7 +310,7 @@ namespace MudBlazor.UnitTests
             comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-year-container > div.mud-picker-year")
                 .Where(x => x.TrimmedText().Contains("2022")).First().Click();
             comp.FindAll("div.mud-picker-month-container").Count.Should().Be(1);
-            comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-month-container > div.mud-picker-month").Skip(1).First().Click();
+            comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-month-container > div.mud-picker-month")[1].Click();
             comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-calendar-header").Count.Should().Be(1);
             comp.FindAll("button.mud-picker-calendar-day")
                 .Where(x => x.TrimmedText().Equals("1")).First().Click();

--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
@@ -190,7 +190,7 @@ namespace MudBlazor.UnitTests
             comp.Instance.DateRange.Should().BeNull();
             // should show years
             comp.FindAll("div.mud-picker-year-container").Count.Should().Be(1);
-            comp.FindAll("div.mud-picker-year").First().Click();
+            comp.FindAll("div.mud-picker-year")[0].Click();
             comp.FindAll("div.mud-picker-month-container").Count.Should().Be(1);
         }
 
@@ -201,7 +201,7 @@ namespace MudBlazor.UnitTests
             comp.Instance.DateRange.Should().BeNull();
             // should show years
             comp.FindAll("div.mud-picker-year-container").Count.Should().Be(1);
-            comp.FindAll("div.mud-picker-year").First().Click();
+            comp.FindAll("div.mud-picker-year")[0].Click();
             comp.FindAll("div.mud-picker-month-container").Count.Should().Be(1);
             // clicking outside to close
             comp.Find("div.mud-overlay").Click();
@@ -226,7 +226,7 @@ namespace MudBlazor.UnitTests
         {
             var comp = OpenPicker();
             // should show months
-            comp.FindAll("div.mud-picker-calendar-header-transition").First().Click();
+            comp.FindAll("div.mud-picker-calendar-header-transition")[0].Click();
             comp.FindAll("div.mud-picker-month-container").Count.Should().Be(1);
         }
 
@@ -235,7 +235,7 @@ namespace MudBlazor.UnitTests
         {
             var comp = OpenPicker(Parameter("OpenTo", OpenTo.Month));
             // should show years
-            comp.FindAll("div.mud-picker-calendar-header-transition").First().Click();
+            comp.FindAll("div.mud-picker-calendar-header-transition")[0].Click();
             comp.FindAll("div.mud-picker-year-container").Count.Should().Be(1);
         }
 
@@ -246,8 +246,7 @@ namespace MudBlazor.UnitTests
             comp.Instance.DateRange.Should().BeNull();
             // should show months
             comp.FindAll("div.mud-picker-month-container").Count.Should().Be(1);
-            comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-month-container > div.mud-picker-month")
-                .Skip(2).First().Click();
+            comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-month-container > div.mud-picker-month")[2].Click();
             comp.FindAll("button.mud-picker-calendar-day")
                 .Where(x => x.TrimmedText().Equals("2")).First().Click();
             comp.FindAll("button.mud-picker-calendar-day")
@@ -271,7 +270,7 @@ namespace MudBlazor.UnitTests
             // should show months
             comp.FindAll("div.mud-picker-month-container").Count.Should().Be(1);
             comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-month-container > div.mud-picker-month")
-                .Skip(3).First().Click();
+                [3].Click();
             comp.FindAll("button.mud-picker-calendar-day")
                 .Where(x => x.TrimmedText().Equals("10")).First().Click();
             comp.FindAll("button.mud-picker-calendar-day")
@@ -308,7 +307,7 @@ namespace MudBlazor.UnitTests
             comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-year-container > div.mud-picker-year")
                 .Where(x => x.TrimmedText().Contains("2022")).First().Click();
             comp.FindAll("div.mud-picker-month-container").Count.Should().Be(1);
-            comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-month-container > div.mud-picker-month").Skip(1).First().Click();
+            comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-month-container > div.mud-picker-month")[1].Click();
             comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-calendar-header").Count.Should().Be(2);
             comp.FindAll("button.mud-picker-calendar-day")
                 .Where(x => x.TrimmedText().Equals("1")).First().Click();

--- a/src/MudBlazor.UnitTests/Components/MenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MenuTests.cs
@@ -38,9 +38,9 @@ namespace MudBlazor.UnitTests
         public void OpenMenu_ClickFirstItem_CheckClosed()
         {
             var comp = ctx.RenderComponent<MenuTest1>();
-            comp.FindAll("button.mud-button-root").First().Click();
+            comp.FindAll("button.mud-button-root")[0].Click();
             comp.FindAll("div.mud-list-item").Count.Should().Be(3);
-            comp.FindAll("div.mud-list-item").First().Click();
+            comp.FindAll("div.mud-list-item")[0].Click();
             comp.FindAll("div.mud-popover-open").Count.Should().Be(0);
         }
 
@@ -48,9 +48,9 @@ namespace MudBlazor.UnitTests
         public void OpenMenu_ClickSecondItem_CheckClosed()
         {
             var comp = ctx.RenderComponent<MenuTest1>();
-            comp.FindAll("button.mud-button-root").First().Click();
+            comp.FindAll("button.mud-button-root")[0].Click();
             comp.FindAll("div.mud-list-item").Count.Should().Be(3);
-            comp.FindAll("div.mud-list-item").Skip(1).First().Click();
+            comp.FindAll("div.mud-list-item")[1].Click();
             comp.FindAll("div.mud-popover-open").Count.Should().Be(0);
         }
 
@@ -58,9 +58,9 @@ namespace MudBlazor.UnitTests
         public void OpenMenu_ClickThirdItem_CheckClosed()
         {
             var comp = ctx.RenderComponent<MenuTest1>();
-            comp.FindAll("button.mud-button-root").First().Click();
+            comp.FindAll("button.mud-button-root")[0].Click();
             comp.FindAll("div.mud-list-item").Count.Should().Be(3);
-            comp.FindAll("div.mud-list-item").Skip(2).First().Click();
+            comp.FindAll("div.mud-list-item")[2].Click();
             comp.FindAll("div.mud-popover-open").Count.Should().Be(0);
         }
     }

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -367,7 +367,7 @@ namespace MudBlazor.UnitTests
             var select = comp.FindComponent<MudSelect<string>>();
             Console.WriteLine(comp.Markup);
             comp.FindAll("div.mud-list-item-disabled").Count.Should().Be(1);
-            comp.FindAll("div.mud-list-item-disabled").First().Click();
+            comp.FindAll("div.mud-list-item-disabled")[0].Click();
             select.Instance.Value.Should().BeNull();
         }
     }

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -123,24 +123,24 @@ namespace MudBlazor.UnitTests
             Console.WriteLine(comp.Markup);
             // after initial load
             comp.FindAll("tr.mud-table-row").Count.Should().Be(10);
-            comp.FindAll("p.mud-table-pagination-caption").Last().TextContent.Trim().Should().Be("1-10 of 59");
+            comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 59");
             var pagingButtons = comp.FindAll("button");
             // click next page
             pagingButtons[2].Click();
             comp.FindAll("tr.mud-table-row").Count.Should().Be(10);
-            comp.FindAll("p.mud-table-pagination-caption").Last().TextContent.Trim().Should().Be("11-20 of 59");
+            comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("11-20 of 59");
             // last page
             pagingButtons[3].Click();
             comp.FindAll("tr.mud-table-row").Count.Should().Be(9);
-            comp.FindAll("p.mud-table-pagination-caption").Last().TextContent.Trim().Should().Be("51-59 of 59");
+            comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("51-59 of 59");
             // previous page
             pagingButtons[1].Click();
             comp.FindAll("tr.mud-table-row").Count.Should().Be(10);
-            comp.FindAll("p.mud-table-pagination-caption").Last().TextContent.Trim().Should().Be("41-50 of 59");
+            comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("41-50 of 59");
             // first page
             pagingButtons[0].Click();
             comp.FindAll("tr.mud-table-row").Count.Should().Be(10);
-            comp.FindAll("p.mud-table-pagination-caption").Last().TextContent.Trim().Should().Be("1-10 of 59");
+            comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 59");
         }
 
         /// <summary>
@@ -154,24 +154,24 @@ namespace MudBlazor.UnitTests
             Console.WriteLine(comp.Markup);
             // after initial load
             comp.FindAll("tr.mud-table-row").Count.Should().Be(10);
-            comp.FindAll("p.mud-table-pagination-caption").Last().TextContent.Trim().Should().Be("1-10 of 59");
+            comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 59");
             var pagingButtons = comp.FindAll("button");
             // click next page
             pagingButtons[1].Click();
             comp.FindAll("tr.mud-table-row").Count.Should().Be(10);
-            comp.FindAll("p.mud-table-pagination-caption").Last().TextContent.Trim().Should().Be("11-20 of 59");
+            comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("11-20 of 59");
             // last page
             pagingButtons[0].Click();
             comp.FindAll("tr.mud-table-row").Count.Should().Be(9);
-            comp.FindAll("p.mud-table-pagination-caption").Last().TextContent.Trim().Should().Be("51-59 of 59");
+            comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("51-59 of 59");
             // previous page
             pagingButtons[2].Click();
             comp.FindAll("tr.mud-table-row").Count.Should().Be(10);
-            comp.FindAll("p.mud-table-pagination-caption").Last().TextContent.Trim().Should().Be("41-50 of 59");
+            comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("41-50 of 59");
             // first page
             pagingButtons[3].Click();
             comp.FindAll("tr.mud-table-row").Count.Should().Be(10);
-            comp.FindAll("p.mud-table-pagination-caption").Last().TextContent.Trim().Should().Be("1-10 of 59");
+            comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 59");
         }
 
 
@@ -191,17 +191,17 @@ namespace MudBlazor.UnitTests
             table.SetParametersAndRender(ComponentParameter.CreateParameter("RowsPerPage", 20));
             pager.Value.Should().Be("20");
             comp.FindAll("tr.mud-table-row").Count.Should().Be(20);
-            comp.FindAll("p.mud-table-pagination-caption").Last().TextContent.Trim().Should().Be("1-20 of 59");
+            comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-20 of 59");
             // change page size
             table.SetParametersAndRender(ComponentParameter.CreateParameter("RowsPerPage", 60));
             pager.Value.Should().Be("60");
             comp.FindAll("tr.mud-table-row").Count.Should().Be(59);
-            comp.FindAll("p.mud-table-pagination-caption").Last().TextContent.Trim().Should().Be("1-59 of 59");
+            comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-59 of 59");
             // change page size
             table.SetParametersAndRender(ComponentParameter.CreateParameter("RowsPerPage", 10));
             pager.Value.Should().Be("10");
             comp.FindAll("tr.mud-table-row").Count.Should().Be(10);
-            comp.FindAll("p.mud-table-pagination-caption").Last().TextContent.Trim().Should().Be("1-10 of 59");
+            comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 59");
         }
 
         /// <summary>
@@ -215,11 +215,11 @@ namespace MudBlazor.UnitTests
             // search returns 3 items
             searchString.Change("Ala");
             comp.FindAll("tr").Count.Should().Be(3);
-            comp.FindAll("p.mud-table-pagination-caption").Last().TextContent.Trim().Should().Be("1-3 of 3");
+            comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-3 of 3");
             // clear search
             searchString.Change(string.Empty);
             comp.FindAll("tr").Count.Should().Be(10);
-            comp.FindAll("p.mud-table-pagination-caption").Last().TextContent.Trim().Should().Be("1-10 of 59");
+            comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 59");
         }
 
         /// <summary>
@@ -233,24 +233,24 @@ namespace MudBlazor.UnitTests
             Console.WriteLine(comp.Markup);
             // after initial load
             comp.FindAll("tr.mud-table-row").Count.Should().Be(10);
-            comp.FindAll("p.mud-table-pagination-caption").Last().TextContent.Trim().Should().Be("1-10 of 59");
+            comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 59");
             var pagingButtons = comp.FindAll("button");
             // goto page 3
             pagingButtons[2].Click();
             pagingButtons[2].Click();
             comp.FindAll("tr.mud-table-row").Count.Should().Be(10);
-            comp.FindAll("p.mud-table-pagination-caption").Last().TextContent.Trim().Should().Be("21-30 of 59");
+            comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("21-30 of 59");
             // should return 3 items and 
             var table = comp.FindComponent<MudTable<string>>().Instance;
             var searchString = comp.Find("#searchString");
             searchString.Change("Ala");
             table.GetFilteredItemsCount().Should().Be(3);
             comp.FindAll("tr.mud-table-row").Count.Should().Be(3);
-            comp.FindAll("p.mud-table-pagination-caption").Last().TextContent.Trim().Should().Be("1-3 of 3");
+            comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-3 of 3");
             searchString.Change(string.Empty);
             table.GetFilteredItemsCount().Should().Be(59);
             comp.FindAll("tr.mud-table-row").Count.Should().Be(10);
-            comp.FindAll("p.mud-table-pagination-caption").Last().TextContent.Trim().Should().Be("1-10 of 59");
+            comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 59");
         }
 
         /// <summary>
@@ -427,7 +427,7 @@ namespace MudBlazor.UnitTests
             await Task.Delay(200);
             Console.WriteLine(comp.Markup);
             comp.FindAll("tr.mud-table-row").Count.Should().Be(11); // ten rows + header row
-            comp.FindAll("p.mud-table-pagination-caption").Last().TextContent.Trim().Should().Be("1-10 of 20");
+            comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 20");
         }
 
         /// <summary>

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -82,7 +82,7 @@ namespace MudBlazor.UnitTests
             // all panels should be evident in the markup:
             comp.FindAll("button").Count.Should().Be(3);
             // every panel should be rendered first exactly once throughout the test:
-            comp.FindAll("p").Last().MarkupMatches("<p>Panel 1<br>Panel 2<br>Panel 3<br></p>");
+            comp.FindAll("p")[^1].MarkupMatches("<p>Panel 1<br>Panel 2<br>Panel 3<br></p>");
             // only the first panel should be active:
             comp.FindAll("div.mud-tabs-panels > div")[0].GetAttribute("style").Should().Be("display:contents");
             comp.FindAll("div.mud-tabs-panels > div")[1].GetAttribute("style").Should().Be("display:none");
@@ -95,7 +95,7 @@ namespace MudBlazor.UnitTests
             // switch to the second tab:
             comp.FindAll("div.mud-tab")[1].Click();
             // none of the panels should have had a render pass with firstRender==true, so this must be as before:
-            comp.FindAll("p").Last().MarkupMatches("<p>Panel 1<br>Panel 2<br>Panel 3<br></p>");
+            comp.FindAll("p")[^1].MarkupMatches("<p>Panel 1<br>Panel 2<br>Panel 3<br></p>");
             // second panel should be displayed
             comp.FindAll("div.mud-tabs-panels > div")[0].GetAttribute("style").Should().Be("display:none");
             comp.FindAll("div.mud-tabs-panels > div")[1].GetAttribute("style").Should().Be("display:contents");
@@ -115,13 +115,13 @@ namespace MudBlazor.UnitTests
             comp.FindAll("button")[0].TrimmedText().Should().Be("Panel 1=1");
             comp.FindAll("button")[1].TrimmedText().Should().Be("Panel 2=2");
             comp.FindAll("button")[2].TrimmedText().Should().Be("Panel 3=0");
-            comp.FindAll("p").Last().MarkupMatches("<p>Panel 1<br>Panel 2<br>Panel 3<br></p>");
+            comp.FindAll("p")[^1].MarkupMatches("<p>Panel 1<br>Panel 2<br>Panel 3<br></p>");
             // switch back to the first tab:
             comp.FindAll("div.mud-tab")[0].Click();
             comp.FindAll("button")[0].TrimmedText().Should().Be("Panel 1=1");
             comp.FindAll("button")[1].TrimmedText().Should().Be("Panel 2=2");
             comp.FindAll("button")[2].TrimmedText().Should().Be("Panel 3=0");
-            comp.FindAll("p").Last().MarkupMatches("<p>Panel 1<br>Panel 2<br>Panel 3<br></p>");
+            comp.FindAll("p")[^1].MarkupMatches("<p>Panel 1<br>Panel 2<br>Panel 3<br></p>");
             // only the first panel should be active:
             comp.FindAll("div.mud-tabs-panels > div")[0].GetAttribute("style").Should().Be("display:contents");
             comp.FindAll("div.mud-tabs-panels > div")[1].GetAttribute("style").Should().Be("display:none");
@@ -140,7 +140,7 @@ namespace MudBlazor.UnitTests
             // only one panel should be evident in the markup:
             comp.FindAll("button").Count.Should().Be(1);
             // only the first panel should be rendered first
-            comp.FindAll("p").Last().MarkupMatches("<p>Panel 1<br></p>");
+            comp.FindAll("p")[^1].MarkupMatches("<p>Panel 1<br></p>");
             // no child divs in div.mud-tabs-panels
             comp.FindAll("div.mud-tabs-panels > div").Count.Should().Be(0);
             // click first button and show button click counters
@@ -150,7 +150,7 @@ namespace MudBlazor.UnitTests
             // switch to the second tab:
             comp.FindAll("div.mud-tab")[1].Click();
             // first and second panel were rendered once with firstRender==true:
-            comp.FindAll("p").Last().MarkupMatches("<p>Panel 1<br>Panel 2<br></p>");
+            comp.FindAll("p")[^1].MarkupMatches("<p>Panel 1<br>Panel 2<br></p>");
             // only one panel should be evident in the markup:
             comp.FindAll("button").Count.Should().Be(1);
             comp.FindAll("button")[0].TrimmedText().Should().Be("Panel 2=0");
@@ -162,13 +162,13 @@ namespace MudBlazor.UnitTests
             comp.FindAll("div.mud-tab")[2].Click();
             // second panel should be displayed
             comp.FindAll("button")[0].TrimmedText().Should().Be("Panel 3=0");
-            comp.FindAll("p").Last().MarkupMatches("<p>Panel 1<br>Panel 2<br>Panel 3<br></p>");
+            comp.FindAll("p")[^1].MarkupMatches("<p>Panel 1<br>Panel 2<br>Panel 3<br></p>");
             // switch back to the first tab:
             comp.FindAll("div.mud-tab")[0].Click();
             comp.FindAll("button")[0].TrimmedText().Should().Be("Panel 1=0");
             comp.FindAll("button")[0].Click();
             comp.FindAll("button")[0].TrimmedText().Should().Be("Panel 1=1");
-            comp.FindAll("p").Last().MarkupMatches("<p>Panel 1<br>Panel 2<br>Panel 3<br>Panel 1<br></p>");
+            comp.FindAll("p")[^1].MarkupMatches("<p>Panel 1<br>Panel 2<br>Panel 3<br>Panel 1<br></p>");
         }
     }
 

--- a/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
@@ -94,24 +94,24 @@ namespace MudBlazor.UnitTests
             var comp = OpenPicker();
             var picker = comp.Instance;
             // select 16 hours on outer dial and 30 mins
-            comp.FindAll("div.mud-picker-stick-outer.mud-hour").Skip(3).First().Click();
+            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[3].Click();
             picker.Time.Value.Hours.Should().Be(16);
             picker.Time.Value.Minutes.Should().Be(0);
             // select 30 minutes
-            comp.FindAll("div.mud-minute").Skip(30).First().Click();
+            comp.FindAll("div.mud-minute")[30].Click();
             picker.Time.Value.Hours.Should().Be(16);
             picker.Time.Value.Minutes.Should().Be(30);
             Console.Write(comp.Markup);
             // click 04 hours on the inner dial and 21 mins
-            comp.FindAll("button.mud-timepicker-button").First().Click();
-            comp.FindAll("div.mud-picker-stick-inner.mud-hour").Skip(3).First().Click();
-            comp.FindAll("div.mud-minute").Skip(21).First().Click();
+            comp.FindAll("button.mud-timepicker-button")[0].Click();
+            comp.FindAll("div.mud-picker-stick-inner.mud-hour")[3].Click();
+            comp.FindAll("div.mud-minute")[21].Click();
             picker.Time.Value.Hours.Should().Be(4);
             picker.Time.Value.Minutes.Should().Be(21);
             // click 10 hours on the inner dial and 56 mins
-            comp.FindAll("button.mud-timepicker-button").First().Click();
-            comp.FindAll("div.mud-picker-stick-inner.mud-hour").Skip(9).First().Click();
-            comp.FindAll("div.mud-minute").Skip(56).First().Click();
+            comp.FindAll("button.mud-timepicker-button")[0].Click();
+            comp.FindAll("div.mud-picker-stick-inner.mud-hour")[9].Click();
+            comp.FindAll("div.mud-minute")[56].Click();
             picker.Time.Value.Hours.Should().Be(10);
             picker.Time.Value.Minutes.Should().Be(56);
         }
@@ -122,25 +122,25 @@ namespace MudBlazor.UnitTests
             var comp = OpenPicker(Parameter("AmPm", true));
             var picker = comp.Instance;
             // select 11 hours on outer dial and 30 mins
-            comp.FindAll("div.mud-hour").Skip(10).First().Click();
-            comp.FindAll("div.mud-minute").Skip(30).First().Click();
+            comp.FindAll("div.mud-hour")[10].Click();
+            comp.FindAll("div.mud-minute")[30].Click();
             picker.Time.Value.Hours.Should().Be(11);
             picker.Time.Value.Minutes.Should().Be(30);
             Console.Write(comp.Markup);
             // click 04 hours on the inner dial and 21 mins
-            comp.FindAll("button.mud-timepicker-button").First().Click();
-            comp.FindAll("div.mud-hour").Skip(11).First().Click();
-            comp.FindAll("div.mud-minute").Skip(21).First().Click();
+            comp.FindAll("button.mud-timepicker-button")[0].Click();
+            comp.FindAll("div.mud-hour")[11].Click();
+            comp.FindAll("div.mud-minute")[21].Click();
             picker.Time.Value.Hours.Should().Be(0);
             picker.Time.Value.Minutes.Should().Be(21);
             // click 10 hours on the inner dial and 56 mins
-            comp.FindAll("button.mud-timepicker-button").First().Click();
-            comp.FindAll("div.mud-hour").Skip(9).First().Click();
-            comp.FindAll("div.mud-minute").Skip(56).First().Click();
+            comp.FindAll("button.mud-timepicker-button")[0].Click();
+            comp.FindAll("div.mud-hour")[9].Click();
+            comp.FindAll("div.mud-minute")[56].Click();
             picker.Time.Value.Hours.Should().Be(10);
             picker.Time.Value.Minutes.Should().Be(56);
             // click pm button
-            comp.FindAll("button.mud-timepicker-button").Skip(3).First().Click();
+            comp.FindAll("button.mud-timepicker-button")[3].Click();
             picker.Time.Value.Hours.Should().Be(22);
             picker.Time.Value.Minutes.Should().Be(56);
         }
@@ -151,19 +151,19 @@ namespace MudBlazor.UnitTests
             var comp = OpenPicker(Parameter("AmPm", true));
             var picker = comp.Instance;
             // select 11 hours on outer dial and 30 mins
-            comp.FindAll("div.mud-hour").Skip(10).First().Click();
-            comp.FindAll("div.mud-minute").Skip(30).First().Click();
+            comp.FindAll("div.mud-hour")[10].Click();
+            comp.FindAll("div.mud-minute")[30].Click();
             picker.Time.Value.Hours.Should().Be(11);
             picker.Time.Value.Minutes.Should().Be(30);
             // click pm button
-            comp.FindAll("button.mud-timepicker-button").Skip(3).First().Click();
+            comp.FindAll("button.mud-timepicker-button")[3].Click();
             picker.Time.Value.Hours.Should().Be(23);
             picker.Time.Value.Minutes.Should().Be(30);
             // add 12 hours in pm mode
-            comp.FindAll("div.mud-hour").Skip(10).First().Click();
+            comp.FindAll("div.mud-hour")[10].Click();
             picker.Time.Value.Hours.Should().Be(23);
             // click am button shoulkd subtract 12 hours
-            comp.FindAll("button.mud-timepicker-button").Skip(2).First().Click();
+            comp.FindAll("button.mud-timepicker-button")[2].Click();
             picker.Time.Value.Hours.Should().Be(11);
             picker.Time.Value.Minutes.Should().Be(30);
         }
@@ -183,12 +183,12 @@ namespace MudBlazor.UnitTests
             // Are minutes hidden
             comp.FindAll("div.mud-time-picker-minute.mud-time-picker-dial-hidden").Count.Should().Be(1);
             // click on the minutes input
-            comp.FindAll("button.mud-timepicker-button").Skip(1).First().Click();
+            comp.FindAll("button.mud-timepicker-button")[1].Click();
             // clicking outside to close
             comp.Find("div.mud-overlay").Click();
             // should not be open
             comp.FindAll("div.mud-picker-open").Count.Should().Be(0);
-            comp.FindAll("input").First().Click();
+            comp.FindAll("input")[0].Click();
             // Are hours displayed
             comp.FindAll("div.mud-time-picker-minute.mud-time-picker-dial-hidden").Count.Should().Be(1);
         }
@@ -231,7 +231,7 @@ namespace MudBlazor.UnitTests
         {
             var comp = OpenPicker();
             // click on the minutes input
-            comp.FindAll("button.mud-timepicker-button").Skip(1).First().Click();
+            comp.FindAll("button.mud-timepicker-button")[1].Click();
             // Are minutes displayed
             comp.FindAll("div.mud-time-picker-hour.mud-time-picker-dial-hidden").Count.Should().Be(1);
         }
@@ -244,11 +244,11 @@ namespace MudBlazor.UnitTests
             var picker = comp.Instance;
             // click on the minutes input
             comp.Find("div.mud-time-picker-hour").MouseDown();
-            comp.FindAll("div.mud-picker-stick-outer.mud-hour").Skip(3).First().MouseOver();
+            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[3].MouseOver();
             picker.Time.Value.Hours.Should().Be(16);
             picker.Time.Value.Minutes.Should().Be(0);
-            comp.FindAll("div.mud-picker-stick-outer.mud-hour").Skip(5).First().MouseOver();
-            comp.FindAll("div.mud-picker-stick-outer.mud-hour").Skip(5).First().MouseUp();
+            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[5].MouseOver();
+            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[5].MouseUp();
             picker.Time.Value.Hours.Should().Be(18);
             picker.Time.Value.Minutes.Should().Be(0);
             // Are minutes displayed
@@ -265,12 +265,12 @@ namespace MudBlazor.UnitTests
             comp.FindAll("div.mud-time-picker-hour.mud-time-picker-dial-hidden").Count.Should().Be(1);
             // click and drag
             comp.Find("div.mud-time-picker-minute").MouseDown();
-            comp.FindAll("div.mud-minute").Skip(3).First().MouseOver();
+            comp.FindAll("div.mud-minute")[3].MouseOver();
             picker.Time.Value.Minutes.Should().Be(3);
-            comp.FindAll("div.mud-minute").Skip(31).First().MouseOver();
+            comp.FindAll("div.mud-minute")[31].MouseOver();
             picker.Time.Value.Minutes.Should().Be(31);
-            comp.FindAll("div.mud-minute").Skip(5).First().MouseOver();
-            comp.FindAll("div.mud-minute").Skip(5).First().MouseUp();
+            comp.FindAll("div.mud-minute")[5].MouseOver();
+            comp.FindAll("div.mud-minute")[5].MouseUp();
             picker.Time.Value.Minutes.Should().Be(5);
         }
 
@@ -302,11 +302,11 @@ namespace MudBlazor.UnitTests
             for (var i = 0; i < 12; i++)
             {
                 comp.Find("div.mud-time-picker-hour").MouseDown();
-                comp.FindAll("div.mud-hour").Skip(i).First().MouseOver();
+                comp.FindAll("div.mud-hour")[i].MouseOver();
                 picker.Time.Value.Hours.Should().Be(i + 1);
-                comp.FindAll("div.mud-hour").Skip(i).First().MouseUp();
+                comp.FindAll("div.mud-hour")[i].MouseUp();
                 picker.Time.Value.Hours.Should().Be(i + 1);
-                comp.FindAll("div.mud-hour").Skip(i).First().Click();
+                comp.FindAll("div.mud-hour")[i].Click();
                 picker.Time.Value.Hours.Should().Be(i + 1);
             }
         }
@@ -322,22 +322,22 @@ namespace MudBlazor.UnitTests
             for (var i = 0; i < 12; i++)
             {
                 comp.Find("div.mud-time-picker-hour").MouseDown();
-                comp.FindAll("div.mud-picker-stick-outer.mud-hour").Skip(i).First().MouseOver();
+                comp.FindAll("div.mud-picker-stick-outer.mud-hour")[i].MouseOver();
                 picker.Time.Value.Hours.Should().Be(i + 13 == 24 ? 0 : i + 13);
-                comp.FindAll("div.mud-picker-stick-outer.mud-hour").Skip(i).First().MouseUp();
+                comp.FindAll("div.mud-picker-stick-outer.mud-hour")[i].MouseUp();
                 picker.Time.Value.Hours.Should().Be(i + 13 == 24 ? 0 : i + 13);
-                comp.FindAll("div.mud-picker-stick-outer.mud-hour").Skip(i).First().Click();
+                comp.FindAll("div.mud-picker-stick-outer.mud-hour")[i].Click();
                 picker.Time.Value.Hours.Should().Be(i + 13 == 24 ? 0 : i + 13);
             }
             // click and drag 1 to 12 on inner dial
             for (var i = 0; i < 12; i++)
             {
                 comp.Find("div.mud-time-picker-hour").MouseDown();
-                comp.FindAll("div.mud-picker-stick-inner.mud-hour").Skip(i).First().MouseOver();
+                comp.FindAll("div.mud-picker-stick-inner.mud-hour")[i].MouseOver();
                 picker.Time.Value.Hours.Should().Be(i + 1);
-                comp.FindAll("div.mud-picker-stick-inner.mud-hour").Skip(i).First().MouseUp();
+                comp.FindAll("div.mud-picker-stick-inner.mud-hour")[i].MouseUp();
                 picker.Time.Value.Hours.Should().Be(i + 1);
-                comp.FindAll("div.mud-picker-stick-inner.mud-hour").Skip(i).First().Click();
+                comp.FindAll("div.mud-picker-stick-inner.mud-hour")[i].Click();
                 picker.Time.Value.Hours.Should().Be(i + 1);
             }
         }
@@ -356,11 +356,11 @@ namespace MudBlazor.UnitTests
             for (var i = 0; i < 60; i++)
             {
                 comp.Find("div.mud-time-picker-minute").MouseDown();
-                comp.FindAll("div.mud-minute").Skip(i).First().MouseOver();
+                comp.FindAll("div.mud-minute")[i].MouseOver();
                 picker.Time.Value.Minutes.Should().Be(i);
-                comp.FindAll("div.mud-minute").Skip(i).First().MouseUp();
+                comp.FindAll("div.mud-minute")[i].MouseUp();
                 picker.Time.Value.Minutes.Should().Be(i);
-                comp.FindAll("div.mud-minute").Skip(i).First().Click();
+                comp.FindAll("div.mud-minute")[i].Click();
                 picker.Time.Value.Minutes.Should().Be(i);
             }
         }


### PR DESCRIPTION
- The compiler is asking me to use indexer rather than enumerable methods on the testing collections.
- In fact this is how bUnit show it in their examples
- We already mix the 2 for example some use `[0]` and some use `.First()`
- It actually looks better for the intermediate stuff ie `[30]` is easier to read than `.Skip(30).First()`
- The only bit that is less readable is `.Last()` which ends up `[^1]` but its seems odd to leave `.Last()`on its own