### PR TITLE
Fix the issue with server side paging after changing page size

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -200,6 +200,36 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// page size select after paging tests
+        /// </summary>
+        [Test]
+        public async Task TablePagingChangePageSizeAfterPaging()
+        {
+            var comp = ctx.RenderComponent<TableServerSideDataTest2>();
+            // print the generated html
+            Console.WriteLine(comp.Markup);
+            // select elements needed for the test
+            var table = comp.FindComponent<MudTable<int>>();
+            var pager = comp.FindComponent<MudSelect<string>>().Instance;
+            // after initial load
+            comp.FindAll("tr").Count.Should().Be(4); // three rows + header row
+            comp.FindAll("td")[0].TextContent.Trim().Should().Be("1");
+            comp.FindAll("td")[1].TextContent.Trim().Should().Be("2");
+            comp.FindAll("td")[2].TextContent.Trim().Should().Be("3");
+            comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 99");
+            // last page
+            comp.FindAll("div.mud-table-pagination-actions button")[3].Click(); // last >
+            comp.FindAll("td")[0].TextContent.Trim().Should().Be("28");
+            comp.FindAll("td")[1].TextContent.Trim().Should().Be("29");
+            comp.FindAll("td")[2].TextContent.Trim().Should().Be("30");
+            comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("91-99 of 99");
+            // change page size
+            table.SetParametersAndRender(ComponentParameter.CreateParameter("RowsPerPage", 100));
+            pager.Value.Should().Be("100");
+            comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-99 of 99");
+        }
+
+        /// <summary>
         /// simple filter with pager
         /// </summary>
         [Test]

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -16,6 +16,7 @@ namespace MudBlazor
         internal object _editingItem = null;
 
         private int _currentPage = 0;
+        private int _rowsPerPage = 10;
 
         protected string Classname =>
         new CssBuilder("mud-table")
@@ -81,7 +82,15 @@ namespace MudBlazor
         /// If the table has more items than this number, it will break the rows into pages of said size.
         /// Note: requires a MudTablePager in PagerContent.
         /// </summary>
-        [Parameter] public int RowsPerPage { get; set; } = 10;
+        [Parameter]
+        public int RowsPerPage
+        {
+            get => _rowsPerPage;
+            set
+            {
+                SetRowsPerPage(value);
+            }
+        }
 
         /// <summary>
         /// The page index of the currently displayed page (Zero based). Usually called by MudTablePager.
@@ -206,7 +215,10 @@ namespace MudBlazor
 
         public void SetRowsPerPage(int size)
         {
-            RowsPerPage = size;
+            if (_rowsPerPage == size)
+                return;
+            _rowsPerPage = size;
+            CurrentPage = 0;
             StateHasChanged();
             InvokeServerLoadFunc();
         }


### PR DESCRIPTION
This is a fix for Issue #1034.  I thought about it and the safest thing to do is to return to the first page after changing the page size. Any other option could lead you to jump to random locations.  For example, if you were on page 2 with a size of 10 (11-20).  Then changed to 5, you would just jump to "6-10", which is just strange.  Instead, it seems best to just go to the first page again.