### PR TITLE
Fix #994

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -183,17 +183,17 @@ namespace MudBlazor.UnitTests.Components
             var table = comp.FindComponent<MudTable<string>>();
             var pager = comp.FindComponent<MudSelect<string>>().Instance;
             // change page size
-            table.SetParametersAndRender(ComponentParameter.CreateParameter("RowsPerPage", 20));
+            await table.InvokeAsync(() => table.Instance.SetRowsPerPage(20));
             pager.Value.Should().Be("20");
             comp.FindAll("tr.mud-table-row").Count.Should().Be(20);
             comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-20 of 59");
             // change page size
-            table.SetParametersAndRender(ComponentParameter.CreateParameter("RowsPerPage", 60));
+            await table.InvokeAsync(() => table.Instance.SetRowsPerPage(60));
             pager.Value.Should().Be("60");
             comp.FindAll("tr.mud-table-row").Count.Should().Be(59);
             comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-59 of 59");
             // change page size
-            table.SetParametersAndRender(ComponentParameter.CreateParameter("RowsPerPage", 10));
+            await table.InvokeAsync(() => table.Instance.SetRowsPerPage(10));
             pager.Value.Should().Be("10");
             comp.FindAll("tr.mud-table-row").Count.Should().Be(10);
             comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 59");
@@ -224,7 +224,7 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("td")[2].TextContent.Trim().Should().Be("30");
             comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("91-99 of 99");
             // change page size
-            table.SetParametersAndRender(ComponentParameter.CreateParameter("RowsPerPage", 100));
+            await table.InvokeAsync(() => table.Instance.SetRowsPerPage(100));
             pager.Value.Should().Be("100");
             comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-99 of 99");
         }

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -16,7 +16,7 @@ namespace MudBlazor
         internal object _editingItem = null;
 
         private int _currentPage = 0;
-        private int _rowsPerPage = 10;
+        private int? _rowsPerPage;
 
         protected string Classname =>
         new CssBuilder("mud-table")
@@ -99,10 +99,11 @@ namespace MudBlazor
         [Parameter]
         public int RowsPerPage
         {
-            get => _rowsPerPage;
+            get => _rowsPerPage ?? 10;
             set
             {
-                SetRowsPerPage(value);
+                if (_rowsPerPage == null)
+                    SetRowsPerPage(value);
             }
         }
 


### PR DESCRIPTION
The probem here is that in a new render the `RowsPerPage` value is always reapplied. I had two ideas to fix the issue. One is making the parameter bindable, while the other one is change it to one-time-set. I explain why I chosen the second one. I think people use this parameter only to define the default page size, which is obviously a one time binding. I don't think it is general to manipulate later this value via binding. Also, in the first case we basically require to always define a page size in a property which is not a common usage.
If you don't agree just tell me, I can change the code easily.