### PR TITLE
Text align for table cells on mobile

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableBasicExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableBasicExample.razor
@@ -3,7 +3,7 @@
 @namespace MudBlazor.Docs.Examples
 @inject HttpClient httpClient
 
-<MudTable Items="@Elements.Take(4)" Hover="true" Breakpoint="Breakpoint.Sm">
+<MudTable Items="@Elements.Take(4)" Hover="true" Breakpoint="Breakpoint.Sm" RightAlignSmall="_rightAligned">
     <HeaderContent>
         <MudTh>Nr</MudTh>
         <MudTh>Sign</MudTh>
@@ -15,16 +15,20 @@
         <MudTd DataLabel="Nr">@context.Number</MudTd>
         <MudTd DataLabel="Sign">@context.Sign</MudTd>
         <MudTd DataLabel="Name">@context.Name</MudTd>
-        <MudTd DataLabel="Position">@context.Position</MudTd>
+        <MudTd DataLabel="Position" HideSmall="_hidePosition">@context.Position</MudTd>
         <MudTd DataLabel="Molar mass">@context.Molar</MudTd>
     </RowTemplate>
 </MudTable>
 
+<MudSwitch @bind-Checked="_hidePosition">Hide <b>position</b> when Breakpoint=Xs</MudSwitch>
+<MudSwitch @bind-Checked="_rightAligned">Right align cell when Breakpoint=Xs</MudSwitch>
+
 @code {
+    private bool _hidePosition, _rightAligned = true;
     private IEnumerable<Element> Elements = new List<Element>();
 
     protected override async Task OnInitializedAsync()
     {
         Elements = await httpClient.GetFromJsonAsync<List<Element>>("webapi/periodictable");
-    }    
+    }
 }

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -30,6 +30,7 @@ namespace MudBlazor
            .AddClass($"mud-table-square", Square)
            .AddClass($"mud-table-sticky-header", FixedHeader)
            .AddClass($"mud-elevation-{Elevation}", !Outlined)
+           .AddClass($"mud-table-small-alignright", RightAlignSmall)
           .AddClass(Class)
         .Build();
 
@@ -176,6 +177,11 @@ namespace MudBlazor
         /// CSS styles for the table rows. Note, many CSS settings are overridden by MudTd though
         /// </summary>
         [Parameter] public string RowStyle { get; set; }
+
+        /// <summary>
+        /// Alignment of the table cell text when breakpoint is smaller than <see cref="Breakpoint" />
+        /// </summary>
+        [Parameter] public bool RightAlignSmall { get; set; } = true;
 
         public abstract TableContext TableContext { get; }
 

--- a/src/MudBlazor/Components/Table/MudTd.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTd.razor.cs
@@ -6,11 +6,19 @@ namespace MudBlazor
     public partial class MudTd : MudComponentBase
     {
 
-        protected string Classname => new CssBuilder("mud-table-cell")
-       .AddClass(Class).Build();
+        protected string Classname => 
+        new CssBuilder("mud-table-cell")
+            .AddClass("mud-table-cell-hide", HideSmall)
+            .AddClass(Class)
+        .Build();
 
         [Parameter] public RenderFragment ChildContent { get; set; }
 
         [Parameter] public string DataLabel { get; set; }
+
+        /// <summary>
+        /// Hide cell when breakpoint is smaller than the defined value in table.
+        /// </summary>
+        [Parameter] public bool HideSmall { get; set; }
     }
 }

--- a/src/MudBlazor/Styles/components/_table.scss
+++ b/src/MudBlazor/Styles/components/_table.scss
@@ -303,7 +303,19 @@
         .mud-table-cell:before {
             content: attr(data-label);
             font-weight: 500;
-            width: 100%;
+            width: 50%;
+            min-width: 50%;
+        }
+
+        &.mud-table-small-alignright .mud-table-cell:before {
+            margin-right: auto;
+        }
+
+        .mud-table-cell-hide {
+            visibility: collapse;
+            height: 0;
+            padding: 0;
+            margin: 0;
         }
 
         .mud-table-pagination {


### PR DESCRIPTION
Possible solution for #916 
Cell text can be aligned left and right. Also added a posiibility to hide a single row on small screens.
Perhaps naming could be better so I'm open to any suggestion.