### PR TITLE
Fix mediatype for DialogExample

### DIFF
--- a/src/MudBlazor.UnitTests/Mocks/MockDocsMessageHandler.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockDocsMessageHandler.cs
@@ -13,7 +13,7 @@ namespace MudBlazor.UnitTests.Mocks
                 Encoding.UTF8.GetString(Encoding.Default.GetBytes(SampleElementsJson)));
             // DialogScrollableExample
             this.When("https://raw.githubusercontent.com/Garderoben/MudBlazor/master/LICENSE")
-                .Respond("text/plain; charset=utf-8", "Dummy License");
+                .Respond("text/plain", "Dummy License");
         }
 
         private const string SampleElementsJson = @"


### PR DESCRIPTION
- At first I couldn't work out what was happening here.
- It turn out the response from the MockHttpHandler was incorrect.  I did a direct test and got failure 100%
- This error only leaked into the tests very occasionally because the call is actually async within the test so not in the test thread context.
- This fixes the HttpReponse so there in no longer an error in the async call and no possibility of exceptions from this other thread context leaking into the test thread