### PR TITLE
Add KeyXPreventDefault on MudInput

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/TextField/Examples/TextFieldSelectRangeExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TextField/Examples/TextFieldSelectRangeExample.razor
@@ -1,7 +1,5 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-
-
 <MudGrid>
     <MudItem xs="12" sm="12" md="12">
         <MudTextField @ref="multilineReference" T="string" Label="Multiline Select" Lines="3" Variant="Variant.Text" Text="@sampleText" />
@@ -22,7 +20,9 @@
 </MudGrid>
 
 @code
-{ private MudTextField<string> multilineReference;
-            private MudTextField<string> singleLineReference;
+{
+    private MudTextField<string> multilineReference;
+    private MudTextField<string> singleLineReference;
 
-            string sampleText = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."; }
+    string sampleText = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."; 
+}

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -153,6 +153,8 @@ namespace MudBlazor
             OnKeyDown.InvokeAsync(obj).AndForget();
         }
 
+        [Parameter] public bool KeyDownPreventDefault { get; set; }
+
         [Parameter] public EventCallback<KeyboardEventArgs> OnKeyPress { get; set; }
 
         protected virtual void InvokeKeyPress(KeyboardEventArgs obj)
@@ -161,6 +163,8 @@ namespace MudBlazor
             OnKeyPress.InvokeAsync(obj).AndForget();
         }
 
+        [Parameter] public bool KeyPressPreventDefault { get; set; }
+
         [Parameter] public EventCallback<KeyboardEventArgs> OnKeyUp { get; set; }
 
         protected virtual void InvokeKeyUp(KeyboardEventArgs obj)
@@ -168,6 +172,8 @@ namespace MudBlazor
             _isFocused = true;
             OnKeyUp.InvokeAsync(obj).AndForget();
         }
+
+        [Parameter] public bool KeyUpPreventDefault { get; set; }
 
         /// <summary>
         /// Fired when the Value property changes.

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -8,8 +8,10 @@
                          Error="@Error" ErrorText="@ErrorText" Disabled="@Disabled" @onclick="@ToggleMenu">
             <InputContent>
                 <MudInput T="string" @ref="_elementReference" InputType="InputType.Text" Variant="@Variant" @attributes="UserAttributes" Value="@Text" TextChanged="OnTextChanged" DisableUnderLine="@DisableUnderLine" Placeholder="@Placeholder" Disabled=@Disabled ReadOnly="@ReadOnly"
-                          Immediate="true" Margin="@Margin" Class="mud-select-input" Error="@Error" AdornmentIcon="@CurrentIcon" Adornment="Adornment.End" IconSize="Size.Medium" OnKeyDown="@this.OnInputKeyDown"
-                          OnBlur="@OnInputBlurred" OnKeyUp="@base.InvokeKeyUp" OnKeyPress="@base.InvokeKeyPress" autocomplete=@("mud-disabled-"+Guid.NewGuid()) />
+                          Immediate="true" Margin="@Margin" Class="mud-select-input" Error="@Error" AdornmentIcon="@CurrentIcon" Adornment="Adornment.End" IconSize="Size.Medium"
+                          OnBlur="@OnInputBlurred" OnKeyDown="@this.OnInputKeyDown" OnKeyPress="@base.InvokeKeyPress" OnKeyUp="@base.InvokeKeyUp" autocomplete=@("mud-disabled-"+Guid.NewGuid())
+                          KeyDownPreventDefault="KeyDownPreventDefault" KeyPressPreventDefault="KeyPressPreventDefault" KeyUpPreventDefault="KeyUpPreventDefault"
+                          />
             </InputContent>
         </MudInputControl>
         <MudPopover Open="@IsOpen" MaxHeight="@MaxHeight" OffsetY="true">

--- a/src/MudBlazor/Components/Input/MudInput.razor
+++ b/src/MudBlazor/Components/Input/MudInput.razor
@@ -9,29 +9,32 @@
         <MudInputAdornment Class="@AdornmentClassname" Icon="@AdornmentIcon" Color="@AdornmentColor" Size="@IconSize" Text="@AdornmentText" Edge="@Edge.Start" AdornmentClick="@OnAdornmentClick" />
     }
 
-    @if (Lines > 1)
-    {
-        @*note: the value="@Text" is absolutely essential here. the inner html @Text is kept only for compatibility*@
-        <textarea @ref="_elementReference" rows="@Lines" @attributes="UserAttributes" type="@InputTypeString" class="@InputClassname" placeholder="@Placeholder" disabled=@Disabled readonly="@ReadOnly"
-                  @oninput="OnInput" @onchange="OnChange" @onblur="@OnBlurred" @onkeydown="@InvokeKeyDown" @onkeypress="@InvokeKeyPress" @onkeyup="@InvokeKeyUp" value="@Text">@Text</textarea>
-    }
-    else
-    {
-        @if (InputType == InputType.Hidden && ChildContent != null)
-        {
-            <div class="@InputClassname">
-                @ChildContent
-            </div>
-        }
+	@if (Lines > 1)
+	{
+		@*note: the value="@Text" is absolutely essential here. the inner html @Text is kept only for compatibility*@
+	 <textarea @ref="_elementReference" rows="@Lines" @attributes="UserAttributes" type="@InputTypeString" class="@InputClassname" placeholder="@Placeholder" disabled=@Disabled readonly="@ReadOnly"
+			  @oninput="OnInput" @onchange="OnChange" @onblur="@OnBlurred" @onkeydown="@InvokeKeyDown" @onkeypress="@InvokeKeyPress" @onkeyup="@InvokeKeyUp" value="@Text"
+			  @onkeydown:preventDefault="@KeyDownPreventDefault" @onkeypress:preventDefault="@KeyPressPreventDefault" @onkeyup:preventDefault="@KeyUpPreventDefault">@Text</textarea>
+	}
+	else
+	{
+		@if (InputType == InputType.Hidden && ChildContent != null)
+		{
+		 <div class="@InputClassname">
+				@ChildContent
+		 </div>
+		}
 
-        <input @ref="_elementReference" @attributes="UserAttributes" type="@InputTypeString" class="@InputClassname" value="@Text" @oninput="OnInput" @onchange="OnChange"
-               placeholder="@Placeholder" disabled=@Disabled readonly="@ReadOnly" @onblur="@OnBlurred" @onkeydown="@InvokeKeyDown" @onkeypress="@InvokeKeyPress" @onkeyup="@InvokeKeyUp" />
-    }
+	 <input @ref="_elementReference" @attributes="UserAttributes" type="@InputTypeString" class="@InputClassname" value="@Text" @oninput="OnInput" @onchange="OnChange"
+		   placeholder="@Placeholder" disabled=@Disabled readonly="@ReadOnly" @onblur="@OnBlurred"
+		   @onkeydown="@InvokeKeyDown" @onkeypress="@InvokeKeyPress" @onkeyup="@InvokeKeyUp"
+		   @onkeydown:preventDefault="KeyDownPreventDefault" @onkeypress:preventDefault="@KeyPressPreventDefault" @onkeyup:preventDefault="@KeyUpPreventDefault" />
+	}
 
-    @if (Adornment == Adornment.End)
-    {
-        <MudInputAdornment Class="@AdornmentClassname" Icon="@AdornmentIcon" Color="@AdornmentColor" Size="@IconSize" Text="@AdornmentText" Edge="@Edge.End" AdornmentClick="@OnAdornmentClick" />
-    }
+	@if (Adornment == Adornment.End)
+	{
+	 <MudInputAdornment Class="@AdornmentClassname" Icon="@AdornmentIcon" Color="@AdornmentColor" Size="@IconSize" Text="@AdornmentText" Edge="@Edge.End" AdornmentClick="@OnAdornmentClick" />
+	}
 
     @if (Variant == Variant.Outlined)
     {

--- a/src/MudBlazor/Components/TextField/MudTextField.razor
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor
@@ -7,7 +7,8 @@
         <InputContent>
             <MudInput T="string" @ref="_elementReference" @attributes="UserAttributes" InputType="@InputType" Lines="@Lines" Style="@Style" Variant="@Variant" Value="@Text" ValueChanged="(s) => SetTextAsync(s)" Placeholder="@Placeholder" Disabled=@Disabled DisableUnderLine="@DisableUnderLine" ReadOnly="@ReadOnly"
                       Adornment="@Adornment" AdornmentText="@AdornmentText" AdornmentIcon="@AdornmentIcon" AdornmentColor="@AdornmentColor" IconSize="@IconSize" OnAdornmentClick="@OnAdornmentClick" Error="@Error" Immediate="@Immediate" Margin="@Margin"
-                      OnBlur="@OnBlurred" OnKeyDown="@InvokeKeyDown" OnKeyPress="@InvokeKeyPress" OnKeyUp="@InvokeKeyUp" />
+                      OnBlur="@OnBlurred" OnKeyDown="@InvokeKeyDown" OnKeyPress="@InvokeKeyPress" OnKeyUp="@InvokeKeyUp"
+                      KeyDownPreventDefault="KeyDownPreventDefault" KeyPressPreventDefault="KeyPressPreventDefault" KeyUpPreventDefault="KeyUpPreventDefault" />
         </InputContent>
     </MudInputControl>
 </CascadingValue>


### PR DESCRIPTION
Added 3 new properteis on MudInput, associated with keyboard events:

- KeyDownPreventDefault
- KeyPressPreventDefault
- KeyUpPreventDefault

These 3 events are wired on the respective event `@onkeydown:preventDefault` on the input tag.
If true, the browser won't propagate the event on the underlying tag, for example in this case:
https://try.mudblazor.com/snippet/GEmPEdvHuYdBHBPy

If the user press the arrow up key, it won't be propagated (line 23) and thus the value won't be incremented. If the user types a number or the arrow down key, it will work as usual.


Note: #1000 requires this to implement the final piece.