### PR TITLE
Fix ObjectDisposedException race condition in Snackbar

### DIFF
--- a/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
@@ -57,5 +57,28 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("#mud-snackbar-container").InnerHtml.Trim().Should().NotBeEmpty();
             comp.Find("div.mud-snackbar-content-message>span").Should().NotBeNull();
         }
+
+        [Test]
+        public async Task DisposeTest()
+        {
+            var comp = ctx.RenderComponent<MudSnackbarProvider>();
+            Console.WriteLine(comp.Markup);
+            comp.Find("#mud-snackbar-container").InnerHtml.Trim().Should().BeEmpty();
+            var service = ctx.Services.GetService<ISnackbar>() as SnackbarService;
+            service.Should().NotBe(null);
+
+            // shoot out a snackbar
+            Snackbar snackbar = null;
+            await comp.InvokeAsync(() => snackbar = service?.Add("Boom, big reveal. Im a pickle!"));
+            Console.WriteLine(comp.Markup);
+
+            snackbar?.Dispose();
+
+            comp.Find("#mud-snackbar-container").InnerHtml.Trim().Should().NotBeEmpty();
+            comp.Find("div.mud-snackbar-content-message").TrimmedText().Should().Be("Boom, big reveal. Im a pickle!");
+            // close by click on the snackbar
+            comp.Find("button").Click();
+            comp.WaitForAssertion(() => comp.Find("#mud-snackbar-container").InnerHtml.Trim().Should().BeEmpty(), TimeSpan.FromMilliseconds(100));
+        }
     }
 }

--- a/src/MudBlazor/Components/Snackbar/Snackbar.cs
+++ b/src/MudBlazor/Components/Snackbar/Snackbar.cs
@@ -8,7 +8,7 @@ namespace MudBlazor
 {
     public class Snackbar : IDisposable
     {
-        private Timer Timer { get; }
+        private Timer Timer { get; set; }
         internal SnackBarMessageState State { get; }
         public string Message { get; }
         public event Action<Snackbar> OnClose;
@@ -102,7 +102,11 @@ namespace MudBlazor
         {
             if (!disposing) return;
             StopTimer();
-            Timer?.Dispose();
+
+            var timer = Timer;
+            Timer = null;
+
+            timer?.Dispose();
         }
     }
 }


### PR DESCRIPTION
It's possible for the Timer to get disposed, then the StopTimer function to be called. This causes the exception.  The safe way to do this to null out the Timer to ensure StopTimer does nothing in this case.

This fixes issue #1059 