### PR TITLE
feat: add support of data validation attributes on properties targeted by `For`

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteValidationDataAttrTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteValidationDataAttrTest.razor
@@ -1,0 +1,38 @@
+﻿@using System.ComponentModel.DataAnnotations
+@using Microsoft.AspNetCore.Components.Forms
+@namespace MudBlazor.UnitTests.TestComponents
+
+<MudGrid>
+    <MudItem xs="12" sm="6" md="4">
+        <EditForm Model="Model">
+            <DataAnnotationsValidator />
+            <MudAutocomplete For="@(() => Model.Value)" Label="Metasyntactic variable" @bind-Value="Model.Value" SearchFunc="@Search" />
+        </EditForm>
+    </MudItem>
+</MudGrid>
+@code {
+    #pragma warning disable CS1998 // async without await
+    public static string __description__ = "Test use of data attributes accessible using `For` bound expression.";
+
+    class TestModel
+    {
+        [StringLength(3, ErrorMessage = "Should not be longer than 3")]
+        public string Value { get; set; }
+    }
+
+    private TestModel Model { get; set; } = new TestModel();
+
+    // What does this awkward var name means ? => https://en.wikipedia.org/wiki/Metasyntactic_variable
+    private string[] metasyntacticVariable =
+    {
+    "Foo", "Bar", "Qux", "Quux"
+    };
+
+    private async Task<IEnumerable<string>> Search(string value)
+    {
+        // if text is null or empty, show complete list
+        if (string.IsNullOrEmpty(value))
+            return metasyntacticVariable;
+        return metasyntacticVariable.Where(x => x.Contains(value, StringComparison.InvariantCultureIgnoreCase));
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectValidationDataAttrTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectValidationDataAttrTest.razor
@@ -1,0 +1,35 @@
+﻿@using System.ComponentModel.DataAnnotations
+@using Microsoft.AspNetCore.Components.Forms
+@namespace MudBlazor.UnitTests.TestComponents
+
+<MudGrid>
+    <MudItem xs="12" sm="6" md="4">
+        <EditForm Model="Model">
+            <DataAnnotationsValidator />
+            <MudSelect For="@(() => Model.Value)" Label="Metasyntactic variable" @bind-Value="Model.Value">
+                @foreach (var v in metasyntacticVariable)
+                {
+                    <MudSelectItem Value="@v">@v</MudSelectItem>
+                }
+            </MudSelect>
+        </EditForm>
+    </MudItem>
+</MudGrid>
+@code {
+    #pragma warning disable CS1998 // async without await
+    public static string __description__ = "Test use of data attributes accessible using `For` bound expression.";
+
+    class TestModel
+    {
+        [StringLength(3, ErrorMessage = "Should not be longer than 3")]
+        public string Value { get; set; }
+    }
+
+    private TestModel Model { get; set; } = new TestModel();
+
+    // What does this awkward var name means ? => https://en.wikipedia.org/wiki/Metasyntactic_variable
+    private string[] metasyntacticVariable =
+    {
+    "Foo", "Bar", "Qux", "Quux"
+    };
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/TextFieldValidationDataAttrTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/TextFieldValidationDataAttrTest.razor
@@ -1,0 +1,24 @@
+﻿@using System.ComponentModel.DataAnnotations
+@using Microsoft.AspNetCore.Components.Forms
+@namespace MudBlazor.UnitTests.TestComponents
+
+<MudGrid>
+    <MudItem xs="12" sm="6" md="4">
+        <EditForm Model="Model">
+            <DataAnnotationsValidator />
+            <MudTextField For="@(() => Model.Value)" Label="Short string" @bind-Value="Model.Value" />
+        </EditForm>
+    </MudItem>
+</MudGrid>
+
+@code {
+    public static string __description__ = "Test use of data attributes accessible using `For` bound expression.";
+
+    class TestModel
+    {
+        [StringLength(3, ErrorMessage = "Should not be longer than 3")]
+        public string Value { get; set; }
+    }
+
+    private TestModel Model { get; set; } = new TestModel();
+}

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -142,9 +142,9 @@ namespace MudBlazor.UnitTests.Components
             autocomplete.Value.Should().Be("Alabama");
             autocomplete.Text.Should().Be("Alabama");
             // set a value the search won't find
-            autocompletecomp.SetParam(a => a.Text, "Austria"); // not part of the U.S. 
+            autocompletecomp.SetParam(a => a.Text, "Austria"); // not part of the U.S.
             await comp.InvokeAsync(() => autocomplete.ToggleMenu());
-            // now trigger the coercion by closing the menu 
+            // now trigger the coercion by closing the menu
             await comp.InvokeAsync(() => autocomplete.ToggleMenu());
             autocomplete.Value.Should().Be("Alabama");
             autocomplete.Text.Should().Be("Alabama");
@@ -165,7 +165,7 @@ namespace MudBlazor.UnitTests.Components
             // set a value the search won't find
             autocompletecomp.SetParam(a => a.Text, "Austria");
             await comp.InvokeAsync(() => autocomplete.ToggleMenu());
-            // now trigger the coercion by closing the menu 
+            // now trigger the coercion by closing the menu
             await comp.InvokeAsync(() => autocomplete.ToggleMenu());
             autocomplete.Value.Should().Be("Alabama");
             autocomplete.Text.Should().Be("Austria");
@@ -194,5 +194,45 @@ namespace MudBlazor.UnitTests.Components
             Console.WriteLine(comp.Markup);
             comp.FindAll("div.mud-popover-open").Count.Should().Be(0);
         }
+
+        #region DataAttribute validation
+        [Test]
+        public async Task Autocomplete_Should_Validate_Data_Attribute_Fail()
+        {
+            var comp = ctx.RenderComponent<AutocompleteValidationDataAttrTest>();
+            Console.WriteLine(comp.Markup);
+            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
+            var autocomplete = autocompletecomp.Instance;
+            await comp.InvokeAsync(() => autocomplete.DebounceInterval = 0);
+            // Set invalid option
+            await comp.InvokeAsync(() => autocomplete.SelectOption("Quux"));
+            // check initial state
+            autocomplete.Value.Should().Be("Quux");
+            autocomplete.Text.Should().Be("Quux");
+            // check validity
+            await comp.InvokeAsync(() => autocomplete.Validate());
+            autocomplete.ValidationErrors.Should().NotBeEmpty();
+            autocomplete.ValidationErrors.Should().HaveCount(1);
+            autocomplete.ValidationErrors[0].Should().Equals("Should not be longer than 3");
+        }
+
+        [Test]
+        public async Task Autocomplete_Should_Validate_Data_Attribute_Success()
+        {
+            var comp = ctx.RenderComponent<AutocompleteValidationDataAttrTest>();
+            Console.WriteLine(comp.Markup);
+            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
+            var autocomplete = autocompletecomp.Instance;
+            await comp.InvokeAsync(() => autocomplete.DebounceInterval = 0);
+            // Set valid option
+            await comp.InvokeAsync(() => autocomplete.SelectOption("Qux"));
+            // check initial state
+            autocomplete.Value.Should().Be("Qux");
+            autocomplete.Text.Should().Be("Qux");
+            // check validity
+            await comp.InvokeAsync(() => autocomplete.Validate());
+            autocomplete.ValidationErrors.Should().BeEmpty();
+        }
+        #endregion
     }
 }

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -442,5 +442,44 @@ namespace MudBlazor.UnitTests.Components
             select.Instance.Text.Should().Be("1");
             validatedValue.Should().Be("1");
         }
+
+
+        #region DataAttribute validation
+        [Test]
+        public async Task TextField_Should_Validate_Data_Attribute_Fail()
+        {
+            var comp = ctx.RenderComponent<SelectValidationDataAttrTest>();
+            Console.WriteLine(comp.Markup);
+            var selectcomp = comp.FindComponent<MudSelect<string>>();
+            var select = selectcomp.Instance;
+            // Select invalid option
+            await comp.InvokeAsync(() => select.SelectOption("Quux"));
+            // check initial state
+            select.Value.Should().Be("Quux");
+            select.Text.Should().Be("Quux");
+            // check validity
+            await comp.InvokeAsync(() => select.Validate());
+            select.ValidationErrors.Should().NotBeEmpty();
+            select.ValidationErrors.Should().HaveCount(1);
+            select.ValidationErrors[0].Should().Equals("Should not be longer than 3");
+        }
+
+        [Test]
+        public async Task TextField_Should_Validate_Data_Attribute_Success()
+        {
+            var comp = ctx.RenderComponent<SelectValidationDataAttrTest>();
+            Console.WriteLine(comp.Markup);
+            var selectcomp = comp.FindComponent<MudSelect<string>>();
+            var select = selectcomp.Instance;
+            // Select valid option
+            await comp.InvokeAsync(() => select.SelectOption("Qux"));
+            // check initial state
+            select.Value.Should().Be("Qux");
+            select.Text.Should().Be("Qux");
+            // check validity
+            await comp.InvokeAsync(() => select.Validate());
+            select.ValidationErrors.Should().BeEmpty();
+        }
+        #endregion
     }
 }

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -369,6 +369,46 @@ namespace MudBlazor.UnitTests.Components
             Console.WriteLine(comp.Markup);
         }
 
+
+        #region DataAttribute validation
+        [Test]
+        public async Task TextField_Should_Validate_Data_Attribute_Fail()
+        {
+            var comp = ctx.RenderComponent<TextFieldValidationDataAttrTest>();
+            Console.WriteLine(comp.Markup);
+            var textfieldcomp = comp.FindComponent<MudTextField<string>>();
+            var textfield = textfieldcomp.Instance;
+            await comp.InvokeAsync(() => textfield.DebounceInterval = 0);
+            // Set invalid text
+            comp.Find("input").Change("Quux");
+            // check initial state
+            textfield.Value.Should().Be("Quux");
+            textfield.Text.Should().Be("Quux");
+            // check validity
+            await comp.InvokeAsync(() => textfield.Validate());
+            textfield.ValidationErrors.Should().NotBeEmpty();
+            textfield.ValidationErrors.Should().HaveCount(1);
+            textfield.ValidationErrors[0].Should().Equals("Should not be longer than 3");
+        }
+
+        [Test]
+        public async Task TextField_Should_Validate_Data_Attribute_Success()
+        {
+            var comp = ctx.RenderComponent<TextFieldValidationDataAttrTest>();
+            Console.WriteLine(comp.Markup);
+            var textfieldcomp = comp.FindComponent<MudTextField<string>>();
+            var textfield = textfieldcomp.Instance;
+            await comp.InvokeAsync(() => textfield.DebounceInterval = 0);
+            // Set valid text
+            comp.Find("input").Change("Qux");
+            // check initial state
+            textfield.Value.Should().Be("Qux");
+            textfield.Text.Should().Be("Qux");
+            // check validity
+            await comp.InvokeAsync(() => textfield.Validate());
+            textfield.ValidationErrors.Should().BeEmpty();
+        }
+        #endregion
     }
 
 }

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -84,7 +84,7 @@ namespace MudBlazor
         [Parameter] public Variant Variant { get; set; } = Variant.Text;
 
         /// <summary>
-        ///  Will adjust vertical spacing. 
+        ///  Will adjust vertical spacing.
         /// </summary>
         [Parameter] public Margin Margin { get; set; } = Margin.None;
 
@@ -115,7 +115,7 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// Text change hook for descendants. Called when Text needs to be refreshed from current Value property.   
+        /// Text change hook for descendants. Called when Text needs to be refreshed from current Value property.
         /// </summary>
         protected virtual Task UpdateTextPropertyAsync(bool updateValue)
         {
@@ -155,7 +155,7 @@ namespace MudBlazor
         protected virtual void InvokeKeyUp(KeyboardEventArgs obj) => OnKeyUp.InvokeAsync(obj).AndForget();
 
         /// <summary>
-        /// Fired when the Value property changes. 
+        /// Fired when the Value property changes.
         /// </summary>
         [Parameter]
         public EventCallback<T> ValueChanged { get; set; }
@@ -183,7 +183,7 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// Value change hook for descendants. Called when Value needs to be refreshed from current Text property.  
+        /// Value change hook for descendants. Called when Value needs to be refreshed from current Text property.
         /// </summary>
         protected virtual Task UpdateValuePropertyAsync(bool updateText)
         {

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -4,6 +4,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
@@ -239,6 +240,16 @@ namespace MudBlazor
 
                     changed = !EqualityComparer<T>.Default.Equals(value, _value);
                 }
+
+                // Run each validation attributes of the property targetted with `For`
+                if (_validationAttrsFor is IEnumerable<ValidationAttribute> va)
+                {
+                    foreach (var v in va)
+                    {
+                        ValidateWithAttribute(v, _value, errors);
+                    }
+                }
+
                 // required error (must be last, because it is least important!)
                 var hasValue = HasValue(_value);
                 if (Required)
@@ -255,7 +266,7 @@ namespace MudBlazor
                 if (!changed)
                 {
                     // this must be called in any case, because even if Validation is null the user might have set Error and ErrorText manually
-                    // if Error and ErrorText are set by the user, setting them here will have no effect. 
+                    // if Error and ErrorText are set by the user, setting them here will have no effect.
                     ValidationErrors = errors;
                     Error = errors.Count > 0;
                     ErrorText = errors.FirstOrDefault();
@@ -412,6 +423,13 @@ namespace MudBlazor
         public Expression<Func<T>>? For { get; set; }
 #nullable disable
 
+        /// <summary>
+        /// Stores the list of validation attributes attached to the property targeted by <seealso cref="For"/>. If <seealso cref="For"/> is null, this property is null too.
+        /// </summary>
+#nullable enable
+        private IEnumerable<ValidationAttribute>? _validationAttrsFor;
+#nullable disable
+
         private void OnValidationStateChanged(object sender, ValidationStateChangedEventArgs e)
         {
             if (EditContext != null)
@@ -448,6 +466,12 @@ namespace MudBlazor
             {
                 if (For != _currentFor)
                 {
+                    // Extract validation attributes
+                    // Sourced from https://stackoverflow.com/a/43076222/4839162
+                    var expression = (MemberExpression)For.Body;
+                    var propertyInfo = (PropertyInfo)expression.Member;
+                    _validationAttrsFor = propertyInfo.GetCustomAttributes(typeof(ValidationAttribute), true).Cast<ValidationAttribute>();
+
                     _fieldIdentifier = FieldIdentifier.Create(For);
                     _currentFor = For;
                 }

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -242,11 +242,11 @@ namespace MudBlazor
                 }
 
                 // Run each validation attributes of the property targetted with `For`
-                if (_validationAttrsFor is IEnumerable<ValidationAttribute> va)
+                if (_validationAttrsFor is IEnumerable<ValidationAttribute> validationAttrs)
                 {
-                    foreach (var v in va)
+                    foreach (var attr in validationAttrs)
                     {
-                        ValidateWithAttribute(v, _value, errors);
+                        ValidateWithAttribute(attr, _value, errors);
                     }
                 }
 


### PR DESCRIPTION
I've encountered issues with validation using data attributes on my models with EditForms.

This PR allows form controls to retrieve the list of [DataValidation attributes](https://docs.microsoft.com/en-us/aspnet/core/mvc/models/validation?view=aspnetcore-5.0#validation-attributes) from the property targeted by simple `For` expressions, and run them during validation.

Since this is added at the `MudBaseInput` level, tests include verifications that some inputs (`MudSelect`, `MudTextField` and `MudAutocomplete`) are behaving correctly.

Those validations were previously made at the `EditForm` level (I guess), but not at the MudBlazor inputs level.

Feel free to feedback. 🥂 