### PR TITLE
fix: avoid autocomplete popover to be too low

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Select/Examples/SelectInteractiveExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Select/Examples/SelectInteractiveExample.razor
@@ -3,7 +3,7 @@
 <MudGrid>
     <MudItem xs="12" md="3">
         <MudForm>
-            <MudSwitch T="bool" CheckedChanged="@OnPostitionChange" Color="Color.Primary" Label="Open Top" />
+            <MudSwitch T="bool" CheckedChanged="@OnPositionChange" Color="Color.Primary" Label="Open Top" />
             <MudSwitch @bind-Checked="@OffsetY" Color="Color.Secondary" Label="Offset Y" />
             <MudSwitch @bind-Checked="@Dense" Color="Color.Primary" Label="Dense" />
         </MudForm>
@@ -30,7 +30,7 @@
     public Direction _direction {get; set;}
     public Variant _variant { get; set; } = Variant.Filled;
 
-    protected void OnPostitionChange()
+    protected void OnPositionChange()
     {
         OpenTop = !OpenTop;
 

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -1,9 +1,9 @@
-﻿@namespace MudBlazor
+@namespace MudBlazor
 @inherits MudBaseInput<T>
 @typeparam T
 
 <CascadingValue Name="Standalone" Value="false" IsFixed="true">
-    <div class="mud-select mud-autocomplete" >
+    <div class="mud-select mud-autocomplete">
         <MudInputControl Label="@Label" Variant="@Variant" HelperText="@HelperText" FullWidth="@FullWidth" Margin="@Margin" Class="@Classname" Style="@Style"
                          Error="@Error" ErrorText="@ErrorText" Disabled="@Disabled" @onclick="@ToggleMenu">
             <InputContent>
@@ -12,39 +12,39 @@
                           OnBlur="@OnInputBlurred" OnKeyDown="@this.OnInputKeyDown" OnKeyPress="@base.InvokeKeyPress" OnKeyUp="@base.InvokeKeyUp" autocomplete=@("mud-disabled-"+Guid.NewGuid())
                           KeyDownPreventDefault="KeyDownPreventDefault" KeyPressPreventDefault="KeyPressPreventDefault" KeyUpPreventDefault="KeyUpPreventDefault"
                           />
+                <MudPopover Open="@IsOpen" MaxHeight="@MaxHeight" OffsetY="true">
+                    @*this must be the real scroll container, not the Popover, hence the maxheight*@
+                    <MudList Clickable="true" Dense="@Dense" Style=@($"max-height: {MaxHeight}px; overflow-y:auto;")>
+                        @if (_items != null && _items.Any())
+                        {
+                            int i = 0;
+                            @foreach (T item in _items)
+                            {
+                                bool is_selected = i == _selectedListItemIndex;
+                                <MudListItem @key="@item" id="@GetListItemId(i)" OnClick="@(() => SelectOption(item))" Class="@(is_selected ? "mud-selected-item" : "")">
+                                    @if (ItemTemplate == null)
+                                    {
+                                        @GetItemString(item)
+                                    }
+                                    else if (is_selected)
+                                    {
+                                        @if (ItemSelectedTemplate == null)
+                                            @ItemTemplate(item)
+                                        else
+                                            @ItemSelectedTemplate(item)
+                                    }
+                                    else
+                                    {
+                                        @ItemTemplate(item)
+                                    }
+                                </MudListItem>
+                                i++;
+                            }
+                        }
+                    </MudList>
+                </MudPopover>
             </InputContent>
         </MudInputControl>
-        <MudPopover Open="@IsOpen" MaxHeight="@MaxHeight" OffsetY="true">
-            @*this must be the real scroll container, not the Popover, hence the maxheight*@
-            <MudList Clickable="true" Dense="@Dense" Style=@($"max-height: {MaxHeight}px; overflow-y:auto;")>
-                @if (_items != null && _items.Any())
-                {
-                    int i = 0;
-                    @foreach (T item in _items)
-                    {
-                        bool is_selected = i == _selectedListItemIndex;
-                        <MudListItem @key="@item" id="@GetListItemId(i)" OnClick="@(() => SelectOption(item))" Class="@(is_selected ? "mud-selected-item" : "")">
-                            @if (ItemTemplate == null)
-                            {
-                                @GetItemString(item)
-                            }
-                            else if (is_selected)
-                            {
-                                @if (ItemSelectedTemplate == null)
-                                    @ItemTemplate(item)
-                                else
-                                    @ItemSelectedTemplate(item)
-                            }
-                            else
-                            {
-                                @ItemTemplate(item)
-                            }
-                        </MudListItem>
-                        i++;
-                    }
-                }
-            </MudList>
-        </MudPopover>
     </div>
 </CascadingValue>
 

--- a/src/MudBlazor/Components/InputControl/MudInputControl.razor
+++ b/src/MudBlazor/Components/InputControl/MudInputControl.razor
@@ -5,29 +5,29 @@
 
 
 <div @attributes="UserAttributes" class="@Classname" style="@Style">
-    @InputContent
-    @if (!String.IsNullOrEmpty(Label))
+    <div class="mud-input-control-input-container">
+        @InputContent
+        @if (!String.IsNullOrEmpty(Label))
+        {
+            <MudInputLabel Class="mud-input-label-inputcontrol" Variant="@Variant" Disabled=@Disabled Error="@Error" Margin="@Margin">
+                @Label
+            </MudInputLabel>
+        }
+    </div>
+    @if (Error || !String.IsNullOrEmpty(HelperText))
     {
-        <MudInputLabel Class="mud-input-label-inputcontrol" Variant="@Variant" Disabled=@Disabled Error="@Error" Margin="@Margin">
-            @Label
-        </MudInputLabel>
-    }
-    @if (!String.IsNullOrEmpty(HelperText))
-    {
-        <p class="@HelperClass">
-            @if (Error)
-            {
-                @ErrorText
-            }
-            else
-            {
-                @HelperText
-            }
-        </p>
-    }
-    else if (String.IsNullOrEmpty(HelperText) && Error)
-    {
-        <p class="@HelperClass">@ErrorText</p>
+        <div class="mud-input-control-helper-container">
+            <p class="@HelperClass">
+                @if (Error)
+                {
+                    @ErrorText
+                }
+                else if (!String.IsNullOrEmpty(HelperText))
+                {
+                    @HelperText
+                }
+            </p>
+        </div>
     }
     @ChildContent
 </div>

--- a/src/MudBlazor/Styles/components/_inputcontrol.scss
+++ b/src/MudBlazor/Styles/components/_inputcontrol.scss
@@ -24,25 +24,31 @@
         width: 100%;
     }
 
-    & > div {
-        &.mud-input.mud-input-text {
-            margin-top: 16px;
-        }
+    & > .mud-input-control-input-container {
+        position: relative;
+        display: flex;
+        flex-direction: column;
 
-        &.mud-input.mud-input-filled {
-        }
+        & > div {
+            &.mud-input.mud-input-text {
+                margin-top: 16px;
+            }
 
-        &.mud-input.mud-input-outlined {
+            &.mud-input.mud-input-filled {
+            }
+
+            &.mud-input.mud-input-outlined {
+            }
         }
     }
 
-    & > .mud-input-label-outlined {
+    & > .mud-input-control-input-container > .mud-input-label-outlined {
         &.mud-input-label-inputcontrol {
             line-height: 18px;
         }
     }
 
-    & > .mud-input-label-inputcontrol {
+    & > .mud-input-control-input-container > .mud-input-label-inputcontrol {
         color: var(--mud-palette-text-secondary);
         padding: 0;
         font-size: 1rem;
@@ -50,7 +56,7 @@
         line-height: 1;
         letter-spacing: 0.00938em;
         z-index: 0;
-        pointer-events:none;
+        pointer-events: none;
 
         &.mud-disabled {
             color: var(--mud-palette-text-disabled);
@@ -61,7 +67,7 @@
         }
     }
 
-    &.mud-input-required > .mud-input-label::after {
+    &.mud-input-required > .mud-input-control-input-container > .mud-input-label::after {
         content: "*";
     }
 }

--- a/src/MudBlazor/Styles/components/_inputlabel.scss
+++ b/src/MudBlazor/Styles/components/_inputlabel.scss
@@ -47,50 +47,34 @@
     }
 }
 
+label.mud-input-label.mud-input-label-inputcontrol {
+    .mud-shrink ~ & {
+        color: var(--mud-palette-text-primary);
+    }
 
-.mud-input:focus-within ~ label {
-    &.mud-input-label.mud-input-label-inputcontrol {
+    .mud-input:focus-within ~ & {
         color: var(--mud-palette-primary);
+    }
+
+    .mud-shrink ~ &,
+    .mud-input:focus-within ~ & {
         transform: translate(0, 1.5px) scale(0.75);
         transform-origin: top left;
 
-        &.mud-input-error {
-            color: var(--mud-palette-error);
+        &.mud-input-label-filled {
+            transform: translate(12px, 10px) scale(0.75);
+
+            &.mud-input-label-margin-dense {
+                transform: translate(12px, 7px) scale(0.75);
+            }
+        }
+
+        &.mud-input-label-outlined {
+            transform: translate(14px, -6px) scale(0.75);
         }
     }
 
-    &.mud-input-label.mud-input-label-inputcontrol.mud-input-label-filled {
-        transform: translate(12px, 10px) scale(0.75);
-
-        &.mud-input-label-margin-dense {
-            transform: translate(12px, 7px) scale(0.75);
-        }
-    }
-
-    &.mud-input-label.mud-input-label-inputcontrol.mud-input-label-outlined {
-        color: var(--mud-palette-primary);
-        transform: translate(14px, -6px) scale(0.75);
+    .mud-input:focus-within ~ &.mud-input-error {
+        color: var(--mud-palette-error);
     }
 }
-
-.mud-shrink ~ label {
-    &.mud-input-label.mud-input-label-inputcontrol {
-        color: var(--mud-palette-text-primary);
-        transform: translate(0, 1.5px) scale(0.75);
-        transform-origin: top left;
-    }
-
-    &.mud-input-label.mud-input-label-inputcontrol.mud-input-label-filled {
-        transform: translate(12px, 10px) scale(0.75);
-
-        &.mud-input-label-margin-dense {
-            transform: translate(12px, 7px) scale(0.75);
-        }
-    }
-
-    &.mud-input-label.mud-input-label-inputcontrol.mud-input-label-outlined {
-        color: var(--mud-palette-text-primary);
-        transform: translate(14px, -6px) scale(0.75);
-    }
-}
-

--- a/src/MudBlazor/Styles/components/_inputlabel.scss
+++ b/src/MudBlazor/Styles/components/_inputlabel.scss
@@ -48,7 +48,7 @@
 }
 
 
-.mud-input:focus-within + label {
+.mud-input:focus-within ~ label {
     &.mud-input-label.mud-input-label-inputcontrol {
         color: var(--mud-palette-primary);
         transform: translate(0, 1.5px) scale(0.75);
@@ -73,7 +73,7 @@
     }
 }
 
-.mud-shrink + label {
+.mud-shrink ~ label {
     &.mud-input-label.mud-input-label-inputcontrol {
         color: var(--mud-palette-text-primary);
         transform: translate(0, 1.5px) scale(0.75);


### PR DESCRIPTION
> Note: new InputControl container `.mud-input-control-input-container` enables relative positioning so that absolute positioning of popover works as expected.
> Closes #472

This PR is highly experimental, and I don't know how to check if it causes UI regression (though it doesn't in my end-usage project). I would be grateful if you could check it out.

Since this is UI only, I could have written E2E tests but there are no boilerplate for it, and it does not modify any logic really testable through Unit Tests

Cheers.  🥂 