### PR TITLE
Added !important to colors utility classes

### DIFF
--- a/src/MudBlazor/Styles/abstracts/_colors.scss
+++ b/src/MudBlazor/Styles/abstracts/_colors.scss
@@ -41,17 +41,17 @@
 }
 
 .white {
-    background-color: #FFFFFF;
+    background-color: #FFFFFF !important;
 }
 .white-text {
-    color: #FFFFFF;
+    color: #FFFFFF !important;
 }
 
 .black {
-    background-color: #000000;
+    background-color: #000000 !important;
 }
 
 .black-text {
-    color: #000000;
+    color: #000000 !important;
 }
 


### PR DESCRIPTION
Color utility classes should have `!important` to have more specificity
This fixes #1272 