### PR TITLE
Fix #999 ignore all errors in dispose

### DIFF
--- a/src/MudBlazor/Components/Tabs/MudTabPanel.razor
+++ b/src/MudBlazor/Components/Tabs/MudTabPanel.razor
@@ -80,6 +80,10 @@ else
 
     public void Dispose()
     {
-        Parent?.RemovePanel(this);
+        try
+        {
+            Parent?.RemovePanel(this);
+        }
+        catch { }
     }
 }

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -229,11 +229,7 @@ namespace MudBlazor
                     ActivePanel = null;
             }
             Panels.Remove(tabPanel);
-            try
-            {
-                StateHasChanged();
-            }
-            catch (ObjectDisposedException) { }
+            StateHasChanged();
         }
 
         string GetTabClass(MudTabPanel panel)


### PR DESCRIPTION
- We need to take a harder approach to prevent exceptions in the absence of a proper cleanup event from MS