### PR TITLE
Fix dispose DotNetObjectReference

### DIFF
--- a/src/MudBlazor/Components/Collapse/MudCollapse.razor.cs
+++ b/src/MudBlazor/Components/Collapse/MudCollapse.razor.cs
@@ -20,6 +20,7 @@ namespace MudBlazor
         private bool _expanded, _isRendered;
         private ElementReference _container, _wrapper;
         private CollapseState _state = CollapseState.Exited;
+        private DotNetObjectReference<MudCollapse> _dotNetRef;
 
         protected string Stylename =>
             new StyleBuilder()
@@ -106,20 +107,41 @@ namespace MudBlazor
             }
         }
 
+        protected override void OnInitialized()
+        {
+            _dotNetRef = DotNetObjectReference.Create(this);
+        }
+
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
             if (firstRender)
             {
                 _isRendered = true;
                 await UpdateHeight();
-                _listenerId = await _container.MudAddEventListenerAsync(DotNetObjectReference.Create(this), "animationend", nameof(AnimationEnd));
+                _listenerId = await _container.MudAddEventListenerAsync(_dotNetRef, "animationend", nameof(AnimationEnd));
             }
             await base.OnAfterRenderAsync(firstRender);
         }
 
+        bool _disposed;
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    _ = _container.MudRemoveEventListenerAsync("animationend", _listenerId);
+                    _dotNetRef?.Dispose();
+                }
+                _disposed = true;
+            }
+        }
+
         public void Dispose()
         {
-            _ = _container.MudRemoveEventListenerAsync("animationend", _listenerId);
+            Dispose(true);
+            GC.SuppressFinalize(this);
         }
 
         [JSInvokable]

--- a/src/MudBlazor/Services/ResizeListener/ResizeListenerService.cs
+++ b/src/MudBlazor/Services/ResizeListener/ResizeListenerService.cs
@@ -10,7 +10,7 @@ namespace MudBlazor.Services
     /// <summary>
     /// This service listens to browser resize events and allows you to react to a changing window size in Blazor
     /// </summary>
-    public class ResizeListenerService : IResizeListenerService
+    public class ResizeListenerService : IResizeListenerService, IDisposable
     {
         /// <summary>
         /// 
@@ -200,6 +200,7 @@ namespace MudBlazor.Services
                 {
                     _onResized = null;
                     _onBreakpointChanged = null;
+                    _dotNetRef?.Dispose();
                 }
                 _disposed = true;
             }

--- a/src/MudBlazor/Services/Scroll/ScrollListener.cs
+++ b/src/MudBlazor/Services/Scroll/ScrollListener.cs
@@ -22,7 +22,7 @@ namespace MudBlazor
     internal class ScrollListener : IScrollListener, IDisposable
     {
         private readonly IJSRuntime _js;
-        private DotNetObjectReference<ScrollListener> _dotnetRef;
+        private DotNetObjectReference<ScrollListener> _dotNetRef;
 
         /// <summary>
         /// The CSS selector to which the scroll event will be attached
@@ -79,10 +79,10 @@ namespace MudBlazor
         /// </summary>        
         private async ValueTask Start()
         {
-            _dotnetRef = DotNetObjectReference.Create(this);
+            _dotNetRef = DotNetObjectReference.Create(this);
             await _js.InvokeVoidAsync
                 ("mudScrollListener.listenForScroll",
-                           _dotnetRef,
+                           _dotNetRef,
                            Selector);
         }
 
@@ -102,7 +102,7 @@ namespace MudBlazor
 
         public void Dispose()
         {
-            _dotnetRef?.Dispose();
+            _dotNetRef?.Dispose();
         }
     }
 }


### PR DESCRIPTION
- A couple of places we didn't dispose of DotNetObjectReference
- Renamed another for consistency
- Reference https://blazor-university.com/javascript-interop/calling-dotnet-from-javascript/lifetimes-and-memory-leaks/
- @tungi52 @TyrenDe Can you review please