### PR TITLE
Add date format changed hook for descendants

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -96,6 +96,21 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task DatePicker_Should_ApplyDateFormatAfterDate()
+        {
+            var comp = ctx.RenderComponent<MudDatePicker>();
+            // select elements needed for the test
+            var picker = comp.Instance;
+            picker.Text.Should().Be(null);
+            picker.Date.Should().Be(null);
+            comp.SetParam(p => p.Date, new DateTime(2020, 10, 26));
+            comp.SetParam(p => p.DateFormat, "dd/MM/yyyy");
+            comp.SetParam(p => p.Culture, CultureInfo.InvariantCulture); // <-- this makes a huge difference!
+            picker.Date.Should().Be(new DateTime(2020, 10, 26));
+            picker.Text.Should().Be("26/10/2020");
+        }
+
+        [Test]
         public void Check_Intial_Date_Format()
         {
             DateTime? date = new DateTime(2021, 1, 13);

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor
@@ -50,7 +50,7 @@
                             @foreach (var month in GetAllMonths())
                             {
                                 <div class="mud-picker-month" @onclick="(() => OnMonthSelected(month))" @onclick:stopPropagation="true">
-                                    <MudText Typo="@GetMonthTypo(month)" Class="@GetMonthClasses(month)">@GetAbbreviatedMontName(month)</MudText>
+                                    <MudText Typo="@GetMonthTypo(month)" Class="@GetMonthClasses(month)">@GetAbbreviatedMonthName(month)</MudText>
                                 </div>
                             }
                         </div>

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -47,8 +47,19 @@ namespace MudBlazor
             set
             {
                 if (Converter is DefaultConverter<DateTime?> defaultConverter)
+                {
                     defaultConverter.Format = value;
+                    DateFormatChanged(defaultConverter.Format);
+                }
             }
+        }
+
+        /// <summary>
+        /// Date format value change hook for descendants.
+        /// </summary>
+        protected virtual Task DateFormatChanged(string newFormat)
+        {
+            return Task.CompletedTask;
         }
 
         /// <summary>
@@ -329,7 +340,7 @@ namespace MudBlazor
                 yield return Culture.Calendar.AddMonths(firstOfCalendarYear, i);
         }
 
-        private string GetAbbreviatedMontName(in DateTime month)
+        private string GetAbbreviatedMonthName(in DateTime month)
         {
             return Culture.DateTimeFormat.AbbreviatedMonthNames[month.Month - 1];
         }

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -47,10 +47,8 @@ namespace MudBlazor
             set
             {
                 if (Converter is DefaultConverter<DateTime?> defaultConverter)
-                {
                     defaultConverter.Format = value;
-                    DateFormatChanged(defaultConverter.Format);
-                }
+                DateFormatChanged(value);
             }
         }
 

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -39,6 +39,12 @@ namespace MudBlazor
             }
         }
 
+        protected override Task DateFormatChanged(string newFormat)
+        {
+            Touched = true;
+            return SetTextAsync(Converter.Set(_value), false);
+        }
+
         protected override Task StringValueChanged(string value)
         {
             Touched = true;


### PR DESCRIPTION
We noticed an issue where the order you declare your attributes affected the rendering:
Example: https://try.mudblazor.com/snippet/GkmvaHuTsbmTXvaZ

Notice the second set of pickers, the last one does not update when the format is changed.

This PR is to update that to allow a hook for descendants to allow them to adjust their text as needed. 

I also fixed a typo.