### PR TITLE
add missing css classes

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/ScrollToTop/Examples/CustomScrollToTopExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ScrollToTop/Examples/CustomScrollToTopExample.razor
@@ -1,5 +1,20 @@
 ﻿@namespace MudBlazor.Docs.Examples
-<style>    
+<style>
+    .example-scroll-section{
+        height:300px;
+        overflow:auto;
+        padding:20px;
+    }
+    .example-inner-section{
+        height:3500px;        
+        display:flex;
+        flex-direction:column;
+        justify-content:space-between;
+        padding:3em;
+    }
+    .example-inner-section>h1, .example-inner-section>h2{
+        text-align:center;        
+    }
     .example-scroll-to-top-visible {
         font-size: 20px;
         transition: all 1s;       


### PR DESCRIPTION
.example-scroll-section and .example-inner-section classes were missing from this example however the were loaded on the page by another.  This broke the Try MudBlazor Link