### PR TITLE
Add Title to MudIcon and fix issue #1190

### DIFF
--- a/src/MudBlazor.Docs/Components/DocsIconPanel.razor
+++ b/src/MudBlazor.Docs/Components/DocsIconPanel.razor
@@ -1,7 +1,7 @@
 ﻿
 <div class="docs-icon-panel">
     <div class="docs-icon-panel-inner">
-        <MudIcon Icon="@Code" />
+        <MudIcon Icon="@Code" Title="@Name" />
         <MudText Typo="Typo.caption">
             @Name
         </MudText>

--- a/src/MudBlazor.Docs/Pages/Components/Icons/Examples/IconsUsageExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Icons/Examples/IconsUsageExample.razor
@@ -1,8 +1,8 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudIcon Icon="@Icons.Material.Filled.Favorite" />
-<MudIcon Icon="@Icons.Material.Filled.Api" />
-<MudIcon Icon="@Icons.Material.Filled.AddCircle" />
-<MudIcon Icon="@Icons.Custom.Brands.GitHub" />
-<MudIcon Icon="@Icons.Custom.Brands.Google" />
-<MudIcon Icon="@Icons.Custom.Brands.Reddit" />
+<MudIcon Icon="@Icons.Material.Filled.Favorite" Title="Favorite" />
+<MudIcon Icon="@Icons.Material.Filled.Api" Title="API" />
+<MudIcon Icon="@Icons.Material.Filled.AddCircle" Title="Add" />
+<MudIcon Icon="@Icons.Custom.Brands.GitHub" Title="GitHub" />
+<MudIcon Icon="@Icons.Custom.Brands.Google" Title="Google" />
+<MudIcon Icon="@Icons.Custom.Brands.Reddit" Title="Reddit" />

--- a/src/MudBlazor.Docs/Pages/Components/Icons/IconsPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Icons/IconsPage.razor
@@ -17,6 +17,8 @@
         <DocsPageSection>
             <SectionHeader>
                 <Title>Usage</Title>
+                <Description>MudIcon component shows the specified icon with the chosen style. You can use the Title attribute to improve accessibility with screen readers and show a tooltip on mouse over.</Description>
+
             </SectionHeader>
             <SectionContent Outlined="true">
                 <IconsUsageExample />

--- a/src/MudBlazor.Docs/Styles/components/_icons.scss
+++ b/src/MudBlazor.Docs/Styles/components/_icons.scss
@@ -12,7 +12,7 @@
 
 .docs-icon-panel {
     height: 120px;
-    width: 120px;
+    width: 90px;
     padding: 20px 10px;
     display: inline-block;
     text-align: center;

--- a/src/MudBlazor.Docs/Styles/components/_icons.scss
+++ b/src/MudBlazor.Docs/Styles/components/_icons.scss
@@ -1,6 +1,8 @@
 ﻿
 .docs-icon-container {
     margin-top: 20px;
+    display: flex;
+    flex-wrap: wrap;
 
     & .mud-divider {
         margin-bottom: 20px;
@@ -10,7 +12,7 @@
 
 .docs-icon-panel {
     height: 120px;
-    width: 20;
+    width: 120px;
     padding: 20px 10px;
     display: inline-block;
     text-align: center;

--- a/src/MudBlazor/Components/Icon/MudIcon.razor
+++ b/src/MudBlazor/Components/Icon/MudIcon.razor
@@ -4,10 +4,15 @@
 @if (!string.IsNullOrEmpty(Icon) && Icon.Trim().StartsWith(("<")))
 {
     <svg @attributes="UserAttributes" class="@Classname" style="@Style" focusable="false" viewBox="@ViewBox" aria-hidden="true">
+        @if (Title != null)
+        {
+            <title>@Title</title>
+        }
+
         @((MarkupString)@Icon)
     </svg>
 }
 else
 {
-    <span class="@($"{Classname} {Icon}")" style="@Style" />
+    <span class="@($"{Classname} {Icon}")" style="@Style" title="@Title" />
 }

--- a/src/MudBlazor/Components/Icon/MudIcon.razor.cs
+++ b/src/MudBlazor/Components/Icon/MudIcon.razor.cs
@@ -22,6 +22,11 @@ namespace MudBlazor
         [Parameter] public string Icon { get; set; }
 
         /// <summary>
+        /// Title of the icon used for accessibility.
+        /// </summary>
+        [Parameter] public string Title { get; set; }
+
+        /// <summary>
         /// The Size of the icon.
         /// </summary>
         [Parameter] public Size Size { get; set; } = Size.Medium;


### PR DESCRIPTION
Add title property to MudIcon for accessibility options.
It also fixed issue #1190, slightly reworking the page from always having 5 columns to using a flexbox with fixed width for every icon.
Every icon now also show the name in the tooltip, for when it's too long and gets truncated.