### PR TITLE
feat: use data attributes even if no edit form, retrieve error messages

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -4,13 +4,16 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
 using FluentValidation;
 using Microsoft.AspNetCore.Components;
+using MudBlazor.UnitTests.Mocks;
 using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
 using static Bunit.ComponentParameterFactory;
@@ -407,6 +410,31 @@ namespace MudBlazor.UnitTests.Components
             // check validity
             await comp.InvokeAsync(() => textfield.Validate());
             textfield.ValidationErrors.Should().BeEmpty();
+        }
+
+        public class CustomFailingValidationAttribute : ValidationAttribute
+        {
+            protected override ValidationResult? IsValid(object value,
+                ValidationContext validationContext)
+            {
+                return new ValidationResult("TEST ERROR");
+            }
+        }
+        class TestModel
+        {
+            [CustomFailingValidation]
+            public string Foo { get; set; }
+        }
+        [Test]
+        public async Task TextField_Should_HaveCorrectMessageWithCustomAttr()
+        {
+            var model = new TestModel();
+            var comp = ctx.RenderComponent<MudTextField<string>>(ComponentParameter.CreateParameter("For", (Expression<Func<string>>)(() => model.Foo)));
+            await comp.InvokeAsync(() => comp.Instance.Validate());
+            comp.Instance.Error.Should().BeTrue();
+            comp.Instance.ValidationErrors.Should().HaveCount(1);
+            comp.Instance.ValidationErrors[0].Should().Be("TEST ERROR");
+            comp.Instance.GetErrorText().Should().Be("TEST ERROR");
         }
         #endregion
     }

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -414,7 +414,7 @@ namespace MudBlazor.UnitTests.Components
 
         public class CustomFailingValidationAttribute : ValidationAttribute
         {
-            protected override ValidationResult? IsValid(object value,
+            protected override ValidationResult IsValid(object value,
                 ValidationContext validationContext)
             {
                 return new ValidationResult("TEST ERROR");

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -296,9 +296,11 @@ namespace MudBlazor
                 if (validationResult != ValidationResult.Success)
                     errors.Add(validationResult.ErrorMessage);
             }
-            catch (Exception)
+            catch (Exception e)
             {
-                /* silently ignore exceptions thrown by the validation attribute */
+                // Maybe conditionally add full error message if `IWebAssemblyHostEnvironment.IsDevelopment()`
+                // Or log using proper logger.
+                errors.Add($"An unhandled exception occured: {e.Message}");
             }
         }
 

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -288,7 +288,10 @@ namespace MudBlazor
         {
             try
             {
-                var validationContext = new ValidationContext(this);
+                // The validation context is applied either on the `EditContext.Model`, or `this` as a stub subject.
+                // Complex validation with fields references (like `CompareAttribute`) should use an EditContext.
+                var validationContextSubject = EditContext?.Model ?? this;
+                var validationContext = new ValidationContext(validationContextSubject);
                 var validationResult = attr.GetValidationResult(value, validationContext);
                 if (validationResult != ValidationResult.Success)
                     errors.Add(validationResult.ErrorMessage);

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Globalization;
@@ -242,7 +242,7 @@ namespace MudBlazor
                 }
 
                 // Run each validation attributes of the property targeted with `For`
-                if (_validationAttrsFor!=null)
+                if (_validationAttrsFor != null)
                 {
                     foreach (var attr in _validationAttrsFor)
                     {
@@ -288,9 +288,10 @@ namespace MudBlazor
         {
             try
             {
-                var isValid = attr.IsValid(value);
-                if (!isValid)
-                    errors.Add(attr.ErrorMessage);
+                var validationContext = new ValidationContext(this);
+                var validationResult = attr.GetValidationResult(value, validationContext);
+                if (validationResult != ValidationResult.Success)
+                    errors.Add(validationResult.ErrorMessage);
             }
             catch (Exception)
             {
@@ -440,7 +441,7 @@ namespace MudBlazor
 
         private void OnValidationStateChanged(object sender, ValidationStateChangedEventArgs e)
         {
-            if (EditContext != null)
+            if (EditContext != null && !_fieldIdentifier.Equals(default(FieldIdentifier)))
             {
                 var error_msgs = EditContext.GetValidationMessages(_fieldIdentifier).ToArray();
                 Error = error_msgs.Length > 0;
@@ -470,26 +471,23 @@ namespace MudBlazor
 
         protected override void OnParametersSet()
         {
-            if (EditContext != null && For != null)
+            if (For != null && For != _currentFor)
             {
-                if (For != _currentFor)
-                {
-                    // Extract validation attributes
-                    // Sourced from https://stackoverflow.com/a/43076222/4839162
-                    var expression = (MemberExpression)For.Body;
-                    var propertyInfo = (PropertyInfo)expression.Member;
-                    _validationAttrsFor = propertyInfo.GetCustomAttributes(typeof(ValidationAttribute), true).Cast<ValidationAttribute>();
+                // Extract validation attributes
+                // Sourced from https://stackoverflow.com/a/43076222/4839162
+                var expression = (MemberExpression)For.Body;
+                var propertyInfo = (PropertyInfo)expression.Member;
+                _validationAttrsFor = propertyInfo.GetCustomAttributes(typeof(ValidationAttribute), true).Cast<ValidationAttribute>();
 
-                    _fieldIdentifier = FieldIdentifier.Create(For);
-                    _currentFor = For;
-                }
+                _fieldIdentifier = FieldIdentifier.Create(For);
+                _currentFor = For;
+            }
 
-                if (EditContext != _currentEditContext)
-                {
-                    DetachValidationStateChangedListener();
-                    EditContext.OnValidationStateChanged += OnValidationStateChanged;
-                    _currentEditContext = EditContext;
-                }
+            if (EditContext != null && EditContext != _currentEditContext)
+            {
+                DetachValidationStateChangedListener();
+                EditContext.OnValidationStateChanged += OnValidationStateChanged;
+                _currentEditContext = EditContext;
             }
         }
 


### PR DESCRIPTION
I've spotted the regression introduced in #1198 and fixed by 93773b8a15662dd3758313d0ebeb768d1eb7ce0c, and worked on it on my side. My PR actually did not retrieved correctly error messages from custom attributes.

This new PR fixes retrieval of error in custom attributes that returns the error message from the `ValidationResult` instead of a property hosted on the attribute itself. Moreover, it enables support of `For` & DataValidation even out of an `EditContext`.

Test included.