### PR TITLE
Add action buttons to pickers

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerBasicUsageExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerBasicUsageExample.razor
@@ -21,7 +21,18 @@
         <MudDatePicker Label="Display two months" DisplayMonths="2" TitleDateFormat="dddd, dd MMMM" @bind-Date="date" />
     </MudItem>
 </MudGrid>
+<MudGrid>
+    <MudItem xs="12" sm="6" md="4">
+        <MudDatePicker @ref="_picker" Label="With action buttons" @bind-Date="date">
+            <PickerActions>
+                <MudButton OnClick="@(() => _picker.Close(false))">Cancel</MudButton>
+                <MudButton Color="Color.Primary" OnClick="@(() => _picker.Close())">Ok</MudButton>
+            </PickerActions>
+        </MudDatePicker>
+    </MudItem>
+</MudGrid>
 
 @code {
+    MudDatePicker _picker;
     DateTime? date = DateTime.Today;
 }

--- a/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerBasicUsageExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerBasicUsageExample.razor
@@ -25,6 +25,7 @@
     <MudItem xs="12" sm="6" md="4">
         <MudDatePicker @ref="_picker" Label="With action buttons" @bind-Date="date">
             <PickerActions>
+                <MudButton Class="mr-auto align-self-start" OnClick="@(() => _picker.Clear())">Clear</MudButton>
                 <MudButton OnClick="@(() => _picker.Close(false))">Cancel</MudButton>
                 <MudButton Color="Color.Primary" OnClick="@(() => _picker.Close())">Ok</MudButton>
             </PickerActions>

--- a/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DateRangePickerUsageExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DateRangePickerUsageExample.razor
@@ -15,6 +15,7 @@
     <MudItem xs="12" sm="6">
         <MudDateRangePicker @ref="_picker" Label="With action buttons" @bind-DateRange="_dateRange">
             <PickerActions>
+                <MudButton Class="mr-auto align-self-start" OnClick="@(() => _picker.Clear())">Clear</MudButton>
                 <MudButton OnClick="@(() => _picker.Close(false))">Cancel</MudButton>
                 <MudButton Color="Color.Primary" OnClick="@(() => _picker.Close())">Ok</MudButton>
             </PickerActions>

--- a/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DateRangePickerUsageExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DateRangePickerUsageExample.razor
@@ -1,15 +1,28 @@
 ﻿@namespace MudBlazor.Docs.Examples
 <MudGrid>
     <MudItem xs="12" sm="6">
-        <MudDateRangePicker Label="Basic range picker" DateRange="@(new DateRange(DateTime.Now.Date, DateTime.Now.AddDays(5).Date))" />
+        <MudDateRangePicker Label="Basic range picker" @bind-DateRange="_dateRange" />
     </MudItem>
     <MudItem xs="12" sm="6">
-        <MudDateRangePicker Label="Basic range picker (editable)" Editable="true" DateRange="@(new DateRange(DateTime.Now.Date, DateTime.Now.AddDays(5).Date))" />
+        <MudDateRangePicker Label="Basic range picker (editable)" Editable="true" @bind-DateRange="_dateRange" />
     </MudItem>
     <MudItem xs="12" sm="6">
-        <MudDateRangePicker Label="Range picker format" HelperText="For custom cultures" DateFormat="dd/MM/yyyy" DateRange="@(new DateRange(DateTime.Now.Date, DateTime.Now.AddDays(5).Date))" />
+        <MudDateRangePicker Label="Range picker format" HelperText="For custom cultures" DateFormat="dd/MM/yyyy" @bind-DateRange="_dateRange" />
     </MudItem>
     <MudItem xs="12" sm="6">
-        <MudDateRangePicker Label="Custom start month" StartMonth="@DateTime.Now.AddMonths(-1)" DateRange="@(new DateRange(DateTime.Now.Date, DateTime.Now.AddDays(5).Date))" />
+        <MudDateRangePicker Label="Custom start month" StartMonth="@DateTime.Now.AddMonths(-1)" @bind-DateRange="_dateRange" />
+    </MudItem>
+    <MudItem xs="12" sm="6">
+        <MudDateRangePicker @ref="_picker" Label="With action buttons" @bind-DateRange="_dateRange">
+            <PickerActions>
+                <MudButton OnClick="@(() => _picker.Close(false))">Cancel</MudButton>
+                <MudButton Color="Color.Primary" OnClick="@(() => _picker.Close())">Ok</MudButton>
+            </PickerActions>
+        </MudDateRangePicker>
     </MudItem>
 </MudGrid>
+
+@code { 
+    MudDateRangePicker _picker;
+    DateRange _dateRange = new DateRange(DateTime.Now.Date, DateTime.Now.AddDays(5).Date);
+}

--- a/src/MudBlazor.Docs/Pages/Components/TimePicker/Examples/TimePickerBasicUsageExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TimePicker/Examples/TimePickerBasicUsageExample.razor
@@ -9,7 +9,17 @@
     <MudItem xs="12" sm="6" md="4">
         <MudTimePicker Label="24 hours (editable)" Editable="true" />
     </MudItem>
+    <MudItem xs="12" sm="6" md="4">
+        <MudTimePicker @ref="_picker" Label="With action buttons">
+            <PickerActions>
+                <MudButton OnClick="@(() => _picker.Close(false))">Cancel</MudButton>
+                <MudButton Color="Color.Primary" OnClick="@(() => _picker.Close())">Ok</MudButton>
+            </PickerActions>
+        </MudTimePicker>
+    </MudItem>
 </MudGrid>
 
 @code{
-    TimeSpan? time = new TimeSpan(00, 45, 00); }
+    MudTimePicker _picker;
+    TimeSpan? time = new TimeSpan(00, 45, 00);
+}

--- a/src/MudBlazor.Docs/Pages/Components/TimePicker/Examples/TimePickerBasicUsageExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TimePicker/Examples/TimePickerBasicUsageExample.razor
@@ -12,6 +12,7 @@
     <MudItem xs="12" sm="6" md="4">
         <MudTimePicker @ref="_picker" Label="With action buttons">
             <PickerActions>
+                <MudButton Class="mr-auto align-self-start" OnClick="@(() => _picker.Clear())">Clear</MudButton>
                 <MudButton OnClick="@(() => _picker.Close(false))">Cancel</MudButton>
                 <MudButton Color="Color.Primary" OnClick="@(() => _picker.Close())">Ok</MudButton>
             </PickerActions>

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -105,9 +105,9 @@ namespace MudBlazor.UnitTests.Components
             var picker = comp.Instance;
             picker.Text.Should().Be(null);
             picker.Date.Should().Be(null);
-            comp.SetParam(p => p.Date, new DateTime(2020, 10, 26));
             comp.SetParam(p => p.DateFormat, "dd/MM/yyyy");
             comp.SetParam(p => p.Culture, CultureInfo.InvariantCulture); // <-- this makes a huge difference!
+            comp.SetParam(p => p.Date, new DateTime(2020, 10, 26));
             picker.Date.Should().Be(new DateTime(2020, 10, 26));
             picker.Text.Should().Be("26/10/2020");
         }

--- a/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
@@ -88,25 +88,25 @@ namespace MudBlazor.UnitTests.Components
             var picker = comp.Instance;
             // select 16 hours on outer dial and 30 mins
             comp.FindAll("div.mud-picker-stick-outer.mud-hour")[3].Click();
-            picker.Time.Value.Hours.Should().Be(16);
-            picker.Time.Value.Minutes.Should().Be(0);
+            picker.TimeIntermediate.Value.Hours.Should().Be(16);
+            picker.TimeIntermediate.Value.Minutes.Should().Be(0);
             // select 30 minutes
             comp.FindAll("div.mud-minute")[30].Click();
-            picker.Time.Value.Hours.Should().Be(16);
-            picker.Time.Value.Minutes.Should().Be(30);
+            picker.TimeIntermediate.Value.Hours.Should().Be(16);
+            picker.TimeIntermediate.Value.Minutes.Should().Be(30);
             Console.Write(comp.Markup);
             // click 04 hours on the inner dial and 21 mins
             comp.FindAll("button.mud-timepicker-button")[0].Click();
             comp.FindAll("div.mud-picker-stick-inner.mud-hour")[3].Click();
             comp.FindAll("div.mud-minute")[21].Click();
-            picker.Time.Value.Hours.Should().Be(4);
-            picker.Time.Value.Minutes.Should().Be(21);
+            picker.TimeIntermediate.Value.Hours.Should().Be(4);
+            picker.TimeIntermediate.Value.Minutes.Should().Be(21);
             // click 10 hours on the inner dial and 56 mins
             comp.FindAll("button.mud-timepicker-button")[0].Click();
             comp.FindAll("div.mud-picker-stick-inner.mud-hour")[9].Click();
             comp.FindAll("div.mud-minute")[56].Click();
-            picker.Time.Value.Hours.Should().Be(10);
-            picker.Time.Value.Minutes.Should().Be(56);
+            picker.TimeIntermediate.Value.Hours.Should().Be(10);
+            picker.TimeIntermediate.Value.Minutes.Should().Be(56);
         }
 
         [Test]
@@ -117,25 +117,25 @@ namespace MudBlazor.UnitTests.Components
             // select 11 hours on outer dial and 30 mins
             comp.FindAll("div.mud-hour")[10].Click();
             comp.FindAll("div.mud-minute")[30].Click();
-            picker.Time.Value.Hours.Should().Be(11);
-            picker.Time.Value.Minutes.Should().Be(30);
+            picker.TimeIntermediate.Value.Hours.Should().Be(11);
+            picker.TimeIntermediate.Value.Minutes.Should().Be(30);
             Console.Write(comp.Markup);
             // click 04 hours on the inner dial and 21 mins
             comp.FindAll("button.mud-timepicker-button")[0].Click();
             comp.FindAll("div.mud-hour")[11].Click();
             comp.FindAll("div.mud-minute")[21].Click();
-            picker.Time.Value.Hours.Should().Be(0);
-            picker.Time.Value.Minutes.Should().Be(21);
+            picker.TimeIntermediate.Value.Hours.Should().Be(0);
+            picker.TimeIntermediate.Value.Minutes.Should().Be(21);
             // click 10 hours on the inner dial and 56 mins
             comp.FindAll("button.mud-timepicker-button")[0].Click();
             comp.FindAll("div.mud-hour")[9].Click();
             comp.FindAll("div.mud-minute")[56].Click();
-            picker.Time.Value.Hours.Should().Be(10);
-            picker.Time.Value.Minutes.Should().Be(56);
+            picker.TimeIntermediate.Value.Hours.Should().Be(10);
+            picker.TimeIntermediate.Value.Minutes.Should().Be(56);
             // click pm button
             comp.FindAll("button.mud-timepicker-button")[3].Click();
-            picker.Time.Value.Hours.Should().Be(22);
-            picker.Time.Value.Minutes.Should().Be(56);
+            picker.TimeIntermediate.Value.Hours.Should().Be(22);
+            picker.TimeIntermediate.Value.Minutes.Should().Be(56);
         }
 
         [Test]
@@ -146,19 +146,19 @@ namespace MudBlazor.UnitTests.Components
             // select 11 hours on outer dial and 30 mins
             comp.FindAll("div.mud-hour")[10].Click();
             comp.FindAll("div.mud-minute")[30].Click();
-            picker.Time.Value.Hours.Should().Be(11);
-            picker.Time.Value.Minutes.Should().Be(30);
+            picker.TimeIntermediate.Value.Hours.Should().Be(11);
+            picker.TimeIntermediate.Value.Minutes.Should().Be(30);
             // click pm button
             comp.FindAll("button.mud-timepicker-button")[3].Click();
-            picker.Time.Value.Hours.Should().Be(23);
-            picker.Time.Value.Minutes.Should().Be(30);
+            picker.TimeIntermediate.Value.Hours.Should().Be(23);
+            picker.TimeIntermediate.Value.Minutes.Should().Be(30);
             // add 12 hours in pm mode
             comp.FindAll("div.mud-hour")[10].Click();
-            picker.Time.Value.Hours.Should().Be(23);
+            picker.TimeIntermediate.Value.Hours.Should().Be(23);
             // click am button shoulkd subtract 12 hours
             comp.FindAll("button.mud-timepicker-button")[2].Click();
-            picker.Time.Value.Hours.Should().Be(11);
-            picker.Time.Value.Minutes.Should().Be(30);
+            picker.TimeIntermediate.Value.Hours.Should().Be(11);
+            picker.TimeIntermediate.Value.Minutes.Should().Be(30);
         }
 
         [Test]
@@ -238,12 +238,12 @@ namespace MudBlazor.UnitTests.Components
             // click on the minutes input
             comp.Find("div.mud-time-picker-hour").MouseDown();
             comp.FindAll("div.mud-picker-stick-outer.mud-hour")[3].MouseOver();
-            picker.Time.Value.Hours.Should().Be(16);
-            picker.Time.Value.Minutes.Should().Be(0);
+            picker.TimeIntermediate.Value.Hours.Should().Be(16);
+            picker.TimeIntermediate.Value.Minutes.Should().Be(0);
             comp.FindAll("div.mud-picker-stick-outer.mud-hour")[5].MouseOver();
             comp.FindAll("div.mud-picker-stick-outer.mud-hour")[5].MouseUp();
-            picker.Time.Value.Hours.Should().Be(18);
-            picker.Time.Value.Minutes.Should().Be(0);
+            picker.TimeIntermediate.Value.Hours.Should().Be(18);
+            picker.TimeIntermediate.Value.Minutes.Should().Be(0);
             // Are minutes displayed
             comp.FindAll("div.mud-time-picker-hour.mud-time-picker-dial-hidden").Count.Should().Be(1);
         }
@@ -259,12 +259,12 @@ namespace MudBlazor.UnitTests.Components
             // click and drag
             comp.Find("div.mud-time-picker-minute").MouseDown();
             comp.FindAll("div.mud-minute")[3].MouseOver();
-            picker.Time.Value.Minutes.Should().Be(3);
+            picker.TimeIntermediate.Value.Minutes.Should().Be(3);
             comp.FindAll("div.mud-minute")[31].MouseOver();
-            picker.Time.Value.Minutes.Should().Be(31);
+            picker.TimeIntermediate.Value.Minutes.Should().Be(31);
             comp.FindAll("div.mud-minute")[5].MouseOver();
             comp.FindAll("div.mud-minute")[5].MouseUp();
-            picker.Time.Value.Minutes.Should().Be(5);
+            picker.TimeIntermediate.Value.Minutes.Should().Be(5);
         }
 
         [Test]
@@ -274,13 +274,13 @@ namespace MudBlazor.UnitTests.Components
             var picker = comp.Instance;
             // valid time
             comp.Find("input").Change("23:02");
-            picker.Time.Should().Be(new TimeSpan(23, 2, 0));
+            picker.TimeIntermediate.Should().Be(new TimeSpan(23, 2, 0));
             // invalid time
             comp.Find("input").Change("25:06");
-            picker.Time.Should().BeNull();
+            picker.TimeIntermediate.Should().BeNull();
             // invalid time
             comp.Find("input").Change("");
-            picker.Time.Should().BeNull();
+            picker.TimeIntermediate.Should().BeNull();
         }
 
         [Test]
@@ -296,11 +296,11 @@ namespace MudBlazor.UnitTests.Components
             {
                 comp.Find("div.mud-time-picker-hour").MouseDown();
                 comp.FindAll("div.mud-hour")[i].MouseOver();
-                picker.Time.Value.Hours.Should().Be(i + 1);
+                picker.TimeIntermediate.Value.Hours.Should().Be(i + 1);
                 comp.FindAll("div.mud-hour")[i].MouseUp();
-                picker.Time.Value.Hours.Should().Be(i + 1);
+                picker.TimeIntermediate.Value.Hours.Should().Be(i + 1);
                 comp.FindAll("div.mud-hour")[i].Click();
-                picker.Time.Value.Hours.Should().Be(i + 1);
+                picker.TimeIntermediate.Value.Hours.Should().Be(i + 1);
             }
         }
 
@@ -316,22 +316,22 @@ namespace MudBlazor.UnitTests.Components
             {
                 comp.Find("div.mud-time-picker-hour").MouseDown();
                 comp.FindAll("div.mud-picker-stick-outer.mud-hour")[i].MouseOver();
-                picker.Time.Value.Hours.Should().Be(i + 13 == 24 ? 0 : i + 13);
+                picker.TimeIntermediate.Value.Hours.Should().Be(i + 13 == 24 ? 0 : i + 13);
                 comp.FindAll("div.mud-picker-stick-outer.mud-hour")[i].MouseUp();
-                picker.Time.Value.Hours.Should().Be(i + 13 == 24 ? 0 : i + 13);
+                picker.TimeIntermediate.Value.Hours.Should().Be(i + 13 == 24 ? 0 : i + 13);
                 comp.FindAll("div.mud-picker-stick-outer.mud-hour")[i].Click();
-                picker.Time.Value.Hours.Should().Be(i + 13 == 24 ? 0 : i + 13);
+                picker.TimeIntermediate.Value.Hours.Should().Be(i + 13 == 24 ? 0 : i + 13);
             }
             // click and drag 1 to 12 on inner dial
             for (var i = 0; i < 12; i++)
             {
                 comp.Find("div.mud-time-picker-hour").MouseDown();
                 comp.FindAll("div.mud-picker-stick-inner.mud-hour")[i].MouseOver();
-                picker.Time.Value.Hours.Should().Be(i + 1);
+                picker.TimeIntermediate.Value.Hours.Should().Be(i + 1);
                 comp.FindAll("div.mud-picker-stick-inner.mud-hour")[i].MouseUp();
-                picker.Time.Value.Hours.Should().Be(i + 1);
+                picker.TimeIntermediate.Value.Hours.Should().Be(i + 1);
                 comp.FindAll("div.mud-picker-stick-inner.mud-hour")[i].Click();
-                picker.Time.Value.Hours.Should().Be(i + 1);
+                picker.TimeIntermediate.Value.Hours.Should().Be(i + 1);
             }
         }
 
@@ -350,11 +350,11 @@ namespace MudBlazor.UnitTests.Components
             {
                 comp.Find("div.mud-time-picker-minute").MouseDown();
                 comp.FindAll("div.mud-minute")[i].MouseOver();
-                picker.Time.Value.Minutes.Should().Be(i);
+                picker.TimeIntermediate.Value.Minutes.Should().Be(i);
                 comp.FindAll("div.mud-minute")[i].MouseUp();
-                picker.Time.Value.Minutes.Should().Be(i);
+                picker.TimeIntermediate.Value.Minutes.Should().Be(i);
                 comp.FindAll("div.mud-minute")[i].Click();
-                picker.Time.Value.Minutes.Should().Be(i);
+                picker.TimeIntermediate.Value.Minutes.Should().Be(i);
             }
         }
 
@@ -371,6 +371,19 @@ namespace MudBlazor.UnitTests.Components
             // closing programmatically
             await comp.InvokeAsync(() => comp.Instance.Close());
             comp.FindAll("div.mud-picker-content").Count.Should().Be(0);
+        }
+
+        [Test]
+        public void SelectTime_Close_CheckTime()
+        {
+            var comp = OpenPicker(Parameter("AmPm", true));
+            var picker = comp.Instance;
+            // select 11 hours on outer dial and 30 mins
+            comp.FindAll("div.mud-hour")[10].Click();
+            comp.FindAll("div.mud-minute")[30].Click();
+            comp.Find("div.mud-overlay").Click();
+            picker.Time.Value.Hours.Should().Be(11);
+            picker.Time.Value.Minutes.Should().Be(30);
         }
     }
 }

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -96,6 +96,13 @@ namespace MudBlazor
             _selectedDate = null;
         }
 
+        public override void Clear(bool close = true)
+        {
+            Date = null;
+            _selectedDate = null;
+            base.Clear();
+        }
+
         protected override string GetTitleDateString()
         {
             if (_selectedDate != null)

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -9,6 +9,7 @@ namespace MudBlazor
 {
     public class MudDatePicker : MudBaseDatePicker
     {
+        private DateTime? _selectedDate;
 
         /// <summary>
         /// Fired when the DateFormat changes.
@@ -57,7 +58,7 @@ namespace MudBlazor
             var b = new CssBuilder("mud-day");
             if (day < GetMonthStart(month) || day > GetMonthEnd(month))
                 return b.AddClass("mud-hidden").Build();
-            if (Date?.Date == day)
+            if ((Date?.Date == day && _selectedDate == null) || _selectedDate?.Date == day)
                 return b.AddClass("mud-selected").AddClass($"mud-theme-{Color.ToDescriptionString()}").Build();
             if (day == DateTime.Today)
                 return b.AddClass("mud-current").AddClass($"mud-{Color.ToDescriptionString()}-text").Build();
@@ -66,17 +67,39 @@ namespace MudBlazor
 
         protected override async void OnDayClicked(DateTime dateTime)
         {
-            await SetDateAsync(dateTime, true);
-
-            if (PickerVariant != PickerVariant.Static)
+            _selectedDate = dateTime;
+            if (PickerActions == null)
             {
-                await Task.Delay(ClosingDelay);
-                Close();
+                Submit();
+
+                if (PickerVariant != PickerVariant.Static)
+                {
+                    await Task.Delay(ClosingDelay);
+                    Close(false);
+                }
             }
+        }
+
+        protected override void OnOpened()
+        {
+            _selectedDate = null;
+
+            base.OnOpened();
+        }
+
+        protected override async void Submit()
+        {
+            if (_selectedDate == null)
+                return;
+
+            await SetDateAsync(_selectedDate, true);
+            _selectedDate = null;
         }
 
         protected override string GetTitleDateString()
         {
+            if (_selectedDate != null)
+                return _selectedDate.Value.ToString(TitleDateFormat ?? "ddd, dd MMM", Culture) ?? "";
             return Date?.ToString(TitleDateFormat ?? "ddd, dd MMM", Culture) ?? "";
         }
 

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -208,6 +208,13 @@ namespace MudBlazor
             _secondDate = null;
         }
 
+        public override void Clear(bool close = true)
+        {
+            DateRange = null;
+            _firstDate = _secondDate = null;
+            base.Clear();
+        }
+
         protected override string GetTitleDateString()
         {
             if (_firstDate != null && _secondDate != null)

--- a/src/MudBlazor/Components/Picker/MudPicker.razor
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor
@@ -31,6 +31,12 @@
                        <div class="@PickerContainerClass">
                            @PickerContent
                        </div>
+                        @if (PickerActions != null)
+                        {
+                            <div class="@ActionClass">
+                                @PickerActions
+                            </div>
+                        }
                    </MudPaper>
                </div>
             }
@@ -40,22 +46,34 @@
                    <div class="@PickerContainerClass">
                        @PickerContent
                    </div>
+                    @if (PickerActions != null)
+                    {
+                        <div class="@ActionClass">
+                            @PickerActions
+                        </div>
+                    }
                </MudPaper>
             }
             else if(IsOpen && PickerVariant == PickerVariant.Dialog)
             {
-               <MudOverlay Visible="IsOpen" OnClick="Close" DarkBackground="true" Class="mud-overlay-dialog">
+               <MudOverlay Visible="IsOpen" OnClick="CloseOverlay" DarkBackground="true" Class="mud-overlay-dialog">
                    <MudPaper @attributes="UserAttributes" Class="@PickerPaperClass" Elevation="@_pickerElevation" Square="@_pickerSquare">
                        <div class="@PickerContainerClass">
                            @PickerContent
                        </div>
+                        @if (PickerActions != null)
+                        {
+                            <div class="@ActionClass">
+                                @PickerActions
+                            </div>
+                        }
                    </MudPaper>
                </MudOverlay>
             }
         </div>
         @if (PickerVariant == PickerVariant.Inline)
         {
-            <MudOverlay Visible="IsOpen" OnClick="Close" LockScroll="false"/>
+            <MudOverlay Visible="IsOpen" OnClick="CloseOverlay" LockScroll="false"/>
         }
     </CascadingValue>;
 }

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -248,6 +248,14 @@ namespace MudBlazor
 
         protected virtual void Submit() { }
 
+        public virtual void Clear(bool close = true)
+        {
+            if (close && PickerVariant != PickerVariant.Static)
+            {
+                Close(false);
+            }
+        }
+
         private bool _pickerSquare;
         private int _pickerElevation;
         private ElementReference _pickerInlineRef;

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -71,6 +71,10 @@ namespace MudBlazor
             new CssBuilder("mud-input-input-control").AddClass(Class)
             .Build();
 
+        protected string ActionClass => new CssBuilder("mud-picker-actions")
+          .AddClass(ClassActions)
+        .Build();
+
         /// <summary>
         /// Sets the icon of the input text field
         /// </summary>
@@ -182,6 +186,16 @@ namespace MudBlazor
         }
         private string _text;
 
+        /// <summary>
+        /// CSS class that will be applied to the action buttons container
+        /// </summary>
+        [Parameter] public string ClassActions { get; set; }
+
+        /// <summary>
+        /// Define the action buttons here
+        /// </summary>
+        [Parameter] public RenderFragment PickerActions { get; set; }
+
         protected async Task SetTextAsync(string value, bool callback)
         {
             if (_text != value)
@@ -211,10 +225,15 @@ namespace MudBlazor
                 Open();
         }
 
-        public void Close()
+        public void Close(bool submit = true)
         {
             IsOpen = false;
+
+            if (submit)
+                Submit();
+
             StateHasChanged();
+
             OnClosed();
         }
 
@@ -224,6 +243,10 @@ namespace MudBlazor
             StateHasChanged();
             OnOpened();
         }
+
+        private void CloseOverlay() => Close(PickerActions == null);
+
+        protected virtual void Submit() { }
 
         private bool _pickerSquare;
         private int _pickerElevation;

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -117,6 +117,13 @@ namespace MudBlazor
             Time = TimeIntermediate;
         }
 
+        public override void Clear(bool close = true)
+        {
+            Time = null;
+            TimeIntermediate = null;
+            base.Clear();
+        }
+
         private string GetHourString()
         {
             if (TimeIntermediate == null)

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -47,6 +47,8 @@ namespace MudBlazor
 
         private OpenTo _currentView;
 
+        internal TimeSpan? TimeIntermediate { get; private set; }
+
         /// <summary>
         /// First view to show in the MudDatePicker.
         /// </summary>
@@ -76,6 +78,7 @@ namespace MudBlazor
         {
             if (_value != time)
             {
+                TimeIntermediate = time;
                 _value = time;
                 if (updateValue)
                     await SetTextAsync(Converter.Set(_value), false);
@@ -109,24 +112,29 @@ namespace MudBlazor
             };
         }
 
+        protected override void Submit()
+        {
+            Time = TimeIntermediate;
+        }
+
         private string GetHourString()
         {
-            if (_value == null)
+            if (TimeIntermediate == null)
                 return "--";
-            var h = AmPm ? _value.Value.ToAmPmHour() : _value.Value.Hours;
+            var h = AmPm ? TimeIntermediate.Value.ToAmPmHour() : TimeIntermediate.Value.Hours;
             return Math.Min(23, Math.Max(0, h)).ToString(CultureInfo.InvariantCulture);
         }
 
         private string GetMinuteString()
         {
-            if (_value == null)
+            if (TimeIntermediate == null)
                 return "--";
-            return $"{Math.Min(59, Math.Max(0, _value.Value.Minutes)):D2}";
+            return $"{Math.Min(59, Math.Max(0, TimeIntermediate.Value.Minutes)):D2}";
         }
 
         private void UpdateTime()
         {
-            Time = new TimeSpan(_timeSet.Hour, _timeSet.Minute, 0);
+            TimeIntermediate = new TimeSpan(_timeSet.Hour, _timeSet.Minute, 0);
         }
 
         private void OnHourClick()
@@ -295,14 +303,14 @@ namespace MudBlazor
 
         private void UpdateTimeSetFromTime()
         {
-            if (_value == null)
+            if (TimeIntermediate == null)
             {
                 _timeSet.Hour = 0;
                 _timeSet.Minute = 0;
                 return;
             }
-            _timeSet.Hour = _value.Value.Hours;
-            _timeSet.Minute = _value.Value.Minutes;
+            _timeSet.Hour = TimeIntermediate.Value.Hours;
+            _timeSet.Minute = TimeIntermediate.Value.Minutes;
         }
 
         public bool MouseDown { get; set; }

--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -100,4 +100,10 @@
     <Folder Include="wwwroot\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>MudBlazor.UnitTests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
 </Project>

--- a/src/MudBlazor/Styles/components/_picker.scss
+++ b/src/MudBlazor/Styles/components/_picker.scss
@@ -2,6 +2,18 @@
     &.mud-rounded {
         border-radius: var(--mud-default-borderradius);
     }
+
+    & .mud-picker-actions {
+        flex: 0 0 auto;
+        display: flex;
+        padding: 8px;
+        align-items: center;
+        justify-content: flex-end;
+
+        & > :not(:first-child) {
+            margin-left: 8px;
+        }
+    }
 }
 
 .mud-picker-inline {

--- a/src/MudBlazor/Styles/components/_pickerdate.scss
+++ b/src/MudBlazor/Styles/components/_pickerdate.scss
@@ -247,7 +247,7 @@
 :not(.mud-picker-hidden) {
     .mud-picker-calendar-header-last {
         .mud-picker-nav-button-next {
-            visibility: visible !important;
+            visibility: inherit !important;
         }
     }
 }


### PR DESCRIPTION
#724 

I implemented the requested feature in a more general way: I used MudDialog as a reference and make it possible to add action buttons to all type pickers. So this change affects not only timepicker, but the date/daterange pickers too.