### PR TITLE
Fix/autocomplete friendliness

### DIFF
--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -144,6 +144,7 @@ namespace MudBlazor
             IsOpen = !IsOpen;
             if (IsOpen)
             {
+                await _elementReference.SelectAsync();
                 OnSearch();
             }
             else

--- a/src/MudBlazor/Styles/components/_select.scss
+++ b/src/MudBlazor/Styles/components/_select.scss
@@ -5,6 +5,14 @@
 
     &.mud-autocomplete {
         display: block;
+
+        & .mud-select-input {
+            cursor: text;
+        }
+
+        & .mud-input-adornment {
+            cursor: pointer;
+        }
     }
 }
 


### PR DESCRIPTION
Changes:

- cursor on autocomplete input is now `text` and not `pointer` as before. However, cursor in adornment is still `pointer`, because is a button;
- when clicking in autocomplete input, the previous selected item gets its text selected (as when you make a double click in a text), so you don't have to clear the previous search if you want to perform a new one=> Alaska text on input gets selected when opening the menu

See image below
![image](https://user-images.githubusercontent.com/13745954/109423990-af3ff300-79d9-11eb-8495-7ffc53aaa5b0.png)


This improves friendliness