### PR TITLE
Add disabled property for MudLink

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Link/Examples/LinkSimpleExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Link/Examples/LinkSimpleExample.razor
@@ -2,3 +2,4 @@
 
 <MudLink Href="#">Default</MudLink>
 <MudLink Href="#" Typo="Typo.body2">Different Typography</MudLink>
+<MudLink Href="#" Disabled="true">Disabled link</MudLink>

--- a/src/MudBlazor.UnitTests/Components/LinkTests.cs
+++ b/src/MudBlazor.UnitTests/Components/LinkTests.cs
@@ -1,0 +1,37 @@
+﻿#pragma warning disable CS1998 // async without await
+#pragma warning disable IDE1006 // leading underscore
+
+using System;
+using System.Threading.Tasks;
+using Bunit;
+using FluentAssertions;
+using NUnit.Framework;
+using static Bunit.ComponentParameterFactory;
+
+namespace MudBlazor.UnitTests.Components
+{
+    [TestFixture]
+    public class LinkTests
+    {
+        private Bunit.TestContext ctx;
+
+        [SetUp]
+        public void Setup()
+        {
+            ctx = new Bunit.TestContext();
+            ctx.AddTestServices();
+        }
+
+        [Test]
+        public async Task NavLink_CheckDisabled()
+        {
+            var comp = ctx.RenderComponent<MudLink>(new[]
+            {
+                Parameter(nameof(MudLink.Href), "#"),
+                Parameter(nameof(MudLink.Disabled), true)
+            });
+            Console.WriteLine(comp.Markup);
+            comp.Find("a").GetAttribute("href").Should().BeNullOrEmpty();
+        }
+    }
+}

--- a/src/MudBlazor/Components/Link/MudLink.razor
+++ b/src/MudBlazor/Components/Link/MudLink.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
 
-<a @attributes="UserAttributes" class="@Classname" style="@Style" href="@Href" target="@Target">
+<a @attributes="Attributes" class="@Classname" style="@Style">
     @ChildContent
 </a>

--- a/src/MudBlazor/Components/Link/MudLink.razor.cs
+++ b/src/MudBlazor/Components/Link/MudLink.razor.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Components;
+﻿using System.Collections.Generic;
+using Microsoft.AspNetCore.Components;
 using MudBlazor.Extensions;
 using MudBlazor.Utilities;
 
@@ -11,8 +12,18 @@ namespace MudBlazor
            .AddClass($"mud-{Color.ToDescriptionString()}-text")
           .AddClass($"mud-link-underline-{Underline.ToDescriptionString()}")
           .AddClass($"mud-typography-{Typo.ToDescriptionString()}")
+          .AddClass($"mud-link-disabled", Disabled)
           .AddClass(Class)
         .Build();
+        
+        private Dictionary<string, object> Attributes
+        {
+            get => Disabled ? UserAttributes : new Dictionary<string, object>(UserAttributes)
+            {
+                { "href", Href },
+                { "target", Target }
+            };
+        }
 
         /// <summary>
         /// The color of the component. It supports the theme colors.
@@ -43,5 +54,10 @@ namespace MudBlazor
         /// Child content of component.
         /// </summary>
         [Parameter] public RenderFragment ChildContent { get; set; }
+
+        /// <summary>
+        /// If true, the navlink will be disabled.
+        /// </summary>
+        [Parameter] public bool Disabled { get; set; }
     }
 }

--- a/src/MudBlazor/Styles/components/_link.scss
+++ b/src/MudBlazor/Styles/components/_link.scss
@@ -15,4 +15,13 @@
     &.mud-link-underline-always {
         text-decoration: underline;
     }
+
+    &.mud-link-disabled {
+        cursor: default;
+        color: var(--mud-palette-action-disabled) !important;
+
+        &:not(.mud-link-underline-always) {
+            text-decoration: none;
+        }
+    }
 }


### PR DESCRIPTION
#1185 

I added a simple test too, however I don't know how to check for navigation events in bUnit. So instead I test that "href" attribute presents or not.