### PR TITLE
Fix mudcollapse default open state

### DIFF
--- a/src/MudBlazor.Docs/Shared/NavMenu.razor.cs
+++ b/src/MudBlazor.Docs/Shared/NavMenu.razor.cs
@@ -21,7 +21,11 @@ namespace MudBlazor.Docs.Shared
         //component links are the part of the url that tells us what component is featured
         string _componentLink;
 
-
+        protected override void OnInitialized()
+        {
+            Refresh();
+            base.OnInitialized();
+        }
 
         public void Refresh()
         {

--- a/src/MudBlazor/Components/Collapse/MudCollapse.razor.cs
+++ b/src/MudBlazor/Components/Collapse/MudCollapse.razor.cs
@@ -50,10 +50,14 @@ namespace MudBlazor
                     return;
 
                 _expanded = value;
-                _state = _expanded ? CollapseState.Entering : CollapseState.Exiting;
                 if (_isRendered)
                 {
+                    _state = _expanded ? CollapseState.Entering : CollapseState.Exiting;
                     _ = UpdateHeight();
+                }
+                else if (_expanded)
+                {
+                    _state = CollapseState.Entered;
                 }
                 _ = ExpandedChanged.InvokeAsync(_expanded);
             }
@@ -106,11 +110,6 @@ namespace MudBlazor
         {
             if (firstRender)
             {
-                if (_expanded)
-                {
-                    _state = CollapseState.Entered;
-                    StateHasChanged();
-                }
                 _isRendered = true;
                 await UpdateHeight();
                 _listenerId = await _container.MudAddEventListenerAsync(DotNetObjectReference.Create(this), "animationend", nameof(AnimationEnd));


### PR DESCRIPTION
For #1078 
@mikes-gh I'm pretty sure this is just a part of the problem. With this the navgroup in drawer won't collapse after refresh. 