### PR TITLE
Stop exceptions on page leave for tabs

### DIFF
--- a/src/MudBlazor.Docs.Client/wwwroot/index.html
+++ b/src/MudBlazor.Docs.Client/wwwroot/index.html
@@ -25,8 +25,8 @@
     <base href="/wasm/" />
     <link rel="icon" type="image/png" sizes="32x32" href="_content/MudBlazor.Docs/favicon-32x32.png">
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet" />
-    <link href="_content/MudBlazor/MudBlazor.min.css?v=5.0.3" rel="stylesheet" />
-    <link href="_content/MudBlazor.Docs/MudBlazorDocs.min.css?v=5.0.3" rel="stylesheet" />
+    <link href="_content/MudBlazor/MudBlazor.min.css?v=5.0.3.1" rel="stylesheet" />
+    <link href="_content/MudBlazor.Docs/MudBlazorDocs.min.css?v=5.0.3.1" rel="stylesheet" />
 </head>
 
 <body>
@@ -51,8 +51,8 @@
         <a class="dismiss">🗙</a>
     </div>
     <script src="_framework/blazor.webassembly.js"></script>
-    <script src="_content/MudBlazor/MudBlazor.min.js?v=5.0.3"></script>
-    <script src="_content/MudBlazor.Docs/JS/docs.js?v=5.0.3"></script>
+    <script src="_content/MudBlazor/MudBlazor.min.js?v=5.0.3.1"></script>
+    <script src="_content/MudBlazor.Docs/JS/docs.js?v=5.0.3.1"></script>
 </body>
 
 </html>

--- a/src/MudBlazor.Docs.Server/Pages/_Host.cshtml
+++ b/src/MudBlazor.Docs.Server/Pages/_Host.cshtml
@@ -31,8 +31,8 @@
     <base href="~/" />
     <link rel="icon" type="image/png" sizes="32x32" href="_content/MudBlazor.Docs/favicon-32x32.png">
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet" />
-    <link href="_content/MudBlazor/MudBlazor.min.css?v=5.0.3" rel="stylesheet" />
-    <link href="_content/MudBlazor.Docs/MudBlazorDocs.min.css?v=5.0.3" rel="stylesheet" />
+    <link href="_content/MudBlazor/MudBlazor.min.css?v=5.0.3.1" rel="stylesheet" />
+    <link href="_content/MudBlazor.Docs/MudBlazorDocs.min.css?v=5.0.3.1" rel="stylesheet" />
 </head>
 <body>
     <app>
@@ -51,7 +51,7 @@
     </div>
 
     <script src="_framework/blazor.server.js"></script>
-    <script src="_content/MudBlazor/MudBlazor.min.js?v=5.0.3"></script>
-    <script src="_content/MudBlazor.Docs/JS/docs.js?v=5.0.3"></script>
+    <script src="_content/MudBlazor/MudBlazor.min.js?v=5.0.3.1"></script>
+    <script src="_content/MudBlazor.Docs/JS/docs.js?v=5.0.3.1"></script>
 </body>
 </html>

--- a/src/MudBlazor/TScripts/mudElementReference.js
+++ b/src/MudBlazor/TScripts/mudElementReference.js
@@ -56,7 +56,7 @@
     }
 
     getBoundingClientRect (element) {
-        return element.getBoundingClientRect();
+        return element?.getBoundingClientRect();
     }
 
     changeCss (element, css) {


### PR DESCRIPTION
- Because Dispose completes before OnAfterRenderAsync is complete elementRef can be null.
- We need to check for null at the JS level as ElementRef is a struct in c# and cannot be null.
- I am pushing this fix through as at the moment there are a lots of navigation errors in the server logs which is not good UX
- We need to discuss this further
- There are still some other exceptions to discuss This fix will at least reduce the logs dramatically so we can see the others

Good reference found by @tungi52 

https://www.thinktecture.com/en/blazor/blazor-components-lifecycle-is-not-always-straightforward/