### PR TITLE
Tidy up test namespaces

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTest1.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTest1.razor
@@ -1,5 +1,4 @@
-﻿@using MudBlazor;
-@namespace MudBlazor.UnitTests
+﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudAutocomplete T="string" Label="US States" @bind-Value="value1" SearchFunc="@Search1" DebounceInterval="10" />
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTest2.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTest2.razor
@@ -1,5 +1,4 @@
-﻿@using MudBlazor;
-@namespace MudBlazor.UnitTests
+﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudAutocomplete T="string" Label="US States" @bind-Value="value1" SearchFunc="@Search1" DebounceInterval="10" MinCharacters="3" />
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTest3.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTest3.razor
@@ -1,5 +1,4 @@
-﻿@using MudBlazor;
-@namespace MudBlazor.UnitTests
+﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudAutocomplete Label="State" SearchFunc="@SearchStateAsync" 
                  ToStringFunc="@(e => e?.StateName)" @bind-Value="@StateDetails" Variant="Variant.Outlined" 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTest4.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTest4.razor
@@ -1,5 +1,4 @@
-﻿@using MudBlazor;
-@namespace MudBlazor.UnitTests
+﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudAutocomplete Label="State" SearchFunc="@SearchStateAsync" 
                  @bind-Value="@StateDetails" Variant="Variant.Outlined" 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTest5.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteTest5.razor
@@ -1,5 +1,4 @@
-﻿@using MudBlazor;
-@namespace MudBlazor.UnitTests
+﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudAutocomplete ReadOnly="true" T="string" Label="US States" @bind-Value="value1" SearchFunc="@Search1" DebounceInterval="10" />
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteValidationTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteValidationTest.razor
@@ -1,4 +1,6 @@
-﻿<MudGrid>
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudGrid>
     <MudItem xs="12" sm="6" md="4">
         <MudForm @ref="form">
             <MudAutocomplete T="string" Label="US States" @bind-Value="value" SearchFunc="@Search" Required="true" 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/CheckBox/CheckBoxFormTest1.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/CheckBox/CheckBoxFormTest1.razor
@@ -1,5 +1,4 @@
-﻿@using MudBlazor;
-@namespace MudBlazor.UnitTests
+﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudForm ValidationDelay="0">
     <MudCheckBox T="bool" Required="true" RequiredError="You must agree">

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/CheckBox/CheckBoxTest3.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/CheckBox/CheckBoxTest3.razor
@@ -1,5 +1,4 @@
-﻿@using MudBlazor;
-@namespace MudBlazor.UnitTests
+﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudCheckBox  @bind-Checked="is_checked">Synced</MudCheckBox>
 <MudCheckBox @bind-Checked="is_checked">Synced</MudCheckBox>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/CheckBox/CheckBoxesBindAgainstArrayTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/CheckBox/CheckBoxesBindAgainstArrayTest.razor
@@ -1,4 +1,6 @@
-﻿<MudGrid>
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudGrid>
     @for (int i = 0; i < amenities.Length; i++)
     {
         var local = i;

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/ChipSet/ChipSetDefaultChipsTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/ChipSet/ChipSetDefaultChipsTest.razor
@@ -1,4 +1,6 @@
-﻿<MudChipSet @bind-SelectedChips="selected" MultiSelection="@MultiSelection" Filter="filter">
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudChipSet @bind-SelectedChips="selected" MultiSelection="@MultiSelection" Filter="filter">
     <MudChip Text="Milk"></MudChip>
     <MudChip Text="Eggs" Default="true"></MudChip>
     <MudChip Text="Soap"></MudChip>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/ChipSet/ChipSetTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/ChipSet/ChipSetTest.razor
@@ -1,4 +1,6 @@
-﻿<MudChipSet @bind-SelectedChips="selected" Filter="filter">
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudChipSet @bind-SelectedChips="selected" Filter="filter">
     <MudChip Text="Milk"></MudChip>
     <MudChip Text="Eggs"></MudChip>
     <MudChip Text="Soap"></MudChip>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/PersianDatePickerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/PersianDatePickerTest.razor
@@ -1,5 +1,5 @@
 ﻿@using System.Globalization;
-@using System.Reflection
+@namespace MudBlazor.UnitTests.TestComponents
 
 <h3>Persian DatePicker</h3>
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogOkCancel.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogOkCancel.razor
@@ -1,4 +1,6 @@
-﻿<MudDialog>
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudDialog>
     <DialogContent>
         <MudText>Wabalabadubdub!</MudText>
     </DialogContent>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/InlineDialogIsVisibleStateTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/InlineDialogIsVisibleStateTest.razor
@@ -1,4 +1,6 @@
-﻿<div class="d-flex">
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<div class="d-flex">
     <MudButton OnClick="OpenDialog" Variant="Variant.Filled" Color="Color.Primary">
         Open dialog
     </MudButton>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/TestInlineDialog.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/TestInlineDialog.razor
@@ -1,4 +1,6 @@
-﻿<MudButton Variant="Variant.Filled" OnClick="()=>visible=true">Open</MudButton>
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudButton Variant="Variant.Filled" OnClick="()=>visible=true">Open</MudButton>
 
 <MudDialog @bind-IsVisible="visible">
     <DialogContent>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Drawer/DrawerResponsiveTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Drawer/DrawerResponsiveTest.razor
@@ -1,4 +1,6 @@
-﻿<MudLayout>
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudLayout>
     <MudAppBar Elevation="1">
         <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@ToggleDrawer" />
     </MudAppBar>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Drawer/DrawerTest1.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Drawer/DrawerTest1.razor
@@ -1,4 +1,6 @@
-﻿<MudDrawer @ref="@Drawer" @bind-Open="@isOpen" Variant="@Variant" DisableOverlay="@DisableOverlay" ClipMode="@ClipMode"></MudDrawer>
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudDrawer @ref="@Drawer" @bind-Open="@isOpen" Variant="@Variant" DisableOverlay="@DisableOverlay" ClipMode="@ClipMode"></MudDrawer>
 <button @onclick="@HandleButtonClick" />
 
 @code {

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/EditFormOnFieldChangedTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/EditFormOnFieldChangedTest.razor
@@ -1,4 +1,4 @@
-﻿@using System.ComponentModel.DataAnnotations
+﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <div style="max-width: 400px;">
     <EditForm EditContext="@editContext">

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormConversionErrorTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormConversionErrorTest.razor
@@ -1,4 +1,6 @@
-﻿<MudForm @bind-IsValid="@_isValid" ValidationDelay="0">
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudForm @bind-IsValid="@_isValid" ValidationDelay="0">
     <MudTextField T="int" Immediate="true" />
 </MudForm>
 <MudButton Disabled="@(!_isValid)" Variant="Variant.Filled" Color="Color.Primary">Submit</MudButton>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormIsValidTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormIsValidTest.razor
@@ -1,5 +1,4 @@
-﻿@using MudBlazor;
-@namespace MudBlazor.UnitTests
+﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudForm ValidationDelay="0">
     <MudTextField T="string" Required="true" RequiredError="Enter a rock star"></MudTextField>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormIsValidTest2.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormIsValidTest2.razor
@@ -1,5 +1,4 @@
-﻿@using MudBlazor;
-@namespace MudBlazor.UnitTests
+﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudForm ValidationDelay="0">
     <MudTextField T="string" Label="Don't care if you fill this field or not"></MudTextField>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormValidationTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormValidationTest.razor
@@ -1,5 +1,4 @@
-﻿@using MudBlazor;
-@namespace MudBlazor.UnitTests
+﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudForm ValidationDelay="0">
     <MudTextField T="string" Required="true" RequiredError="Enter a star" Validation="@validation"></MudTextField>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormValidationTest2.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormValidationTest2.razor
@@ -1,5 +1,4 @@
-﻿@using MudBlazor;
-@namespace MudBlazor.UnitTests
+﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudForm ValidationDelay="0">
     <MudTextField T="string" Required="true" RequiredError="Enter a star" Validation="@validation"></MudTextField>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormWithCheckboxTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormWithCheckboxTest.razor
@@ -1,4 +1,6 @@
-﻿<div style="max-width: 400px;">
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<div style="max-width: 400px;">
     <MudCard>
         <MudCardContent>
             <MudForm>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormWithDatePickerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormWithDatePickerTest.razor
@@ -1,5 +1,4 @@
-﻿@using MudBlazor;
-@namespace MudBlazor.UnitTests
+﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudForm ValidationDelay="0">
     <MudDatePicker Required="true" @bind-Date="Date">

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormWithRadioGroupTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormWithRadioGroupTest.razor
@@ -1,5 +1,4 @@
-﻿@using MudBlazor;
-@namespace MudBlazor.UnitTests
+﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudForm ValidationDelay="0">
     <MudRadioGroup T="string" Required="true" @bind-SelectedOption="Selected">

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormWithTimePickerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormWithTimePickerTest.razor
@@ -1,5 +1,4 @@
-﻿@using MudBlazor;
-@namespace MudBlazor.UnitTests
+﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudForm ValidationDelay="0">
     <MudTimePicker Required="true" @bind-Time="Time">

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/List/ListSelectionTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/List/ListSelectionTest.razor
@@ -1,4 +1,6 @@
-﻿<MudList Clickable="true" @bind-SelectedItem="selectedItem">
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudList Clickable="true" @bind-SelectedItem="selectedItem">
     <MudListSubheader>
         Your drink:
         <MudChip Color="Color.Secondary">

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Menu/MenuTest1.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Menu/MenuTest1.razor
@@ -1,5 +1,4 @@
-@using MudBlazor
-@namespace MudBlazor.UnitTests
+@namespace MudBlazor.UnitTests.TestComponents
 
 <MudMenu Label="Full Menu Width" Variant="Variant.Filled" Color="Color.Primary" FullWidth="true">
     <MudMenuItem>1</MudMenuItem>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/NavLink/NavLinkDisabledTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/NavLink/NavLinkDisabledTest.razor
@@ -1,5 +1,6 @@
 ﻿@using MudBlazor.Interfaces 
 @implements INavigationEventReceiver
+@namespace MudBlazor.UnitTests.TestComponents
 
 <CascadingValue Value="this" IsFixed="true">
     <MudNavLink Disabled="@Disabled" />

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/RadioGroup/RadioGroupTest1.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/RadioGroup/RadioGroupTest1.razor
@@ -1,5 +1,4 @@
-﻿@using MudBlazor;
-@namespace MudBlazor.UnitTests
+﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudRadioGroup T="string">
     <MudRadio Option="@("1")" />

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/RadioGroup/RadioGroupTest2.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/RadioGroup/RadioGroupTest2.razor
@@ -1,5 +1,4 @@
-﻿@using MudBlazor;
-@namespace MudBlazor.UnitTests
+﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudRadioGroup @bind-SelectedOption="@option">
     <MudRadio Option="@("1")" />

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/RadioGroup/RadioGroupTest3.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/RadioGroup/RadioGroupTest3.razor
@@ -1,5 +1,4 @@
-﻿@using MudBlazor;
-@namespace MudBlazor.UnitTests
+﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudRadioGroup @bind-SelectedOption="@option">
     <MudRadio Option="@("1")" />

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/RadioGroup/RadioGroupTest4.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/RadioGroup/RadioGroupTest4.razor
@@ -1,5 +1,4 @@
-﻿@using MudBlazor;
-@namespace MudBlazor.UnitTests
+﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudRadioGroup T="string" >
     <MudRadio Option="@("1")" />

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/RadioGroup/RadioGroupTest5.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/RadioGroup/RadioGroupTest5.razor
@@ -1,5 +1,4 @@
-﻿@using MudBlazor;
-@namespace MudBlazor.UnitTests
+﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudRadioGroup @bind-SelectedOption="@option">
     <MudRadio Option="@("1")" />

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/MultiSelectTest1.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/MultiSelectTest1.razor
@@ -1,5 +1,4 @@
-﻿@using MudBlazor;
-@namespace MudBlazor.UnitTests
+﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudSelect @bind-Value="value" MultiSelection="true">
     <MudSelectItem Value="@("1")">1</MudSelectItem>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectTest1.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectTest1.razor
@@ -1,5 +1,4 @@
-﻿@using MudBlazor;
-@namespace MudBlazor.UnitTests
+﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudSelect @bind-Value="value">
     <MudSelectItem Value="@("1")"/>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectUnrepresentableValueTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectUnrepresentableValueTest.razor
@@ -1,5 +1,4 @@
-﻿@using MudBlazor;
-@namespace MudBlazor.UnitTests
+﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudSelect @bind-Value="value">
     <MudSelectItem T="int" Value="1">One</MudSelectItem>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectUnrepresentableValueTest2.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectUnrepresentableValueTest2.razor
@@ -1,5 +1,4 @@
-﻿@using MudBlazor;
-@namespace MudBlazor.UnitTests
+﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudSelect @bind-Value="value" Strict="true">
     <MudSelectItem T="int" Value="1"/>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectWithEnumTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectWithEnumTest.razor
@@ -1,5 +1,4 @@
-﻿@using MudBlazor;
-@namespace MudBlazor.UnitTests
+﻿@namespace MudBlazor.UnitTests.TestComponents
 
 Value: @Selected
 <br />

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectWithoutItemPresentersTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectWithoutItemPresentersTest.razor
@@ -1,5 +1,4 @@
-﻿@using MudBlazor;
-@namespace MudBlazor.UnitTests
+﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudSelect @bind-Value="value">
     <MudSelectItem T="int" Value="1"/>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableFilterTest1.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableFilterTest1.razor
@@ -1,5 +1,4 @@
-@using MudBlazor;
-@namespace MudBlazor.UnitTests
+@namespace MudBlazor.UnitTests.TestComponents
 
 
 <MudTable @ref="filteredTable" Items="states" Filter="new Func<string, bool>(FilterFunc)">

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableInlineEditTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableInlineEditTest.razor
@@ -1,5 +1,4 @@
-﻿@using MudBlazor;
-@namespace MudBlazor.UnitTests
+﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudTable @ref="_table" T="string" Items="items" @bind-SelectedItem="selectedItem">
     <HeaderContent>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelectionTest1.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelectionTest1.razor
@@ -1,5 +1,4 @@
-﻿@using MudBlazor;
-@namespace MudBlazor.UnitTests
+﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudText>SelectedItems { @string.Join(", ", selectedItems) }</MudText>
 <MudTable Items="items" @bind-SelectedItems="selectedItems" MultiSelection="true">

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelectionTest2.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelectionTest2.razor
@@ -1,5 +1,4 @@
-﻿@using MudBlazor;
-@namespace MudBlazor.UnitTests
+﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudText>SelectedItems { @string.Join(", ", selectedItems) }</MudText>
 <MudTable Items="items" @bind-SelectedItems="selectedItems" MultiSelection="true">

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelectionTest3.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelectionTest3.razor
@@ -1,5 +1,4 @@
-﻿@using MudBlazor;
-@namespace MudBlazor.UnitTests
+﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudText>SelectedItems { @string.Join(", ", selectedItems) }</MudText>
 <MudTable Items="items" @bind-SelectedItems="selectedItems" MultiSelection="true">

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelectionTest4.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelectionTest4.razor
@@ -1,5 +1,4 @@
-﻿@using MudBlazor;
-@namespace MudBlazor.UnitTests
+﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudText>SelectedItems { @string.Join(", ", selectedItems) }</MudText>
 <MudTable Items="items" @bind-SelectedItems="selectedItems" MultiSelection="true">

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelectionTest5.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelectionTest5.razor
@@ -1,5 +1,4 @@
-﻿@using MudBlazor;
-@namespace MudBlazor.UnitTests
+﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudText>SelectedItems { @string.Join(", ", selectedItems) }</MudText>
 <MudTable Items="items" @bind-SelectedItems="selectedItems" MultiSelection="true" RowsPerPage="2">

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TablePaginationTest1.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TablePaginationTest1.razor
@@ -1,5 +1,7 @@
 ﻿@using System.ComponentModel
 @using System.Runtime.CompilerServices
+@namespace MudBlazor.UnitTests.TestComponents
+
 <MudPaper>
     <MudTable InlineEdit="false"
               Items="@viewModel.Items"

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TablePagingTest1.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TablePagingTest1.razor
@@ -1,5 +1,4 @@
-@using MudBlazor;
-@namespace MudBlazor.UnitTests
+@namespace MudBlazor.UnitTests.TestComponents
 
 
 <MudTable @ref="filteredTable" Items="states" Filter="new Func<string, bool>(FilterFunc)">

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TablePagingTest1Rtl.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TablePagingTest1Rtl.razor
@@ -1,5 +1,4 @@
-﻿@using MudBlazor;
-@namespace MudBlazor.UnitTests
+﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudLayout RightToLeft="true">
     <MudMainContent>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableRowClassStyleTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableRowClassStyleTest.razor
@@ -1,5 +1,4 @@
-﻿@using MudBlazor;
-@namespace MudBlazor.UnitTests
+﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudTable T="int" Items="items" RowStyleFunc="@((item, index) => item > 1 ? "color: blue" : "color: red")" RowClassFunc="@((item, index) => index % 2 == 0 ? "even" : "odd")">
     <HeaderContent>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableRowClickTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableRowClickTest.razor
@@ -1,5 +1,4 @@
-﻿@using MudBlazor;
-@namespace MudBlazor.UnitTests
+﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudTable T="int" Items="items" OnRowClick="@(args => OnRowClicked(args))">
     <HeaderContent>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableServerSideDataTest1.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableServerSideDataTest1.razor
@@ -1,4 +1,6 @@
-﻿<MudTable ServerData="@(new Func<TableState, Task<TableData<int>>>(ServerReload))">
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudTable ServerData="@(new Func<TableState, Task<TableData<int>>>(ServerReload))">
     <HeaderContent>
         <MudTh><MudTableSortLabel SortLabel="No." T="int">Nr</MudTableSortLabel></MudTh>
     </HeaderContent>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableServerSideDataTest2.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableServerSideDataTest2.razor
@@ -1,4 +1,6 @@
-﻿<MudTable ServerData="@(new Func<TableState, Task<TableData<int>>>(ServerReload))">
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudTable ServerData="@(new Func<TableState, Task<TableData<int>>>(ServerReload))">
     <HeaderContent>
         <MudTh><MudTableSortLabel SortLabel="No." T="int">Nr</MudTableSortLabel></MudTh>
     </HeaderContent>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableServerSideDataTest3.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableServerSideDataTest3.razor
@@ -1,4 +1,6 @@
-﻿<MudTable ServerData="@(new Func<TableState, Task<TableData<int>>>(ServerReload))">
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudTable ServerData="@(new Func<TableState, Task<TableData<int>>>(ServerReload))">
     <HeaderContent>
         <MudTh><MudTableSortLabel SortLabel="No." InitialDirection="SortDirection.Descending" T="int">Nr</MudTableSortLabel></MudTh>
     </HeaderContent>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableSingleSelectionTest1.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableSingleSelectionTest1.razor
@@ -1,5 +1,4 @@
-@using MudBlazor;
-@namespace MudBlazor.UnitTests
+@namespace MudBlazor.UnitTests.TestComponents
 
 <MudText>Seleted Item: @(selectedItem.ToString())</MudText>
 <MudTable Items="items"  @bind-SelectedItems="selectedItems" @bind-SelectedItem="selectedItem" Hover="true" MultiSelection="false">

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/KeepTabsAlive/TabsKeepAlivePanel.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/KeepTabsAlive/TabsKeepAlivePanel.razor
@@ -1,4 +1,4 @@
-﻿@namespace MudBlazor.UnitTests
+﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudButton OnClick="@(()=>Counter++)">@($"{ComponentName}={Counter}")</MudButton>
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/KeepTabsAlive/TabsKeepAliveTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/KeepTabsAlive/TabsKeepAliveTest.razor
@@ -1,5 +1,4 @@
-﻿@namespace MudBlazor.UnitTests
-@using MudBlazor.UnitTests
+﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudTabs KeepPanelsAlive="@KeepPanelsAlive">
     <MudTabPanel Text="Item One">

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/TabsAddingRemovingTabsTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/TabsAddingRemovingTabsTest.razor
@@ -1,4 +1,6 @@
-﻿<MudButton OnClick="AddTab">Add Tab</MudButton>
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudButton OnClick="AddTab">Add Tab</MudButton>
 <MudButton OnClick="RemoveLast">Remove Last</MudButton>
 
 <MudTabs Elevation="1">

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/DebouncedTextFieldTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/DebouncedTextFieldTest.razor
@@ -1,4 +1,6 @@
-﻿<MudText Typo="Typo.h6">Result: @searchString</MudText>
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudText Typo="Typo.h6">Result: @searchString</MudText>
 <MudTextField @bind-Value="searchString" T="string" DebounceInterval="500"></MudTextField>
 @code
 {

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/MultilineTextfieldBindingTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/MultilineTextfieldBindingTest.razor
@@ -1,4 +1,6 @@
-﻿@*based on a bugreport*@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+@*based on a bugreport*@
 <MudContainer MaxWidth="MaxWidth.ExtraLarge" Class="mt-16 mb-16">
 
     <MudTextField T="string" @bind-Value="text" Label="First edit here"

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/TextFieldRequiredTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/TextFieldRequiredTest.razor
@@ -1,4 +1,6 @@
-﻿<MudTextField
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudTextField
     @bind-Value="_value"
      Label="Input" 
      Variant="Variant.Filled"

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/ToggleIconButton/ToggleIconButtonTest1.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/ToggleIconButton/ToggleIconButtonTest1.razor
@@ -1,5 +1,4 @@
-﻿@using MudBlazor;
-@namespace MudBlazor.UnitTests
+﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudToggleIconButton @bind-Toggled="@AlarmOn"
                      Icon="@Icons.Material.Filled.AlarmOff" Color="@Color.Error"

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewTemplateTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewTemplateTest.razor
@@ -1,4 +1,6 @@
-﻿<MudTreeView CanActivate="true" CanSelect="true" Items="TreeItems" Style="width: 500px;">
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudTreeView CanActivate="true" CanSelect="true" Items="TreeItems" Style="width: 500px;">
     <ItemTemplate>
         <MudTreeViewItem @bind-Activated="@context.IsSelected" @bind-Expanded="@context.IsExpanded" Icon="@context.Icon"
                          Text="@context.Title" EndText="@context.Number?.ToString()" EndTextTypo="@Typo.caption" Items="@context.TreeItems" />

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewTest1.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewTest1.razor
@@ -1,4 +1,6 @@
-﻿<MudTreeView T="string" CanSelect="true" CanActivate="true">
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudTreeView T="string" CanSelect="true" CanActivate="true">
     <MudTreeViewItem Value='"content"' @bind-Activated="Item1Activated" @bind-Selected="ParentItemSelected">
         <MudTreeViewItem Value='"logo.png"' />
         <MudTreeViewItem Value='"MudBlazor.svg"' @bind-Selected="SubItemSelected" />

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewTest2.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewTest2.razor
@@ -1,4 +1,6 @@
-﻿<MudTreeView T="string" ExpandOnClick="true">
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudTreeView T="string" ExpandOnClick="true">
     <MudTreeViewItem Value='"content"'>
         <MudTreeViewItem Value='"logo.png"' />
         <MudTreeViewItem Value='"MudBlazor.svg"' />

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -8,9 +8,10 @@ using System.Linq;
 using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
+using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
 
-namespace MudBlazor.UnitTests
+namespace MudBlazor.UnitTests.Components
 {
 
     [TestFixture]

--- a/src/MudBlazor.UnitTests/Components/BreadcrumbTests.cs
+++ b/src/MudBlazor.UnitTests/Components/BreadcrumbTests.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using Bunit;
 using FluentAssertions;
+using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
 using static Bunit.ComponentParameterFactory;
 

--- a/src/MudBlazor.UnitTests/Components/ButtonsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ButtonsTests.cs
@@ -4,7 +4,8 @@
 using FluentAssertions;
 using NUnit.Framework;
 using static Bunit.ComponentParameterFactory;
-namespace MudBlazor.UnitTests
+
+namespace MudBlazor.UnitTests.Components
 {
     [TestFixture]
     public class ButtonsTests

--- a/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
@@ -2,20 +2,12 @@
 #pragma warning disable IDE1006 // leading underscore
 
 using System;
-using System.Linq;
-using System.Net.Http;
 using Bunit;
-using Bunit.Rendering;
 using FluentAssertions;
-using Microsoft.AspNetCore.Components;
-using Microsoft.Extensions.DependencyInjection;
-using MudBlazor.Services;
-using MudBlazor.UnitTests.Mocks;
-using MudBlazor.UnitTests.TestComponents.CheckBox;
+using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
 
-
-namespace MudBlazor.UnitTests
+namespace MudBlazor.UnitTests.Components
 {
 
     [TestFixture]

--- a/src/MudBlazor.UnitTests/Components/ChipSetTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ChipSetTests.cs
@@ -3,23 +3,14 @@
 #pragma warning disable BL0005 // Set parameter outside component
 
 using System;
-using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
-using System.Net.Http;
 using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
-using FluentValidation;
-using Microsoft.AspNetCore.Components;
-using MudBlazor.Services;
-using MudBlazor.UnitTests.Mocks;
-using MudBlazor.UnitTests.TestComponents.ChipSet;
-using MudBlazor.UnitTests.TestComponents.TextField;
+using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
-using static Bunit.ComponentParameterFactory;
 
-namespace MudBlazor.UnitTests
+namespace MudBlazor.UnitTests.Components
 {
 
     [TestFixture]

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -6,20 +6,15 @@ using System;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
-using System.Net.Http;
 using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
-using Microsoft.AspNetCore.Components;
-using Microsoft.Extensions.DependencyInjection;
-using MudBlazor.Services;
-using MudBlazor.UnitTests.Mocks;
-using MudBlazor.UnitTests.TestComponents.DatePicker;
+using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
 using static Bunit.ComponentParameterFactory;
 
-namespace MudBlazor.UnitTests
+namespace MudBlazor.UnitTests.Components
 {
     [TestFixture]
     public class DatePickerTests

--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
@@ -11,7 +11,7 @@ using NUnit.Framework;
 using NUnit.Framework.Internal;
 using static Bunit.ComponentParameterFactory;
 
-namespace MudBlazor.UnitTests
+namespace MudBlazor.UnitTests.Components
 {
     [TestFixture]
     public class DateRangePickerTests

--- a/src/MudBlazor.UnitTests/Components/DialogTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DialogTests.cs
@@ -2,22 +2,14 @@
 #pragma warning disable IDE1006 // leading underscore
 
 using System;
-using System.Diagnostics;
-using System.Linq;
-using System.Net.Http;
 using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
-using Microsoft.AspNetCore.Components;
-using Microsoft.Extensions.DependencyInjection;
-using MudBlazor.Services;
-using MudBlazor.UnitTests.Mocks;
-using MudBlazor.UnitTests.TestComponents.Dialog;
+using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
 
-
-namespace MudBlazor.UnitTests
+namespace MudBlazor.UnitTests.Components
 {
 
     [TestFixture]

--- a/src/MudBlazor.UnitTests/Components/DrawerTest.cs
+++ b/src/MudBlazor.UnitTests/Components/DrawerTest.cs
@@ -8,12 +8,12 @@ using Bunit;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using MudBlazor.Services;
+using MudBlazor.UnitTests.TestComponents;
 using MudBlazor.UnitTests.Mocks;
-using MudBlazor.UnitTests.TestComponents.Drawer;
 using NUnit.Framework;
 using static Bunit.ComponentParameterFactory;
 
-namespace MudBlazor.UnitTests.Components
+namespace MudBlazor.UnitTests.Components.Components
 {
     [TestFixture]
     public class DrawerTest

--- a/src/MudBlazor.UnitTests/Components/ElementTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ElementTests.cs
@@ -4,7 +4,7 @@
 using Bunit;
 using NUnit.Framework;
 using static Bunit.ComponentParameterFactory;
-namespace MudBlazor.UnitTests
+namespace MudBlazor.UnitTests.Components
 {
     [TestFixture]
     public class ElementTests

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -4,19 +4,13 @@
 using System;
 using System.Threading.Tasks;
 using Bunit;
-using Bunit.Rendering;
-using Bunit.TestDoubles;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Web;
-using Microsoft.Extensions.DependencyInjection;
 using MudBlazor.Docs.Examples;
-using MudBlazor.Services;
-using MudBlazor.UnitTests.Mocks;
-using MudBlazor.UnitTests.TestComponents.Form;
+using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
 
-namespace MudBlazor.UnitTests
+namespace MudBlazor.UnitTests.Components
 {
 
     [TestFixture]

--- a/src/MudBlazor.UnitTests/Components/HighlighterTests.cs
+++ b/src/MudBlazor.UnitTests/Components/HighlighterTests.cs
@@ -8,7 +8,7 @@ using NUnit.Framework;
 using static Bunit.ComponentParameterFactory;
 using static MudBlazor.Components.Highlighter.Splitter;
 
-namespace MudBlazor.UnitTests
+namespace MudBlazor.UnitTests.Components
 {
     [TestFixture]
     public class HighlighterSplitterTests

--- a/src/MudBlazor.UnitTests/Components/IconTests.cs
+++ b/src/MudBlazor.UnitTests/Components/IconTests.cs
@@ -5,7 +5,7 @@ using Bunit;
 using FluentAssertions;
 using NUnit.Framework;
 using static Bunit.ComponentParameterFactory;
-namespace MudBlazor.UnitTests
+namespace MudBlazor.UnitTests.Components
 {
     [TestFixture]
     public class IconTests

--- a/src/MudBlazor.UnitTests/Components/ListTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ListTests.cs
@@ -2,15 +2,13 @@
 #pragma warning disable IDE1006 // leading underscore
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
-using MudBlazor.UnitTests.TestComponents.List;
+using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
 
-namespace MudBlazor.UnitTests
+namespace MudBlazor.UnitTests.Components
 {
     [TestFixture]
     public class ListTests

--- a/src/MudBlazor.UnitTests/Components/MenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MenuTests.cs
@@ -1,22 +1,12 @@
 ﻿#pragma warning disable IDE1006 // leading underscore
 
-using System;
-using System.Diagnostics;
-using System.Linq;
-using System.Net.Http;
-using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
-using Microsoft.AspNetCore.Components;
-using Microsoft.Extensions.DependencyInjection;
-using MudBlazor.Services;
-using MudBlazor.UnitTests.Mocks;
 using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
-using static Bunit.ComponentParameterFactory;
 
-namespace MudBlazor.UnitTests
+namespace MudBlazor.UnitTests.Components
 {
     [TestFixture]
     public class MenuTests

--- a/src/MudBlazor.UnitTests/Components/MessageBoxTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MessageBoxTests.cs
@@ -2,22 +2,14 @@
 #pragma warning disable IDE1006 // leading underscore
 
 using System;
-using System.Diagnostics;
-using System.Linq;
-using System.Net.Http;
 using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
-using Microsoft.AspNetCore.Components;
-using Microsoft.Extensions.DependencyInjection;
-using MudBlazor.Services;
-using MudBlazor.UnitTests.Mocks;
-using MudBlazor.UnitTests.TestComponents.Dialog;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
 
 
-namespace MudBlazor.UnitTests
+namespace MudBlazor.UnitTests.Components
 {
 
     [TestFixture]

--- a/src/MudBlazor.UnitTests/Components/NavLinkTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NavLinkTests.cs
@@ -5,11 +5,11 @@ using System;
 using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
-using MudBlazor.UnitTests.TestComponents.NavLink;
+using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
 using static Bunit.ComponentParameterFactory;
 
-namespace MudBlazor.UnitTests
+namespace MudBlazor.UnitTests.Components
 {
     [TestFixture]
     public class NavLinkTests

--- a/src/MudBlazor.UnitTests/Components/ProgressTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ProgressTests.cs
@@ -5,8 +5,8 @@ using System;
 using Bunit;
 using FluentAssertions;
 using NUnit.Framework;
-using static Bunit.ComponentParameterFactory;
-namespace MudBlazor.UnitTests
+
+namespace MudBlazor.UnitTests.Components
 {
     [TestFixture]
     public class ProgressTests

--- a/src/MudBlazor.UnitTests/Components/RadioTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RadioTests.cs
@@ -5,10 +5,10 @@ using System;
 using System.Linq;
 using Bunit;
 using FluentAssertions;
+using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
 
-
-namespace MudBlazor.UnitTests
+namespace MudBlazor.UnitTests.Components
 {
 
     [TestFixture]

--- a/src/MudBlazor.UnitTests/Components/RatingTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RatingTests.cs
@@ -6,9 +6,8 @@ using System.Linq;
 using Bunit;
 using FluentAssertions;
 using NUnit.Framework;
-using static Bunit.ComponentParameterFactory;
 
-namespace MudBlazor.UnitTests
+namespace MudBlazor.UnitTests.Components
 {
 
     [TestFixture]

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -8,14 +8,11 @@ using System.Linq;
 using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
-using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Web;
-using Microsoft.Extensions.DependencyInjection;
-using MudBlazor.UnitTests.Mocks;
+using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
-using static MudBlazor.UnitTests.SelectWithEnumTest;
+using static MudBlazor.UnitTests.TestComponents.SelectWithEnumTest;
 
-namespace MudBlazor.UnitTests
+namespace MudBlazor.UnitTests.Components
 {
 
     [TestFixture]

--- a/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
@@ -2,22 +2,13 @@
 #pragma warning disable IDE1006 // leading underscore
 
 using System;
-using System.Diagnostics;
-using System.Linq;
-using System.Net.Http;
 using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
-using Microsoft.AspNetCore.Components;
-using Microsoft.Extensions.DependencyInjection;
-using MudBlazor.Services;
-using MudBlazor.UnitTests.Mocks;
-using MudBlazor.UnitTests.TestComponents.Dialog;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
 
-
-namespace MudBlazor.UnitTests
+namespace MudBlazor.UnitTests.Components
 {
 
     [TestFixture]

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -7,15 +7,10 @@ using System.Linq;
 using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
-using Microsoft.AspNetCore.Components;
-using Microsoft.Extensions.DependencyInjection;
-using MudBlazor.Services;
-using MudBlazor.UnitTests.Mocks;
-using MudBlazor.UnitTests.TestComponents.Table;
+using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
 
-
-namespace MudBlazor.UnitTests
+namespace MudBlazor.UnitTests.Components
 {
 
     [TestFixture]

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -2,22 +2,13 @@
 #pragma warning disable IDE1006 // leading underscore
 
 using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Net.Http;
 using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
-using FluentValidation;
-using Microsoft.AspNetCore.Components;
-using MudBlazor.Services;
-using MudBlazor.UnitTests.Mocks;
-using MudBlazor.UnitTests.TestComponents.Tabs;
+using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
-using static Bunit.ComponentParameterFactory;
 
-namespace MudBlazor.UnitTests
+namespace MudBlazor.UnitTests.Components
 {
 
     [TestFixture]

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -6,19 +6,16 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Net.Http;
 using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
 using FluentValidation;
 using Microsoft.AspNetCore.Components;
-using MudBlazor.Services;
-using MudBlazor.UnitTests.Mocks;
-using MudBlazor.UnitTests.TestComponents.TextField;
+using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
 using static Bunit.ComponentParameterFactory;
 
-namespace MudBlazor.UnitTests
+namespace MudBlazor.UnitTests.Components
 {
 
     [TestFixture]

--- a/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
@@ -2,21 +2,14 @@
 #pragma warning disable BL0005 // Set parameter outside component
 
 using System;
-using System.Diagnostics;
-using System.Linq;
-using System.Net.Http;
 using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
-using Microsoft.AspNetCore.Components;
-using Microsoft.Extensions.DependencyInjection;
-using MudBlazor.Services;
-using MudBlazor.UnitTests.Mocks;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
 using static Bunit.ComponentParameterFactory;
 
-namespace MudBlazor.UnitTests
+namespace MudBlazor.UnitTests.Components
 {
 
     [TestFixture]

--- a/src/MudBlazor.UnitTests/Components/ToggleIconButtonTest.cs
+++ b/src/MudBlazor.UnitTests/Components/ToggleIconButtonTest.cs
@@ -4,6 +4,7 @@
 using System;
 using Bunit;
 using FluentAssertions;
+using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
 
 namespace MudBlazor.UnitTests.Components

--- a/src/MudBlazor.UnitTests/Components/TreeViewTest.cs
+++ b/src/MudBlazor.UnitTests/Components/TreeViewTest.cs
@@ -3,7 +3,7 @@
 using System;
 using Bunit;
 using FluentAssertions;
-using MudBlazor.UnitTests.TestComponents.TreeView;
+using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
 

--- a/src/MudBlazor.UnitTests/Utilities/BindingConverterTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/BindingConverterTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Globalization;
 using FluentAssertions;
-using MudBlazor.Docs.Examples;
 using NUnit.Framework;
 
 namespace MudBlazor.UnitTests.Utilities

--- a/src/MudBlazor.UnitTests/Utilities/CodeSnippetUrlTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/CodeSnippetUrlTests.cs
@@ -1,11 +1,8 @@
 ﻿using System;
-using System.Globalization;
 using System.IO;
 using System.IO.Compression;
 using System.Text;
 using FluentAssertions;
-using MudBlazor.Docs.Compiler;
-using MudBlazor.Docs.Examples;
 using MudBlazor.Docs.Models;
 using NUnit.Framework;
 


### PR DESCRIPTION
- A fairly bland PR but good to do.  A lot of the Razor namespaces were incorrect.  It seems the compilation process is very tolerant of this but its good to have all the dependencies clear.
- I have `MudBlazor.UnitTests.Components` for the tests and `MudBlazor.UnitTests.TestComponents` for Components on test