### PR TITLE
Fixed Typo in FlexPage.razor

### DIFF
--- a/src/MudBlazor.Docs/Pages/Features/Flex/FlexPage.razor
+++ b/src/MudBlazor.Docs/Pages/Features/Flex/FlexPage.razor
@@ -406,7 +406,7 @@
         <DocsPageSection>
             <SectionHeader Class="mt-16">
                 <Title>Flex Grow and Shrink</Title>
-                <Description>MudBlazor have calsses to apply grow and shrink manually. Where <CodeInline>grow</CodeInline> and <CodeInline>shrink</CodeInline> can be either <CodeInline>0</CodeInline> or <CodeInline>1</CodeInline></Description>
+                <Description>MudBlazor has classes to apply grow and shrink manually. Where <CodeInline>grow</CodeInline> and <CodeInline>shrink</CodeInline> can be either <CodeInline>0</CodeInline> or <CodeInline>1</CodeInline></Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" FullWidth="true">
                 <FlexGrowAndShrinkExample/>


### PR DESCRIPTION
Fixed Typo in FlexPage.razor. ("have calsses") -> ("has classes").