### PR TITLE
Add customizable Table header and footer

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableHeaderAndFooterExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableHeaderAndFooterExample.razor
@@ -1,0 +1,67 @@
+﻿@using System.Net.Http.Json
+@using MudBlazor.Examples.Data.Models
+@namespace MudBlazor.Docs.Examples
+@inject HttpClient httpClient
+
+<style type="text/css">
+    .mud-table-head .header-centered th {
+        text-align: center;
+        font-size: 1.2em;
+    }
+
+   .mud-table-foot .bold-text .mud-table-cell {
+       font-weight: 500;
+   }
+</style>
+
+<MudTable Items="@Elements.Take(10)" MultiSelection="true" @bind-SelectedItems="selectedItems" Hover="true" Breakpoint="Breakpoint.Sm" Striped="true" Bordered="true"
+          MultiRowHeader="true" MultiRowFooter="true" HeaderClass="table-head-bordered" FooterClass="table-foot-bordered">
+    <HeaderContent>
+        <MudTHeadRow IgnoreCheckbox="true" Class="header-centered">
+            <MudTh colspan="6">Periodic Elements Info</MudTh>
+        </MudTHeadRow>
+        <MudTHeadRow Class="header-centered">
+            <MudTh colspan="2">Basic</MudTh>
+            <MudTh colspan="3">Extended</MudTh>
+        </MudTHeadRow>
+        <MudTHeadRow IsCheckable="true">
+            <MudTh>Nr</MudTh>Changed
+            <MudTh>Sign</MudTh>
+            <MudTh>Name</MudTh>
+            <MudTh>Position</MudTh>
+            <MudTh>Molar mass</MudTh>
+        </MudTHeadRow>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd DataLabel="Nr">@context.Number</MudTd>
+        <MudTd DataLabel="Sign">@context.Sign</MudTd>
+        <MudTd DataLabel="Name">@context.Name</MudTd>
+        <MudTd DataLabel="Position" HideSmall="_hidePosition">@context.Position</MudTd>
+        <MudTd DataLabel="Molar mass">@context.Molar</MudTd>
+    </RowTemplate>
+    <FooterContent>
+        <MudTFootRow Class="bold-text">
+            <MudTd>Nr</MudTd>
+            <MudTd>Sign</MudTd>
+            <MudTd>Name</MudTd>
+            <MudTd>Position</MudTd>
+            <MudTd>Molar mass</MudTd>
+        </MudTFootRow>
+        <MudTFootRow IsCheckable="true">
+            <MudTd colspan="5">Selected: @selectedItems.Count</MudTd>
+        </MudTFootRow>
+    </FooterContent>
+</MudTable>
+
+<MudSwitch @bind-Checked="_hidePosition">Hide <b>position</b> when Breakpoint=Xs</MudSwitch>
+
+@code {
+    private bool _hidePosition;
+    private IEnumerable<Element> Elements = new List<Element>();
+    private HashSet<Element> selectedItems = new HashSet<Element>();
+
+    protected override async Task OnInitializedAsync()
+    {
+        Elements = await httpClient.GetFromJsonAsync<List<Element>>("webapi/periodictable");
+    }
+}

--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableHeaderAndFooterExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableHeaderAndFooterExample.razor
@@ -15,7 +15,7 @@
 </style>
 
 <MudTable Items="@Elements.Take(10)" MultiSelection="true" @bind-SelectedItems="selectedItems" Hover="true" Breakpoint="Breakpoint.Sm" Striped="true" Bordered="true"
-          MultiRowHeader="true" MultiRowFooter="true" HeaderClass="table-head-bordered" FooterClass="table-foot-bordered">
+          CustomHeader="true" CustomFooter="true" HeaderClass="table-head-bordered" FooterClass="table-foot-bordered">
     <HeaderContent>
         <MudTHeadRow IgnoreCheckbox="true" Class="header-centered">
             <MudTh colspan="6">Periodic Elements Info</MudTh>
@@ -25,7 +25,7 @@
             <MudTh colspan="3">Extended</MudTh>
         </MudTHeadRow>
         <MudTHeadRow IsCheckable="true">
-            <MudTh>Nr</MudTh>Changed
+            <MudTh>Nr</MudTh> 
             <MudTh>Sign</MudTh>
             <MudTh>Name</MudTh>
             <MudTh>Position</MudTh>

--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableMultiSelectExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableMultiSelectExample.razor
@@ -21,6 +21,9 @@
     <PagerContent>
         <MudTablePager PageSizeOptions="new int[]{50, 100}" />
     </PagerContent>
+    <FooterContent>
+        <MudTd colspan="5">Select All</MudTd>
+    </FooterContent>
 </MudTable>
 <MudText Inline="true">Selected items: @(selectedItems==null ? "" : string.Join(", ", selectedItems.OrderBy(x=>x.Sign).Select(x=>x.Sign)))</MudText>
 

--- a/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
@@ -122,11 +122,11 @@
             <SectionHeader>
                 <Title>Header and Footer</Title>
                 <Description>
-                    By default you can put a list of <CodeInline>MudTh</CodeInline> inside <CodeInline>HeaderContent</CodeInline> and <CodeInline>MudTd</CodeInline> inside <CodeInline>FooterContent</CodeInline>, in that case MudTable will automatically manage the row for you, including the select all column and editing column placeholder.<br />
-                    If you prefer to customize the behavior, as well as drawing multiple header or footer rows, you can set the <CodeInline>MultiRowHeader</CodeInline> and <CodeInline>MultiRowFooter</CodeInline> to true.<br />
-                    Then you will need to specify a list of <CodeInline>MudTHeadRow</CodeInline> or <CodeInline>MudTFootRow</CodeInline> with their respective cells.
+                    By default you can put a list of <CodeInline>&lt;MudTh></CodeInline> inside <CodeInline>&lt;HeaderContent></CodeInline> and <CodeInline>&lt;MudTd></CodeInline> inside <CodeInline>&lt;FooterContent></CodeInline>, MudTable will automatically manage the table row for you, including the select-all column and adding an empty column for editable tables.<br />
+                    If you need to customize the behavior, as well as rendering multiple header or footer rows, you can set the <CodeInline>MultiRowHeader</CodeInline> and <CodeInline>MultiRowFooter</CodeInline> attributes to true.<br />
+                    Then setting a list of <CodeInline>&lt;MudTHeadRow></CodeInline> or <CodeInline>&lt;MudTFootRow></CodeInline> with their respective cells will render exactly what required inside the table header and footer.
                     <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">
-                        Note: Unless you specify the attribute <CodeInline>IsCheckeable</CodeInline> for a specific row, the MudTable won't render a checkbox in case of a multi-selection table.
+                        Note: Unless you specify the attribute <CodeInline>IsCheckeable</CodeInline> for a specific row, MudTable won't render a checkbox in case of a multi-selection table.
                         Attributes <CodeInline>IgnoreCheckbox</CodeInline> and <CodeInline>IgnoreEditable</CodeInline> won't render an empty cell either, requiring you to do it manually (for example for a colspan on the entire row).
                     </MudAlert>
                 </Description>

--- a/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
@@ -120,6 +120,25 @@
 
         <DocsPageSection>
             <SectionHeader>
+                <Title>Header and Footer</Title>
+                <Description>
+                    By default you can put a list of <CodeInline>MudTh</CodeInline> inside <CodeInline>HeaderContent</CodeInline> and <CodeInline>MudTd</CodeInline> inside <CodeInline>FooterContent</CodeInline>, in that case MudTable will automatically manage the row for you, including the select all column and editing column placeholder.<br />
+                    If you prefer to customize the behavior, as well as drawing multiple header or footer rows, you can set the <CodeInline>MultiRowHeader</CodeInline> and <CodeInline>MultiRowFooter</CodeInline> to true.<br />
+                    Then you will need to specify a list of <CodeInline>MudTHeadRow</CodeInline> or <CodeInline>MudTFootRow</CodeInline> with their respective cells.
+                    <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">
+                        Note: Unless you specify the attribute <CodeInline>IsCheckeable</CodeInline> for a specific row, the MudTable won't render a checkbox in case of a multi-selection table.
+                        Attributes <CodeInline>IgnoreCheckbox</CodeInline> and <CodeInline>IgnoreEditable</CodeInline> won't render an empty cell either, requiring you to do it manually (for example for a colspan on the entire row).
+                    </MudAlert>
+                </Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" FullWidth="true">
+                <TableHeaderAndFooterExample />
+            </SectionContent>
+            <SectionSource Code="TableHeaderAndFooterExample" ShowCode="false" GitHubFolderName="Table" />
+        </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader>
                 <Title>Table With related data</Title>
                 <Description>
                     Making use of the <CodeInline>&lt;ChildRowContent&gt;</CodeInline> allows more control over the layout for scenarios such as showing the related address data for each person below.

--- a/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
@@ -123,7 +123,7 @@
                 <Title>Header and Footer</Title>
                 <Description>
                     By default you can put a list of <CodeInline>&lt;MudTh></CodeInline> inside <CodeInline>&lt;HeaderContent></CodeInline> and <CodeInline>&lt;MudTd></CodeInline> inside <CodeInline>&lt;FooterContent></CodeInline>, MudTable will automatically manage the table row for you, including the select-all column and adding an empty column for editable tables.<br />
-                    If you need to customize the behavior, as well as rendering multiple header or footer rows, you can set the <CodeInline>MultiRowHeader</CodeInline> and <CodeInline>MultiRowFooter</CodeInline> attributes to true.<br />
+                    If you need to customize the behavior, as well as rendering multiple header or footer rows, you can set the <CodeInline>CustomHeader</CodeInline> and <CodeInline>CustomFooter</CodeInline> attributes to true.<br />
                     Then setting a list of <CodeInline>&lt;MudTHeadRow></CodeInline> or <CodeInline>&lt;MudTFootRow></CodeInline> with their respective cells will render exactly what required inside the table header and footer.
                     <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">
                         Note: Unless you specify the attribute <CodeInline>IsCheckeable</CodeInline> for a specific row, MudTable won't render a checkbox in case of a multi-selection table.

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelectionTest2B.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelectionTest2B.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudText>SelectedItems { @string.Join(", ", selectedItems) }</MudText>
-<MudTable Items="items" @bind-SelectedItems="selectedItems" MultiSelection="true" MultiRowHeader="true">
+<MudTable Items="items" @bind-SelectedItems="selectedItems" MultiSelection="true" CustomHeader="true">
     <HeaderContent>
         <MudTHeadRow IsCheckable="true">
             <MudTh>#</MudTh>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelectionTest2B.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelectionTest2B.razor
@@ -1,0 +1,20 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudText>SelectedItems { @string.Join(", ", selectedItems) }</MudText>
+<MudTable Items="items" @bind-SelectedItems="selectedItems" MultiSelection="true" MultiRowHeader="true">
+    <HeaderContent>
+        <MudTHeadRow IsCheckable="true">
+            <MudTh>#</MudTh>
+        </MudTHeadRow>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd>@context</MudTd>
+    </RowTemplate>
+</MudTable>
+
+@code {
+    public static string __description__ = "the selected items (check-box click or row click) should be represented in SelectedItems.";
+
+    int[] items = new int[]{0,1,2};
+    HashSet<int> selectedItems=new HashSet<int>();
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelectionTest6.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelectionTest6.razor
@@ -1,0 +1,21 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudText>SelectedItems { @string.Join(", ", selectedItems) }</MudText>
+<MudTable Items="items" @bind-SelectedItems="selectedItems" MultiSelection="true">
+    <HeaderContent>
+        <MudTh>#</MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd>@context</MudTd>
+    </RowTemplate>
+    <FooterContent>
+        <MudTd>F</MudTd>
+    </FooterContent>
+</MudTable>
+
+@code {
+    public static string __description__ = "the selected items (check-box click or row click) should be represented in SelectedItems.";
+
+    int[] items = new int[]{0,1,2};
+    HashSet<int> selectedItems=new HashSet<int>();
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelectionTest6B.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelectionTest6B.razor
@@ -1,0 +1,23 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudText>SelectedItems { @string.Join(", ", selectedItems) }</MudText>
+<MudTable Items="items" @bind-SelectedItems="selectedItems" MultiSelection="true" MultiRowFooter="true">
+    <HeaderContent>
+        <MudTh>#</MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd>@context</MudTd>
+    </RowTemplate>
+    <FooterContent>
+        <MudTFootRow IsCheckable="true">
+            <MudTd>F</MudTd>
+        </MudTFootRow>
+    </FooterContent>
+</MudTable>
+
+@code {
+    public static string __description__ = "the selected items (check-box click or row click) should be represented in SelectedItems.";
+
+    int[] items = new int[]{0,1,2};
+    HashSet<int> selectedItems=new HashSet<int>();
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelectionTest6B.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelectionTest6B.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudText>SelectedItems { @string.Join(", ", selectedItems) }</MudText>
-<MudTable Items="items" @bind-SelectedItems="selectedItems" MultiSelection="true" MultiRowFooter="true">
+<MudTable Items="items" @bind-SelectedItems="selectedItems" MultiSelection="true" CustomFooter="true">
     <HeaderContent>
         <MudTh>#</MudTh>
     </HeaderContent>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableRowClickTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableRowClickTest.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
-<MudTable T="int" Items="items" OnRowClick="@(args => OnRowClicked(args))" MultiRowHeader="true" MultiRowFooter="true">
+<MudTable T="int" Items="items" OnRowClick="@(args => OnRowClicked(args))" CustomHeader="true" CustomFooter="true">
     <HeaderContent>
         <MudTHeadRow OnRowClick="OnHeaderClicked">
             <MudTh>#</MudTh>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableRowClickTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableRowClickTest.razor
@@ -1,16 +1,23 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
-<MudTable T="int" Items="items" OnRowClick="@(args => OnRowClicked(args))">
+<MudTable T="int" Items="items" OnRowClick="@(args => OnRowClicked(args))" MultiRowHeader="true" MultiRowFooter="true">
     <HeaderContent>
-        <MudTh>#</MudTh>
+        <MudTHeadRow OnRowClick="OnHeaderClicked">
+            <MudTh>#</MudTh>
+        </MudTHeadRow>
     </HeaderContent>
     <RowTemplate>
         <MudTd>@context</MudTd>
     </RowTemplate>
+    <FooterContent>
+        <MudTFootRow OnRowClick="OnFooterClicked">
+            <MudTd>#</MudTd>
+        </MudTFootRow>
+    </FooterContent>
 </MudTable>
 
 <p>
-    @(string.Join(",",clicked_items))
+    @(string.Join(",", clicked_items))
 </p>
 
 @code {
@@ -18,6 +25,15 @@
 
     int[] items = new int[]{0,1,2};
     List<int> clicked_items = new List<int>();
+
+    private void OnHeaderClicked()
+    {
+        clicked_items.Add(-1);
+    }
+    private void OnFooterClicked()
+    {
+        clicked_items.Add(100);
+    }
 
     private void OnRowClicked(TableRowClickEventArgs<int> args )
     {

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -44,8 +44,10 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("p").TextContent.Trim().Should().Be("0,0");
             trs[2].Click();
             comp.Find("p").TextContent.Trim().Should().Be("0,0,1");
-            trs[0].Click(); // clicking the header row shouldn't to anything
-            comp.Find("p").TextContent.Trim().Should().Be("0,0,1");
+            //trs[0].Click(); // clicking the header should add -1
+            //comp.Find("p").TextContent.Trim().Should().Be("0,0,1,-1");
+            //trs[4].Click(); // clicking the header should add 100
+            //comp.Find("p").TextContent.Trim().Should().Be("0,0,1,-1,100");
         }
 
         /// <summary>
@@ -364,6 +366,40 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// checking the header checkbox should select all items (all checkboxes on, all items in SelectedItems) with multiheader
+        /// </summary>
+        [Test]
+        public void TableMultiSelectionTest2B()
+        {
+            var comp = ctx.RenderComponent<TableMultiSelectionTest2B>();
+            // print the generated html
+            Console.WriteLine(comp.Markup);
+            // select elements needed for the test
+            var table = comp.FindComponent<MudTable<int>>().Instance;
+            var text = comp.FindComponent<MudText>();
+            var checkboxes = comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).ToArray();
+            var tr = comp.FindAll("tr").ToArray();
+            tr.Length.Should().Be(4); // <-- one header, three rows
+            var th = comp.FindAll("th").ToArray();
+            th.Length.Should().Be(2); //  one for the checkbox, one for the header
+            var td = comp.FindAll("td").ToArray();
+            td.Length.Should().Be(6); // two td per row for multi selection
+            var inputs = comp.FindAll("input").ToArray();
+            inputs.Length.Should().Be(4); // one checkbox per row + one for the header
+            table.SelectedItems.Count.Should().Be(0); // selected items should be empty
+            // click header checkbox and verify selection text
+            inputs[0].Change(true);
+            table.SelectedItems.Count.Should().Be(3);
+            comp.Find("p").TextContent.Should().Be("SelectedItems { 0, 1, 2 }");
+            checkboxes.Sum(x => x.Checked ? 1 : 0).Should().Be(4);
+            inputs = comp.FindAll("input").ToArray();
+            inputs[0].Change(false);
+            table.SelectedItems.Count.Should().Be(0);
+            comp.Find("p").TextContent.Should().Be("SelectedItems {  }");
+            checkboxes.Sum(x => x.Checked ? 1 : 0).Should().Be(0);
+        }
+
+        /// <summary>
         /// Initially the values bound to SelectedItems should be selected
         /// </summary>
         [Test]
@@ -440,6 +476,74 @@ namespace MudBlazor.UnitTests.Components
             // now two checkboxes should be checked on page 2
             checkboxes = comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).ToArray();
             checkboxes.Sum(x => x.Checked ? 1 : 0).Should().Be(2);
+        }
+
+        /// <summary>
+        /// checking the footer checkbox should select all items (all checkboxes on, all items in SelectedItems) with multiheader
+        /// </summary>
+        [Test]
+        public void TableMultiSelectionTest6()
+        {
+            var comp = ctx.RenderComponent<TableMultiSelectionTest6>();
+            // print the generated html
+            Console.WriteLine(comp.Markup);
+            // select elements needed for the test
+            var table = comp.FindComponent<MudTable<int>>().Instance;
+            var text = comp.FindComponent<MudText>();
+            var checkboxes = comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).ToArray();
+            var tr = comp.FindAll("tr").ToArray();
+            tr.Length.Should().Be(5); // <-- one header, three rows, one footer
+            var th = comp.FindAll("th").ToArray();
+            th.Length.Should().Be(2); //  one for the checkbox, one for the header
+            var td = comp.FindAll("td").ToArray();
+            td.Length.Should().Be(8); // two td per row for multi selection + two for footer
+            var inputs = comp.FindAll("input").ToArray();
+            inputs.Length.Should().Be(5); // one checkbox per row + one for the header + 1 for the footer
+            table.SelectedItems.Count.Should().Be(0); // selected items should be empty
+            // click footer checkbox and verify selection text
+            inputs[4].Change(true);
+            table.SelectedItems.Count.Should().Be(3);
+            comp.Find("p").TextContent.Should().Be("SelectedItems { 0, 1, 2 }");
+            checkboxes.Sum(x => x.Checked ? 1 : 0).Should().Be(5);
+            inputs = comp.FindAll("input").ToArray();
+            inputs[4].Change(false);
+            table.SelectedItems.Count.Should().Be(0);
+            comp.Find("p").TextContent.Should().Be("SelectedItems {  }");
+            checkboxes.Sum(x => x.Checked ? 1 : 0).Should().Be(0);
+        }
+
+        /// <summary>
+        /// checking the footer checkbox should select all items (all checkboxes on, all items in SelectedItems) with multiheader
+        /// </summary>
+        [Test]
+        public void TableMultiSelectionTest6B()
+        {
+            var comp = ctx.RenderComponent<TableMultiSelectionTest6B>();
+            // print the generated html
+            Console.WriteLine(comp.Markup);
+            // select elements needed for the test
+            var table = comp.FindComponent<MudTable<int>>().Instance;
+            var text = comp.FindComponent<MudText>();
+            var checkboxes = comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).ToArray();
+            var tr = comp.FindAll("tr").ToArray();
+            tr.Length.Should().Be(5); // <-- one header, three rows
+            var th = comp.FindAll("th").ToArray();
+            th.Length.Should().Be(2); //  one for the checkbox, one for the header
+            var td = comp.FindAll("td").ToArray();
+            td.Length.Should().Be(8); // two td per row for multi selection + 2 footer
+            var inputs = comp.FindAll("input").ToArray();
+            inputs.Length.Should().Be(5); // one checkbox per row + one for the header + 1 for the footer
+            table.SelectedItems.Count.Should().Be(0); // selected items should be empty
+            // click footer checkbox and verify selection text
+            inputs[4].Change(true);
+            table.SelectedItems.Count.Should().Be(3);
+            comp.Find("p").TextContent.Should().Be("SelectedItems { 0, 1, 2 }");
+            checkboxes.Sum(x => x.Checked ? 1 : 0).Should().Be(5);
+            inputs = comp.FindAll("input").ToArray();
+            inputs[4].Change(false);
+            table.SelectedItems.Count.Should().Be(0);
+            comp.Find("p").TextContent.Should().Be("SelectedItems {  }");
+            checkboxes.Sum(x => x.Checked ? 1 : 0).Should().Be(0);
         }
 
         /// <summary>

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -44,10 +44,10 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("p").TextContent.Trim().Should().Be("0,0");
             trs[2].Click();
             comp.Find("p").TextContent.Trim().Should().Be("0,0,1");
-            //trs[0].Click(); // clicking the header should add -1
-            //comp.Find("p").TextContent.Trim().Should().Be("0,0,1,-1");
-            //trs[4].Click(); // clicking the header should add 100
-            //comp.Find("p").TextContent.Trim().Should().Be("0,0,1,-1,100");
+            trs[0].Click(); // clicking the header should add -1
+            comp.Find("p").TextContent.Trim().Should().Be("0,0,1,-1");
+            trs[4].Click(); // clicking the header should add 100
+            comp.Find("p").TextContent.Trim().Should().Be("0,0,1,-1,100");
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/Table/MudTFootRow.razor
+++ b/src/MudBlazor/Components/Table/MudTFootRow.razor
@@ -1,0 +1,22 @@
+﻿@namespace MudBlazor
+@implements IDisposable
+@inherits MudComponentBase
+
+<tr class="@Classname" @onclick="@OnRowClick" style="@Style" @attributes="@UserAttributes">
+    @if ((Context?.Table.MultiSelection ?? false) && !IgnoreCheckbox)
+    {
+        <MudTd>
+            @if (IsCheckable)
+            {
+                <MudCheckBox @bind-Checked="IsChecked" />
+            }
+        </MudTd>
+    }
+    @ChildContent
+    @if((Context?.Table.IsEditable ?? false) && !IgnoreEditable)
+    {
+        <MudTd />
+    }
+</tr>
+
+

--- a/src/MudBlazor/Components/Table/MudTFootRow.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTFootRow.razor.cs
@@ -1,0 +1,75 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using MudBlazor.Utilities;
+
+namespace MudBlazor
+{
+    public partial class MudTFootRow : MudComponentBase
+    {
+        protected string Classname => new CssBuilder("mud-table-row")
+            .AddClass(Class).Build();
+
+        [CascadingParameter] public TableContext Context { get; set; }
+
+        [Parameter] public RenderFragment ChildContent { get; set; }
+
+        /// <summary>
+        /// Add a multi-select checkbox that will select/unselect every item in the table
+        /// </summary>
+        [Parameter] public bool IsCheckable { get; set; }
+
+        /// <summary>
+        /// Specify behavior in case the table is multi-select mode. If set to <code>true</code>, it won't render an edditional empty column.
+        /// </summary>
+        [Parameter] public bool IgnoreCheckbox { get; set; }
+
+        /// <summary>
+        /// Specify behavior in case the table is editable. If set to <code>true</code>, it won't render an edditional empty column.
+        /// </summary>
+        [Parameter] public bool IgnoreEditable { get; set; }
+
+        /// <summary>
+        /// On click event
+        /// </summary>
+        [Parameter] public EventCallback<MouseEventArgs> OnRowClick { get; set; }
+
+        private bool _checked;
+        public bool IsChecked
+        {
+            get => _checked;
+            set
+            {
+                if (value != _checked)
+                {
+                    _checked = value;
+                    if (IsCheckable)
+                        Context.Table.OnHeaderCheckboxClicked(value);
+                }
+            }
+        }
+
+        protected override Task OnInitializedAsync()
+        {
+            Context?.FooterRows.Add(this);
+            return base.OnInitializedAsync();
+        }
+
+        public void Dispose()
+        {
+            Context?.FooterRows.Remove(this);
+        }
+
+        public void SetChecked(bool b, bool notify)
+        {
+            if (notify)
+                IsChecked = b;
+            else
+            {
+                _checked = b;
+                if(IsCheckable)
+                    InvokeAsync(StateHasChanged);
+            }
+        }
+    }
+}

--- a/src/MudBlazor/Components/Table/MudTHeadRow.razor
+++ b/src/MudBlazor/Components/Table/MudTHeadRow.razor
@@ -1,0 +1,22 @@
+﻿@namespace MudBlazor
+@implements IDisposable
+@inherits MudComponentBase
+
+<tr class="@Classname" @onclick="@OnRowClick" style="@Style" @attributes="@UserAttributes">
+    @if ((Context?.Table.MultiSelection ?? false) && !IgnoreCheckbox)
+    {
+        <MudTh>
+            @if (IsCheckable)
+            {
+                <MudCheckBox @bind-Checked="IsChecked" />
+            }
+        </MudTh>
+    }
+    @ChildContent
+    @if((Context?.Table.IsEditable ?? false) && !IgnoreEditable)
+    {
+        <MudTh />
+    }
+</tr>
+
+

--- a/src/MudBlazor/Components/Table/MudTHeadRow.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTHeadRow.razor.cs
@@ -1,0 +1,76 @@
+﻿using System.Reflection.PortableExecutable;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using MudBlazor.Utilities;
+
+namespace MudBlazor
+{
+    public partial class MudTHeadRow : MudComponentBase
+    {
+        protected string Classname => new CssBuilder("mud-table-row")
+            .AddClass(Class).Build();
+
+        [CascadingParameter] public TableContext Context { get; set; }
+
+        [Parameter] public RenderFragment ChildContent { get; set; }
+
+        /// <summary>
+        /// Add a multi-select checkbox that will select/unselect every item in the table
+        /// </summary>
+        [Parameter] public bool IsCheckable { get; set; }
+
+        /// <summary>
+        /// Specify behavior in case the table is multi-select mode. If set to <code>true</code>, it won't render an edditional empty column.
+        /// </summary>
+        [Parameter] public bool IgnoreCheckbox { get; set; }
+
+        /// <summary>
+        /// Specify behavior in case the table is editable. If set to <code>true</code>, it won't render an edditional empty column.
+        /// </summary>
+        [Parameter] public bool IgnoreEditable { get; set; }
+
+        /// <summary>
+        /// On click event
+        /// </summary>
+        [Parameter] public EventCallback<MouseEventArgs> OnRowClick { get; set; }
+
+        private bool _checked;
+        public bool IsChecked
+        {
+            get => _checked;
+            set
+            {
+                if (value != _checked)
+                {
+                    _checked = value;
+                    if (IsCheckable)
+                        Context.Table.OnHeaderCheckboxClicked(value);
+                }
+            }
+        }
+
+        protected override Task OnInitializedAsync()
+        {
+            Context?.HeaderRows.Add(this);
+            return base.OnInitializedAsync();
+        }
+
+        public void Dispose()
+        {
+            Context?.HeaderRows.Remove(this);
+        }
+
+        public void SetChecked(bool b, bool notify)
+        {
+            if (notify)
+                IsChecked = b;
+            else
+            {
+                _checked = b;
+                if (IsCheckable)
+                    InvokeAsync(StateHasChanged);
+            }
+        }
+    }
+}

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -35,7 +35,7 @@
                 @if (HeaderContent != null)
                 {
                     <thead class="@HeadClassname">
-                        @if (MultiRowHeader)
+                        @if (CustomHeader)
                         {
                             @HeaderContent
                         }
@@ -79,7 +79,7 @@
                 @if (FooterContent != null)
                 {
                     <tfoot class="@FootClassname">
-                        @if (MultiRowFooter)
+                        @if (CustomFooter)
                         {
                             @FooterContent
                         }

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -34,10 +34,17 @@
                 }
                 @if (HeaderContent != null)
                 {
-                    <thead class="mud-table-head">
-                        <MudTr IsHeader="true" IsCheckable="MultiSelection" IsEditable="RowEditingTemplate != null" IsCheckedChanged="@OnHeaderCheckboxClicked" @ref="TableContext.HeaderRow">
+                    <thead class="@HeadClassname">
+                        @if (MultiRowHeader)
+                        {
                             @HeaderContent
-                        </MudTr>
+                        }
+                        else
+                        {
+                            <MudTHeadRow IsCheckable="MultiSelection">
+                                @HeaderContent
+                            </MudTHeadRow>
+                        }
                     </thead>
                 }
                 <tbody class="mud-table-body">
@@ -69,6 +76,21 @@
                         }
                     }
                 </tbody>
+                @if (FooterContent != null)
+                {
+                    <tfoot class="@FootClassname">
+                        @if (MultiRowFooter)
+                        {
+                            @FooterContent
+                        }
+                        else
+                        {
+                            <MudTFootRow IsCheckable="MultiSelection">
+                                @FooterContent
+                            </MudTFootRow>
+                        }
+                    </tfoot>
+                }
             </table>
         </div>
         @if (PagerContent != null)

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -241,7 +241,7 @@ namespace MudBlazor
             SelectedItemsChanged.InvokeAsync(SelectedItems);
         }
 
-        private void OnHeaderCheckboxClicked(bool value)
+        internal override void OnHeaderCheckboxClicked(bool value)
         {
             if (!value)
                 Context.Selection.Clear();
@@ -311,5 +311,7 @@ namespace MudBlazor
         {
             return InvokeServerLoadFunc();
         }
+
+        internal override bool IsEditable { get => RowEditingTemplate != null; }
     }
 }

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -141,14 +141,14 @@ namespace MudBlazor
         [Parameter] public RenderFragment ToolBarContent { get; set; }
 
         /// <summary>
-        /// Add MudTh cells here to define the table header. If <see cref="MultiRowHeader"/> is set, add one or more MudTHeadRow instead.
+        /// Add MudTh cells here to define the table header. If <see cref="CustomHeader"/> is set, add one or more MudTHeadRow instead.
         /// </summary>
         [Parameter] public RenderFragment HeaderContent { get; set; }
 
         /// <summary>
         /// Specify if the header has multiple rows. In that case, you need to provide the MudTHeadRow tags.
         /// </summary>
-        [Parameter] public bool MultiRowHeader { get; set; }
+        [Parameter] public bool CustomHeader { get; set; }
 
         /// <summary>
         /// Add a class to the thead tag
@@ -156,14 +156,14 @@ namespace MudBlazor
         [Parameter] public string HeaderClass { get; set; }
 
         /// <summary>
-        /// Add MudTd cells here to define the table footer. If<see cref="MultiRowFooter"/> is set, add one or more MudTFootRow instead.
+        /// Add MudTd cells here to define the table footer. If<see cref="CustomFooter"/> is set, add one or more MudTFootRow instead.
         /// </summary>
         [Parameter] public RenderFragment FooterContent { get; set; }
 
         /// <summary>
         /// Specify if the footer has multiple rows. In that case, you need to provide the MudTFootRow tags.
         /// </summary>
-        [Parameter] public bool MultiRowFooter { get; set; }
+        [Parameter] public bool CustomFooter { get; set; }
 
         /// <summary>
         /// Add a class to the tfoot tag

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -36,6 +36,11 @@ namespace MudBlazor
           .AddClass(Class)
         .Build();
 
+        protected string HeadClassname => new CssBuilder("mud-table-head")
+            .AddClass(HeaderClass).Build();
+        protected string FootClassname => new CssBuilder("mud-table-foot")
+            .AddClass(FooterClass).Build();
+
         /// <summary>
         /// The higher the number, the heavier the drop-shadow. 0 for no shadow.
         /// </summary>
@@ -136,9 +141,34 @@ namespace MudBlazor
         [Parameter] public RenderFragment ToolBarContent { get; set; }
 
         /// <summary>
-        /// Add MudTh cells here to define the table header.
+        /// Add MudTh cells here to define the table header. If <see cref="MultiRowHeader"/> is set, add one or more MudTHeadRow instead.
         /// </summary>
         [Parameter] public RenderFragment HeaderContent { get; set; }
+
+        /// <summary>
+        /// Specify if the header has multiple rows. In that case, you need to provide the MudTHeadRow tags.
+        /// </summary>
+        [Parameter] public bool MultiRowHeader { get; set; }
+
+        /// <summary>
+        /// Add a class to the thead tag
+        /// </summary>
+        [Parameter] public string HeaderClass { get; set; }
+
+        /// <summary>
+        /// Add MudTd cells here to define the table footer. If<see cref="MultiRowFooter"/> is set, add one or more MudTFootRow instead.
+        /// </summary>
+        [Parameter] public RenderFragment FooterContent { get; set; }
+
+        /// <summary>
+        /// Specify if the footer has multiple rows. In that case, you need to provide the MudTFootRow tags.
+        /// </summary>
+        [Parameter] public bool MultiRowFooter { get; set; }
+
+        /// <summary>
+        /// Add a class to the tfoot tag
+        /// </summary>
+        [Parameter] public string FooterClass { get; set; }
 
         /// <summary>
         /// Specifies a group of one or more columns in a table for formatting.
@@ -271,6 +301,10 @@ namespace MudBlazor
         internal abstract Task InvokeServerLoadFunc();
 
         internal abstract void FireRowClickEvent(MouseEventArgs args, MudTr mudTr, object item);
+
+        internal abstract void OnHeaderCheckboxClicked(bool value);
+
+        internal abstract bool IsEditable { get; }
 
         public Interfaces.IForm Validator { get; set; } = new TableRowValidator();
     }

--- a/src/MudBlazor/Components/Table/MudTr.razor
+++ b/src/MudBlazor/Components/Table/MudTr.razor
@@ -25,6 +25,10 @@
         {
             <MudTh />
         }
+        else if(IsFooter)
+        { 
+            <MudTd />
+        }
         else
         {
             @* Add datalabel as a placeholder to avoid jumps on small viewports *@

--- a/src/MudBlazor/Components/Table/MudTr.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTr.razor.cs
@@ -21,6 +21,7 @@ namespace MudBlazor
         [Parameter] public bool IsEditable { get; set; }
 
         [Parameter] public bool IsHeader { get; set; }
+        [Parameter] public bool IsFooter { get; set; }
 
         [Parameter]
         public EventCallback<bool> IsCheckedChanged { get; set; }

--- a/src/MudBlazor/Components/Table/TableContext.cs
+++ b/src/MudBlazor/Components/Table/TableContext.cs
@@ -15,7 +15,8 @@ namespace MudBlazor
         public abstract void Add(MudTr row, object item);
         public abstract void Remove(MudTr row, object item);
         public abstract void UpdateRowCheckBoxes(bool notify = true);
-        public MudTr HeaderRow { get; set; }
+        public List<MudTHeadRow> HeaderRows { get; set; } = new List<MudTHeadRow>();
+        public List<MudTFootRow> FooterRows { get; set; } = new List<MudTFootRow>();
 
         public abstract void InitializeSorting();
 
@@ -44,11 +45,17 @@ namespace MudBlazor
                 var item = pair.Key;
                 row.SetChecked(Selection.Contains(item), notify: notify);
             }
-            // update header checkbox
-            if (HeaderRow != null)
+            if (HeaderRows.Count > 0 || FooterRows.Count > 0)
             {
                 var itemsCount = Table.GetFilteredItemsCount();
-                HeaderRow.SetChecked(Selection.Count == itemsCount && itemsCount != 0, notify: false);
+                var b = Selection.Count == itemsCount && itemsCount != 0;
+                // update header checkbox
+                foreach (var header in HeaderRows)
+                    header.SetChecked(b, notify: false);
+
+                // update footer checkbox
+                foreach (var footer in FooterRows)
+                    footer.SetChecked(b, notify: false);
             }
         }
 

--- a/src/MudBlazor/Styles/components/_table.scss
+++ b/src/MudBlazor/Styles/components/_table.scss
@@ -38,14 +38,16 @@
     & .mud-table-body {
         display: table-row-group;
 
-        .mud-table-row:last-child {
-            .mud-table-cell {
-                border-bottom: none;
-            }
-        }
-
         & .mud-table-cell {
             color: var(--mud-palette-text-primary);
+        }
+    }
+
+    & .mud-table-body:last-child {
+        & .mud-table-row:last-child {
+            & .mud-table-cell {
+                border-bottom: none;
+            }
         }
     }
 }
@@ -119,7 +121,8 @@
         & .mud-table-cell {
             padding: 6px 24px 6px 16px;
         }
-        & .mud-table-cell:last-child{
+
+        & .mud-table-cell:last-child {
             padding-right: 16px;
         }
     }
@@ -127,6 +130,22 @@
 
 .mud-table-bordered {
     & .mud-table-container .mud-table-root .mud-table-body {
+        & .mud-table-row {
+            .mud-table-cell {
+                border-right: 1px solid var(--mud-palette-table-lines);
+            }
+        }
+    }
+
+    & .mud-table-container .mud-table-root .mud-table-head.table-head-bordered {
+        & .mud-table-row {
+            .mud-table-cell {
+                border-right: 1px solid var(--mud-palette-table-lines);
+            }
+        }
+    }
+
+    & .mud-table-container .mud-table-root .mud-table-foot.table-foot-bordered {
         & .mud-table-row {
             .mud-table-cell {
                 border-right: 1px solid var(--mud-palette-table-lines);
@@ -250,7 +269,7 @@
     padding-right: 2px;
 }
 
-.mud-table-pagination-spacer{
+.mud-table-pagination-spacer {
     flex: 1 1 100%;
 }
 
@@ -287,13 +306,14 @@
     margin-left: 20px;
 }
 
-.mud-table-smalldevices-sortselect{
-    display:none;
+.mud-table-smalldevices-sortselect {
+    display: none;
 }
 
 @mixin table-display-smalldevices ($breakpoint) {
     .mud-#{$breakpoint}table {
-        .mud-table-root .mud-table-head {
+        .mud-table-root .mud-table-head,
+        .mud-table-root .mud-table-foot {
             display: none;
         }
 
@@ -384,6 +404,7 @@
         }
     }
 }
+
 @media (max-width:416px) {
     .mud-table {
         .mud-table-pagination {
@@ -392,9 +413,10 @@
                 padding-top: 16px;
                 padding-right: 16px;
                 min-height: 100px;
-                .mud-table-pagination-actions{
-                    margin-left:auto;
-                    margin-right:-14px;
+
+                .mud-table-pagination-actions {
+                    margin-left: auto;
+                    margin-right: -14px;
                 }
             }
         }


### PR DESCRIPTION
This PR implements the proposal inside issue #1058 and it's proposed as an alternative to PR #1239 and Issue #1232 .

It provides functionality for a multi row header and footer, without requiring a new fragment and being 100% compatible with existing code.

**Existing implementation**
`MudTable.HeaderContent` requires the user to insert a list of MudTh, it automatically renders the content inside a `MudTr` component, and automatically implement a "check-all" feature in case of multi select, with an additional column on the left, and an empty column on the right in case of editable table (RowEditingTemplate != null).

**New implementation**
Created a new component `MudTHeadRow` that automatically provides all the functionality before implemented "manually" inside `MudTable` when it render a `MudTr` header tag.
If the user sets the new parameter `MudTable.CustomHeader="true"`, it doesn't render the MudTHeadRow component but simply renders the fragment. The user should provide one or more MudTHeadRow, specifying which row, if any, should be enabled to have a check-all checkbox, or even none, giving greater flexibility.
Implemented a new property `MudTable.HeaderClass`. to customize the css for `thead` tag.

The same changes have been made for the newly introduced `FooterContent`.

**Update**
Renamed "MultiRowHeader" to "CustomHeader" to be consistent in case of a custom single row (IE: remove the "check-all checkbox" from the header.