### PR TITLE
Improved Scrolling and Resizing for Tabs

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -288,7 +288,6 @@ dotnet_diagnostic.CA1822.severity = suggestion
 dotnet_diagnostic.CS1591.severity = none
 # IDE0071 Require file header 
 dotnet_diagnostic.IDE0073.severity = none
-file_header_template = Not Used
 # IDE0055: Fix formatting
 dotnet_diagnostic.IDE0055.severity = suggestion
 # IDE0044: Make field readonly

--- a/src/MudBlazor.Docs.Client/wwwroot/index.html
+++ b/src/MudBlazor.Docs.Client/wwwroot/index.html
@@ -30,8 +30,8 @@
     <meta name="msapplication-TileColor" content="#867af1">
     <meta name="theme-color" content="#ffffff">
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet" />
-    <link href="_content/MudBlazor/MudBlazor.min.css?v=5.0.6" rel="stylesheet" />
-    <link href="_content/MudBlazor.Docs/MudBlazorDocs.min.css?v=5.0.6" rel="stylesheet" />
+    <link href="_content/MudBlazor/MudBlazor.min.css?v=5.0.7" rel="stylesheet" />
+    <link href="_content/MudBlazor.Docs/MudBlazorDocs.min.css?v=5.0.7" rel="stylesheet" />
 </head>
 
 <body>
@@ -55,8 +55,8 @@
         <a href="" class="reload">Reload</a>
         <a class="dismiss">🗙</a>
     </div>
-    <script src="_content/MudBlazor/MudBlazor.min.js?v=5.0.6"></script>
-    <script src="_content/MudBlazor.Docs/JS/docs.js?v=5.0.6"></script>
+    <script src="_content/MudBlazor/MudBlazor.min.js?v=5.0.7"></script>
+    <script src="_content/MudBlazor.Docs/JS/docs.js?v=5.0.7"></script>
     <script src="_framework/blazor.webassembly.js"></script>
 </body>
 

--- a/src/MudBlazor.Docs.Server/Pages/_Host.cshtml
+++ b/src/MudBlazor.Docs.Server/Pages/_Host.cshtml
@@ -36,8 +36,8 @@
     <meta name="msapplication-TileColor" content="#867af1">
     <meta name="theme-color" content="#ffffff">
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet" />
-    <link href="_content/MudBlazor/MudBlazor.min.css?v=5.0.6" rel="stylesheet" />
-    <link href="_content/MudBlazor.Docs/MudBlazorDocs.min.css?v=5.0.6" rel="stylesheet" />
+    <link href="_content/MudBlazor/MudBlazor.min.css?v=5.0.7" rel="stylesheet" />
+    <link href="_content/MudBlazor.Docs/MudBlazorDocs.min.css?v=5.0.7" rel="stylesheet" />
 </head>
 <body>
     <app>
@@ -55,8 +55,8 @@
         <a class="dismiss">🗙</a>
     </div>
 
-    <script src="_content/MudBlazor/MudBlazor.min.js?v=5.0.6"></script>
-    <script src="_content/MudBlazor.Docs/JS/docs.js?v=5.0.6"></script>
+    <script src="_content/MudBlazor/MudBlazor.min.js?v=5.0.7"></script>
+    <script src="_content/MudBlazor.Docs/JS/docs.js?v=5.0.7"></script>
     <script src="_framework/blazor.server.js"></script>
 </body>
 </html>

--- a/src/MudBlazor.Docs/Pages/Components/NumericField/Examples/DebouncedNumericFieldExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/NumericField/Examples/DebouncedNumericFieldExample.razor
@@ -1,0 +1,42 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudGrid>
+    <MudItem xs="12" sm="6" md="4">
+        <MudNumericField @bind-Value="@_normal"
+                         Label="Normal"
+                         Variant="Variant.Outlined" />
+    </MudItem>
+    <MudItem xs="12" sm="6" md="4">
+        <MudNumericField @bind-Value="@_immediate"
+                         Label="Immediate"
+                         Variant="Variant.Outlined"
+                         Adornment="Adornment.End"
+                         Immediate="true" />
+    </MudItem>
+    <MudItem xs="12" sm="6" md="4">
+        <MudNumericField @bind-Value="@_debounced"
+                      Label="Debounced"
+                      Variant="Variant.Outlined"
+                      Adornment="Adornment.End"
+                      DebounceInterval="500"
+                      OnDebounceIntervalElapsed="HandleIntervalElapsed" />
+    </MudItem>
+</MudGrid>
+<div class="mt-3">
+    <MudText>Normal: @_normal</MudText>
+    <MudText>Immediate: @_immediate</MudText>
+    <MudText>Debounced: @_debounced</MudText>
+</div>
+
+
+@code {
+    int _normal;
+    int _immediate;
+    int _debounced;
+
+    void HandleIntervalElapsed(string debouncedText)
+    {
+        // at this stage, interval has elapsed
+        //Notice that debouncedText is string, not a number
+    }
+}

--- a/src/MudBlazor.Docs/Pages/Components/NumericField/Examples/NumericFieldAdornmentColorExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/NumericField/Examples/NumericFieldAdornmentColorExample.razor
@@ -1,0 +1,15 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudGrid>
+    <MudItem xs="12" sm="6">
+        <MudNumericField @bind-Value="Amount" Label="Amount" Variant="Variant.Outlined" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.AttachMoney" AdornmentColor="Color.Warning" />
+    </MudItem>
+    <MudItem xs="12" sm="6">
+        <MudNumericField @bind-Value="Weight" Label="Weight" Variant="Variant.Outlined" Adornment="Adornment.End" AdornmentText="Kg" AdornmentColor="Color.Info" />
+    </MudItem>
+</MudGrid>
+
+@code {
+    public decimal? Amount { get; set; }
+    public float? Weight { get; set; }
+}

--- a/src/MudBlazor.Docs/Pages/Components/NumericField/Examples/NumericFieldAdornmentsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/NumericField/Examples/NumericFieldAdornmentsExample.razor
@@ -1,0 +1,30 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudGrid>
+    <MudItem xs="12" sm="12" md="12">
+        <MudNumericField @bind-Value="Amount" Label="Amount" Variant="Variant.Text" Adornment="Adornment.Start" AdornmentText="Kr" />
+    </MudItem>
+    <MudItem xs="12" sm="6" md="4">
+        <MudNumericField @bind-Value="Amount" Label="Amount" Variant="Variant.Text" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.AttachMoney" />
+    </MudItem>
+    <MudItem xs="12" sm="6" md="4">
+        <MudNumericField @bind-Value="Weight" HelperText="Weight" Variant="Variant.Text" Adornment="Adornment.End" AdornmentText="Kg" />
+    </MudItem>
+    <MudItem xs="12" sm="6" md="4">
+        <MudNumericField @bind-Value="Amount" Label="Amount" Variant="Variant.Filled" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.AttachMoney" />
+    </MudItem>
+    <MudItem xs="12" sm="6" md="4">
+        <MudNumericField @bind-Value="Weight" HelperText="Weight" Variant="Variant.Filled" Adornment="Adornment.End" AdornmentText="Kg" />
+    </MudItem>
+    <MudItem xs="12" sm="6" md="4">
+        <MudNumericField @bind-Value="Amount" Label="Amount" Variant="Variant.Outlined" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.AttachMoney" />
+    </MudItem>
+    <MudItem xs="12" sm="6" md="4">
+        <MudNumericField @bind-Value="Weight" HelperText="Weight" Variant="Variant.Outlined" Adornment="Adornment.End" AdornmentText="Kg" />
+    </MudItem>
+</MudGrid>
+
+@code {
+    public decimal? Amount { get; set; }
+    public float? Weight { get; set; }
+}

--- a/src/MudBlazor.Docs/Pages/Components/NumericField/Examples/NumericFieldBasicExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/NumericField/Examples/NumericFieldBasicExample.razor
@@ -1,0 +1,20 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+
+<MudGrid>
+    <MudItem xs="12" sm="6" md="4">
+        <MudNumericField @bind-Value="IntValue" Label="Standard" Variant="Variant.Text" Min="0" Max="10" />
+    </MudItem>
+    <MudItem xs="12" sm="6" md="4">
+        <MudNumericField @bind-Value="DoubleValue" Label="Filled" Variant="Variant.Filled" Min="0.0" />
+    </MudItem>
+    <MudItem xs="12" sm="6" md="4">
+        <MudNumericField @bind-Value="DecimalValue" Label="Outlined" Variant="Variant.Outlined" Step=".2M" />
+    </MudItem>
+</MudGrid>
+
+@code {
+    public int IntValue { get; set; }
+    public double DoubleValue { get; set; }
+    public decimal DecimalValue { get; set; }
+}

--- a/src/MudBlazor.Docs/Pages/Components/NumericField/Examples/NumericFieldBindingExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/NumericField/Examples/NumericFieldBindingExample.razor
@@ -1,0 +1,41 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+
+<MudGrid>
+    <MudItem xs="12" sm="6">
+        <MudNumericField @bind-Value="@element.Mass" Label="Mass" HideSpinButtons="true"/>
+    </MudItem>
+    <MudItem xs="12" sm="6">
+        <MudNumericField @bind-Value="@element.Electrons" Label="Electrons" Min="1" />
+    </MudItem>
+</MudGrid>
+<div class="mt-3 ml-0 d-flex">
+    <div>
+        <MudText>Name: @element.Name</MudText>
+        <MudText>Mass: @element.Mass u</MudText>
+        <MudText>Electrons: @element.Electrons</MudText>
+    </div>
+    <div class="d-flex ml-auto align-center">
+        <MudButton Variant="Variant.Filled" OnClick="Reset">Reset Model</MudButton>
+    </div>
+</div>
+
+
+@code {
+    Atom element = new Atom { Name = "Hydrogen", Mass = 1.00794, Electrons = 1 };
+
+    // A typical POCO
+    public class Atom
+    {
+        public string Name { get; set; }
+        public double Mass { get; set; }
+        public int Electrons { get; set; }
+    }
+
+    private void Reset()
+    {
+        element = new Atom { Name = "Hydrogen", Mass = 1.00794, Electrons = 1 };
+        StateHasChanged();
+    }
+
+}

--- a/src/MudBlazor.Docs/Pages/Components/NumericField/Examples/NumericFieldBindingValueTypesExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/NumericField/Examples/NumericFieldBindingValueTypesExample.razor
@@ -1,0 +1,26 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudGrid>
+    <MudItem xs="12" sm="6">
+        <MudNumericField @bind-Value="intValue" Label="Enter an int" />
+    </MudItem>
+    <MudItem xs="12" sm="6">
+        <MudNumericField @bind-Value="doubleValue" Label="Enter a double" Format="F1" />
+    </MudItem>
+</MudGrid>
+<MudGrid>
+    <MudItem xs="12" sm="6">
+        <MudNumericField @bind-Value="nullableInt" HelperText="Enter an int" />
+    </MudItem>
+    <MudItem xs="12" sm="6">
+        <MudNumericField @bind-Value="nullableDouble" HelperText="Enter a double" Format="F1" />
+    </MudItem>
+</MudGrid>
+
+
+@code { 
+    int intValue;
+    double doubleValue;
+    int? nullableInt;
+    double? nullableDouble;
+}

--- a/src/MudBlazor.Docs/Pages/Components/NumericField/Examples/NumericFieldDenseExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/NumericField/Examples/NumericFieldDenseExample.razor
@@ -1,0 +1,17 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudGrid>
+    <MudItem xs="12" sm="6" md="4">
+        <MudNumericField @bind-Value="Value" Label="Standard" Variant="Variant.Text" Margin="Margin.Dense" />
+    </MudItem>
+    <MudItem xs="12" sm="6" md="4">
+        <MudNumericField @bind-Value="Value" Label="Filled" Variant="Variant.Filled" Margin="Margin.Dense" />
+    </MudItem>
+    <MudItem xs="12" sm="6" md="4">
+        <MudNumericField @bind-Value="Value" Label="Outlined" Variant="Variant.Outlined" Margin="Margin.Dense" />
+    </MudItem>
+</MudGrid>
+
+@code {
+    public int Value { get; set; }
+}

--- a/src/MudBlazor.Docs/Pages/Components/NumericField/Examples/NumericFieldFocusExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/NumericField/Examples/NumericFieldFocusExample.razor
@@ -1,0 +1,30 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+
+<MudGrid>
+    <MudItem xs="12">
+        <MudNumericField @ref="intReference" Label="Manual focus" Variant="Variant.Filled" @bind-Value="@intValue" />
+    </MudItem>
+    <MudItem xs="12" Class="d-flex justify-end">
+        <MudButton @onclick="() => intReference.FocusAsync()">
+            Focus
+        </MudButton>
+    </MudItem>
+    <MudItem xs="12">
+        <MudNumericField @ref="doubleReference" Label="Manual focus" Variant="Variant.Filled" @bind-Value="@doubleValue" />
+    </MudItem>
+    <MudItem xs="12" Class="d-flex justify-end">
+        <MudButton @onclick="() => doubleReference.FocusAsync()">
+            Focus
+        </MudButton>
+    </MudItem>
+</MudGrid>
+
+@code
+{
+    private MudNumericField<int> intReference;
+    private MudNumericField<double> doubleReference;
+
+    int intValue = 100;
+    double doubleValue = Math.PI;
+}

--- a/src/MudBlazor.Docs/Pages/Components/NumericField/Examples/NumericFieldFormPropsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/NumericField/Examples/NumericFieldFormPropsExample.razor
@@ -1,0 +1,39 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudGrid>
+    <MudItem xs="12" sm="6" md="4">
+        <MudNumericField @bind-Value="Helper" Label="With Helper" HelperText="Some helping Text" Variant="Variant.Text" />
+    </MudItem>
+    <MudItem xs="12" sm="6" md="4">
+        <MudNumericField @bind-Value="Disabled" Label="Disabled" Variant="Variant.Text" Disabled="true" />
+    </MudItem>
+    <MudItem xs="12" sm="6" md="4">
+        <MudNumericField @bind-Value="ReadOnly" Label="Read Only" ReadOnly="true" Variant="Variant.Text" />
+    </MudItem>
+
+    <MudItem xs="12" sm="6" md="4">
+        <MudNumericField @bind-Value="Helper" Label="With Helper" HelperText="Some helping Text" Variant="Variant.Filled" />
+    </MudItem>
+    <MudItem xs="12" sm="6" md="4">
+        <MudNumericField @bind-Value="Disabled" Label="Disabled" Variant="Variant.Filled" Disabled="true" />
+    </MudItem>
+    <MudItem xs="12" sm="6" md="4">
+        <MudNumericField @bind-Value="ReadOnly" Label="Read Only" ReadOnly="true" Variant="Variant.Filled" />
+    </MudItem>
+
+    <MudItem xs="12" sm="6" md="4">
+        <MudNumericField @bind-Value="Helper" Label="With Helper" HelperText="Some helping Text" Variant="Variant.Outlined" />
+    </MudItem>
+    <MudItem xs="12" sm="6" md="4">
+        <MudNumericField @bind-Value="Disabled" Label="Disabled" Variant="Variant.Outlined" Disabled="true" />
+    </MudItem>
+    <MudItem xs="12" sm="6" md="4">
+        <MudNumericField @bind-Value="ReadOnly" Label="Read Only" ReadOnly="true" Variant="Variant.Outlined" />
+    </MudItem>
+</MudGrid>
+
+@code {
+    public int? Helper { get; set; }
+    public int Disabled { get; set; } = 2020;
+    public int ReadOnly { get; set; } = 101;
+}

--- a/src/MudBlazor.Docs/Pages/Components/NumericField/Examples/NumericFieldHideButtonsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/NumericField/Examples/NumericFieldHideButtonsExample.razor
@@ -1,0 +1,28 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudGrid>
+	<MudItem xs="12" sm="6" md="4">
+		<MudNumericField @bind-Value="Amount" Label="Amount" Variant="Variant.Text" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.AttachMoney" HideSpinButtons="true" />
+	</MudItem>
+	<MudItem xs="12" sm="6" md="4">
+		<MudNumericField @bind-Value="Amount" Label="Amount" Variant="Variant.Filled" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.AttachMoney" HideSpinButtons="true" />
+	</MudItem>
+	<MudItem xs="12" sm="6" md="4">
+		<MudNumericField @bind-Value="Amount" Label="Amount" Variant="Variant.Outlined" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.AttachMoney" HideSpinButtons="true" />
+	</MudItem>
+	<MudItem xs="12" sm="6" md="4">
+		<MudNumericField @bind-Value="Weight" HelperText="Weight" Variant="Variant.Text" Adornment="Adornment.End" AdornmentText="Kg" HideSpinButtons="true" />
+	</MudItem>
+	<MudItem xs="12" sm="6" md="4">
+		<MudNumericField @bind-Value="Weight" HelperText="Weight" Variant="Variant.Filled" Adornment="Adornment.End" AdornmentText="Kg" HideSpinButtons="true" />
+	</MudItem>
+	<MudItem xs="12" sm="6" md="4">
+		<MudNumericField @bind-Value="Weight" HelperText="Weight" Variant="Variant.Outlined" Adornment="Adornment.End" AdornmentText="Kg" HideSpinButtons="true" />
+	</MudItem>
+</MudGrid>
+
+
+@code {
+	public decimal? Amount { get; set; }
+	public float? Weight { get; set; }
+}

--- a/src/MudBlazor.Docs/Pages/Components/NumericField/Examples/NumericFieldInputsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/NumericField/Examples/NumericFieldInputsExample.razor
@@ -1,0 +1,16 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudGrid>
+	<MudItem xs="12" sm="6" md="3">
+		<MudNumericField T="double" Label="Basic Input" />
+	</MudItem>
+	<MudItem xs="12" sm="6" md="3">
+		<MudNumericField T="int?" Placeholder="Placeholder" />
+	</MudItem>
+	<MudItem xs="12" sm="6" md="3">
+		<MudNumericField Value="0" Label="Disabled" Disabled="true" />
+	</MudItem>
+	<MudItem xs="12" sm="6" md="3">
+		<MudNumericField Value="2" Label="Error" Error="true" ErrorText="Error text." />
+	</MudItem>
+</MudGrid>

--- a/src/MudBlazor.Docs/Pages/Components/NumericField/Examples/NumericFieldSelectExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/NumericField/Examples/NumericFieldSelectExample.razor
@@ -1,0 +1,19 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudGrid>
+    <MudItem xs="12">
+        <MudNumericField @ref="doubleReference" Label="Select" Variant="Variant.Filled" @bind-Value="@value" />
+    </MudItem>
+    <MudItem xs="12" Class="d-flex justify-end">
+        <MudButton @onclick="() => doubleReference.SelectAsync()">
+            Select
+        </MudButton>
+    </MudItem>
+</MudGrid>
+
+@code
+{
+    private MudNumericField<double> doubleReference;
+
+    double value = Math.PI;
+}

--- a/src/MudBlazor.Docs/Pages/Components/NumericField/NumericFieldPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/NumericField/NumericFieldPage.razor
@@ -1,0 +1,157 @@
+﻿@page "/components/NumericField"
+
+
+<DocsPage>
+	<DocsPageHeader Title="Numeric Field" SubTitle="Numeric field components are used for receiving user provided numbers." />
+	<DocsPageContent>
+		<DocsPageSection>
+			<SectionHeader>
+				<Title>Basic Numeric Field's</Title>
+				<Description>
+					Numeric fields are just like text fields, but they work well with numeric value of any type. The input is automatically restricted to numeric values, and it works regardless of the browser locale settings for decimal types.<br />
+					<CodeInline>Min</CodeInline> and <CodeInline>Max</CodeInline> attributes allow to restrict the value within the limits, if they are not specified they assume the default value for the type (i.e <CodeInline>@int.MinValue</CodeInline> and <CodeInline>@int.MaxValue</CodeInline> for <CodeInline>int</CodeInline>).
+					The <CodeInline>Step</CodeInline> attribute define how much the value changes when using the up/down buttons on the right, or with keyboards up/down arrows. If not specified, default value is 1.
+					<br />
+					<MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">Note: for floating point or decimal values, passing a literal string value for <CodeInline>Min</CodeInline>, <CodeInline>Max</CodeInline> or <CodeInline>Step</CodeInline> might trigger a compile error on generated razor code. You can either force decimal points (i.e. <CodeInline>0.0</CodeInline>) or suffix (i.e. <CodeInline>0.5M</CodeInline> for decimal).</MudAlert>
+				</Description>
+			</SectionHeader>
+			<SectionContent Outlined="true">
+				<NumericFieldBasicExample />
+			</SectionContent>
+			<SectionSource Code="NumericFieldBasicExample" ShowCode="false" GitHubFolderName="NumericField" />
+		</DocsPageSection>
+		<DocsPageSection>
+			<SectionHeader>
+				<Title>Dense</Title>
+				<Description>With the <CodeInline>margin</CodeInline> prop you can reduce the field height.</Description>
+			</SectionHeader>
+			<SectionContent Outlined="true">
+				<NumericFieldDenseExample />
+			</SectionContent>
+			<SectionSource Code="NumericFieldDenseExample" ShowCode="false" GitHubFolderName="NumericField" />
+		</DocsPageSection>
+		<DocsPageSection>
+			<SectionHeader>
+				<Title>Form Props</Title>
+				<Description>Required, Disabled, Type, HelperText</Description>
+			</SectionHeader>
+			<SectionContent Outlined="true">
+				<NumericFieldFormPropsExample />
+			</SectionContent>
+			<SectionSource Code="NumericFieldFormPropsExample" ShowCode="false" GitHubFolderName="NumericField" />
+		</DocsPageSection>
+
+		<DocsPageSection>
+			<SectionHeader>
+				<Title>Adornments</Title>
+				<Description>This can be used to add a prefix or a suffix. Text, Icon or Icon Button.</Description>
+			</SectionHeader>
+			<SectionContent Outlined="true" Class="demo-numericfield">
+				<NumericFieldAdornmentsExample />
+			</SectionContent>
+			<SectionSource Code="NumericFieldAdornmentsExample" ShowCode="false" GitHubFolderName="NumericField" />
+		</DocsPageSection>
+
+		<DocsPageSection>
+			<SectionHeader>
+				<Title>Hide Spin Buttons</Title>
+				<Description>
+					This property could be set to hide the spinner buttons, preventing the user to increase and decrease the value with mouse or touch input.<br>
+					It could still be changed with keyboard up/down keys, or manually.
+				</Description>
+			</SectionHeader>
+			<SectionContent Outlined="true" Class="demo-numericfield">
+				<NumericFieldHideButtonsExample />
+			</SectionContent>
+			<SectionSource Code="NumericFieldHideButtonsExample" ShowCode="false" GitHubFolderName="NumericField" />
+		</DocsPageSection>
+
+		<DocsPageSection>
+			<SectionHeader>
+				<Title>Adornment Color</Title>
+				<Description>The color of the adornment can be changed separately from the NumericField.</Description>
+			</SectionHeader>
+			<SectionContent Outlined="true" Class="demo-numericfield">
+				<NumericFieldAdornmentColorExample />
+			</SectionContent>
+			<SectionSource Code="NumericFieldAdornmentColorExample" ShowCode="false" GitHubFolderName="NumericField" />
+		</DocsPageSection>
+
+		<DocsPageSection>
+			<SectionHeader>
+				<Title>Binding Properties of a POCO</Title>
+				<Description>
+					The following text fields are bound against the properties of a POCO (Plain old C-Sharp Object). Edit them to see the model change. Reset the model and see the NumericFields change.
+					<MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">Note: always use two-way bindings (<CodeInline>@("@bind-Value")</CodeInline>) with number fields.</MudAlert>
+				</Description>
+			</SectionHeader>
+			<SectionContent Outlined="true">
+				<NumericFieldBindingExample />
+			</SectionContent>
+			<SectionSource Code="NumericFieldBindingExample" ShowCode="false" GitHubFolderName="NumericField" />
+		</DocsPageSection>
+
+		<DocsPageSection>
+			<SectionHeader>
+				<Title>Binding Value Types vs Nullables</Title>
+				<Description>
+					When you bind value types, the numeric field will not be empty even if the user hasn't entered a value yet because a value type always has a value, even when unassigned.
+					The two-way-bindable <CodeInline>Value</CodeInline> property will automatically assume the default value of that type  (i.e. <CodeInline>0</CodeInline> for <CodeInline>int</CodeInline>).<br />
+					So if you want your numeric fields to be empty as long as nothing has been entered yet or it has been deleted, use the nullable version of that type (i.e. <CodeInline>int?</CodeInline>).<br />
+					Do not assign null values to <CodeInline>Min</CodeInline>, <CodeInline>Max</CodeInline> and <CodeInline>Step</CodeInline>.
+				</Description>
+			</SectionHeader>
+			<SectionContent Outlined="true">
+				<NumericFieldBindingValueTypesExample />
+			</SectionContent>
+			<SectionSource Code="NumericFieldBindingValueTypesExample" ShowCode="false" GitHubFolderName="NumericField" />
+		</DocsPageSection>
+
+		<DocsPageSection>
+			<SectionHeader>
+				<Title>Normal vs Immediate vs Debounced</Title>
+				<Description>
+					Per default, <CodeInline>MudNumericField</CodeInline> updates the bound value on Enter or when it looses focus. Set <CodeInline>Immediate="true"</CodeInline> to update the value whenever the user types.<br />
+                    You can also set the <CodeInline>DebounceInterval</CodeInline> parameter to the amount of milliseconds you want to await before updating the bound value. If you need to know when the interval elapses, you can pass an <CodeInline>OnDebounceIntervalElapsed</CodeInline> EventCallback.
+                    Notice how in this example the debounced text only updates 500 ms after you stop typing.
+					<MudAlert Severity="Severity.Warning" Dense="true" Class="mt-3">Warning: when <CodeInline>Immediate="false"</CodeInline> (default), if the user types a value and then presses the arrow up/down on the keyboard, the step is calculated on the last accepted value.</MudAlert>
+				</Description>
+			</SectionHeader>
+			<SectionContent Outlined="true" FullWidth="true">
+				<DebouncedNumericFieldExample />
+			</SectionContent>
+			<SectionSource Code="DebouncedNumericFieldExample" ShowCode="false" GitHubFolderName="NumericField" />
+		</DocsPageSection>
+		<DocsPageSection>
+			<SectionHeader>
+				<Title>Focus</Title>
+				<Description></Description>
+			</SectionHeader>
+			<SectionContent Outlined="true">
+				<NumericFieldFocusExample />
+			</SectionContent>
+			<SectionSource Code="NumericFieldFocusExample" ShowCode="false" GitHubFolderName="NumericField" />
+		</DocsPageSection>
+		<DocsPageSection>
+			<SectionHeader>
+				<Title>Select</Title>
+				<Description></Description>
+			</SectionHeader>
+			<SectionContent Outlined="true">
+				<NumericFieldSelectExample />
+			</SectionContent>
+			<SectionSource Code="NumericFieldSelectExample" ShowCode="false" GitHubFolderName="NumericField" />
+		</DocsPageSection>
+
+		<DocsPageSection>
+			<SectionHeader>
+				<Title>Inputs</Title>
+				<Description></Description>
+			</SectionHeader>
+			<SectionContent Outlined="true">
+				<NumericFieldInputsExample />
+			</SectionContent>
+			<SectionSource Code="NumericFieldInputsExample" ShowCode="false" GitHubFolderName="NumericField" />
+		</DocsPageSection>
+	</DocsPageContent>
+</DocsPage>

--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableInlineEditExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableInlineEditExample.razor
@@ -41,7 +41,7 @@
             <MudTextField @bind-Value="@context.Name" Required />
         </MudTd>
         <MudTd DataLabel="Position">
-            <MudTextField @bind-Value="@context.Position" Required />
+            <MudNumericField @bind-Value="@context.Position" Required Min="1" />
         </MudTd>
         <MudTd DataLabel="Molar mass">
             <MudTextField @bind-Value="@context.Molar" Required />

--- a/src/MudBlazor.Docs/Pages/Components/TextField/TextFieldPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TextField/TextFieldPage.razor
@@ -75,7 +75,7 @@
             <SectionHeader>
                 <Title>Binding Value Types vs Nullables</Title>
                 <Description>
-                    When you bind value types, the the text field will not be empty even if the user hasn't entered a value yet because a value type always has a value, even when unassigned.
+                    When you bind value types, the text field will not be empty even if the user hasn't entered a value yet because a value type always has a value, even when unassigned.
                     The two-way-bindable <CodeInline>Value</CodeInline> property will automatically assume the default value of that type  (i.e. <CodeInline>0</CodeInline> for <CodeInline>int</CodeInline>).<br />
                     So if you want your text fields to be empty as long as nothing has been entered yet, use the nullable version of that type (i.e. <CodeInline>int?</CodeInline>).
                 </Description>

--- a/src/MudBlazor.Docs/Pages/Versions/Versions.razor
+++ b/src/MudBlazor.Docs/Pages/Versions/Versions.razor
@@ -43,6 +43,13 @@
             </thead>
             <tbody class="mb-16">
                 <tr>
+                    <td>v5.0.7</td>
+                    <td><MudChip Color="Color.Default" Size="Size.Small" Label="true" Style="width:60px;">Patch</MudChip></td>
+                    <td><MudChip Style="background-color: #5027d5; color: #ffffff; width:100px;" Size="Size.Small" Label="true">.NET 5</MudChip></td>
+                    <td><MudLink Typo="Typo.body2" Href="https://www.nuget.org/packages/MudBlazor/5.0.7">Nuget Package</MudLink></td>
+                    <td><MudLink Typo="Typo.body2" Href="https://github.com/Garderoben/MudBlazor/releases/tag/v5.0.7">GitHub Release</MudLink></td>
+                </tr>
+                <tr>
                     <td>v5.0.6</td>
                     <td><MudChip Color="Color.Default" Size="Size.Small" Label="true" Style="width:60px;">Patch</MudChip></td>
                     <td><MudChip Style="background-color: #5027d5; color: #ffffff; width:100px;" Size="Size.Small" Label="true">.NET 5</MudChip></td>
@@ -90,6 +97,13 @@
                     <td><MudChip Style="background-color: #5027d5; color: #ffffff; width:100px;" Size="Size.Small" Label="true">.NET 5</MudChip></td>
                     <td><MudLink Typo="Typo.body2" Href="https://www.nuget.org/packages/MudBlazor/5.0.0">Nuget Package</MudLink></td>
                     <td><MudLink Typo="Typo.body2" Href="https://github.com/Garderoben/MudBlazor/releases/tag/v5.0.0">GitHub Release</MudLink></td>
+                </tr>
+                <tr>
+                    <td>v2.0.7</td>
+                    <td><MudChip Color="Color.Default" Size="Size.Small" Label="true" Style="width:60px;">Patch</MudChip></td>
+                    <td><MudChip Style="background-color: #682a7b; color: #ffffff; width:100px;" Size="Size.Small" Label="true">.NET Core 3.1</MudChip></td>
+                    <td><MudLink Typo="Typo.body2" Href="https://www.nuget.org/packages/MudBlazor/2.0.7">Nuget Package</MudLink></td>
+                    <td><MudLink Typo="Typo.body2" Href="https://github.com/Garderoben/MudBlazor/releases/tag/v2.0.7">GitHub Release</MudLink></td>
                 </tr>
                 <tr>
                     <td>v2.0.6</td>

--- a/src/MudBlazor.Docs/Services/MenuService.cs
+++ b/src/MudBlazor.Docs/Services/MenuService.cs
@@ -80,6 +80,7 @@ namespace MudBlazor.Docs.Services
                 .AddItem("Slider", typeof(MudSlider<T>))
                 .AddItem("Switch", typeof(MudSwitch<T>))
                 .AddItem("Text Field", typeof(MudTextField<T>))
+                .AddItem("Numeric Field", typeof(MudNumericField<T>))
                 .AddItem("Form", typeof(MudForm))
                 .AddItem("Autocomplete", typeof(MudAutocomplete<T>))
                 .AddItem("Field", typeof(MudField))

--- a/src/MudBlazor.Docs/Shared/Footer.razor
+++ b/src/MudBlazor.Docs/Shared/Footer.razor
@@ -39,6 +39,6 @@
                 </ul>
             </MudItem>
         </MudGrid>
-        <MudText Typo="Typo.body2">Currently v5.0.6. Released under the <MudLink Typo="Typo.body2" Href="https://github.com/Garderoben/MudBlazor/blob/master/LICENSE" Target="_blank">MIT License.</MudLink> Copyright © 2020-2021 MudBlazor.</MudText>
+        <MudText Typo="Typo.body2">Currently v5.0.7. Released under the <MudLink Typo="Typo.body2" Href="https://github.com/Garderoben/MudBlazor/blob/master/LICENSE" Target="_blank">MIT License.</MudLink> Copyright © 2020-2021 MudBlazor.</MudText>
     </div>
 </MudContainer>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/ExpansionPanel/ExpansionPanelExpansions.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/ExpansionPanel/ExpansionPanelExpansions.razor
@@ -1,0 +1,16 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudExpansionPanels>
+    <MudExpansionPanel Text="Panel One">
+        Panel One Content
+    </MudExpansionPanel>
+    <MudExpansionPanel Text="Panel Two">
+        Panel Two Content
+    </MudExpansionPanel>
+    <MudExpansionPanel Text="Panel Three">
+        Panel Three Content
+    </MudExpansionPanel>
+</MudExpansionPanels>
+
+
+

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/ExpansionPanel/ExpansionPanelMultiExpansion.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/ExpansionPanel/ExpansionPanelMultiExpansion.razor
@@ -1,0 +1,16 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudExpansionPanels MultiExpansion="true">
+    <MudExpansionPanel Text="Panel One">
+        Panel One Content
+    </MudExpansionPanel>
+    <MudExpansionPanel Text="Panel Two">
+        Panel Two Content
+    </MudExpansionPanel>
+    <MudExpansionPanel Text="Panel Three">
+        Panel Three Content
+    </MudExpansionPanel>
+</MudExpansionPanels>
+
+
+

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/NumericField/NumericFieldRequiredTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/NumericField/NumericFieldRequiredTest.razor
@@ -1,0 +1,12 @@
+﻿<MudNumericField
+    @bind-Value="_value"
+     Label="Input" 
+     Variant="Variant.Filled"
+     Required="true"
+/>
+   
+@code {
+    public static string __description__ = "The numericfield should not show required-error initially!";
+
+    private int? _value = null;
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/NumericField/NumericFieldTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/NumericField/NumericFieldTest.razor
@@ -1,0 +1,69 @@
+﻿<MudNumericField @bind-Value="_value"
+				 Label="int 0, 10, 2"
+				 Variant="Variant.Text"
+				 Min="0"
+				 Max="10"
+				 Step="2" />
+<br/>
+<MudNumericField @bind-Value="_value2"
+				 Label="int 3, 10, 2"
+				 Variant="Variant.Text"
+				 Margin="Margin.Dense"
+				 Min="3"
+				 Max="10"
+				 Step="1" />
+
+<br />
+<MudNumericField @bind-Value="_valueDbl"
+				 Label="double -5, 9.9, 1.3"
+				 Variant="Variant.Filled"
+				 Step="1.3"
+				 Max="9.9"
+				 Min="-5.0"
+				Format="F3"/>
+
+<br />
+<MudNumericField @bind-Value="_valueDec"
+				 Label="decimal .2, 6.6, .3333"
+				 Variant="Variant.Outlined"
+				 Step=".3333M"
+				 Max="6.6M"
+				 Min=".2M" />
+
+<br />
+<MudNumericField @bind-Value="_valueDbl"
+				 Label="double -5, 9.9, 1"
+				 Variant="Variant.Filled"
+				 Margin="Margin.Dense"
+				 Max="9.9"
+				 Min="-5.0" />
+<br/><br/>
+<MudNumericField @bind-Value="_nullable"
+				 Label="int? max 10"
+				 Variant="Variant.Outlined"
+				 Margin="Margin.Dense"
+				 Max="10" />
+				 
+<br/>
+<MudNumericField T="double?"
+				 Label="double?"
+				 Variant="Variant.Outlined"
+				 Margin="Margin.Dense" />
+<br/>
+<MudNumericField T="decimal?"
+				 Label="decimal?"
+				 Variant="Variant.Outlined"
+				 Margin="Margin.Dense" />
+
+@code {
+	public static string __description__ = "The textfield should be changed by up/down arrows";
+
+	private int _value = 0;
+	private int _value2 = 4;
+
+	private double _valueDbl = Math.PI;
+
+	private decimal _valueDec = .9999999M;
+
+	private int? _nullable;
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/ScrollableTabsTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/ScrollableTabsTest.razor
@@ -20,9 +20,9 @@
 
     private List<string> _tabs = new List<string> { "1", "2", "3", "4", "5", "6" };
 
-    public async Task SetPanelActive(Int32 index)
+    public void  SetPanelActive(Int32 index)
     {
-        await _tabElement.ActivatePanel(index);
+      InvokeAsync(() => _tabElement.ActivatePanel(index));
     }
 
     public async Task AddPanel()

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/ScrollableTabsTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/ScrollableTabsTest.razor
@@ -1,0 +1,40 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudTabs Elevation="1" @ref="_tabElement" AlwaysShowScrollButtons="true" Position="Position">
+@foreach (var tab in _tabs)
+{
+    <MudTabPanel @key="tab" Text="@tab">
+        <MudText>@tab</MudText>
+    </MudTabPanel>
+}
+</MudTabs>
+
+@code
+{ 
+    private MudTabs _tabElement;
+
+    public static string __description__ = "scrolling should work";
+
+    [Parameter]
+    public Position Position { get; set; } = Position.Top;
+
+    private List<string> _tabs = new List<string> { "1", "2", "3", "4", "5", "6" };
+
+    public async Task SetPanelActive(Int32 index)
+    {
+        await _tabElement.ActivatePanel(index);
+    }
+
+    public async Task AddPanel()
+    {
+        _tabs.Add("new item");
+        await InvokeAsync(StateHasChanged);
+    }
+
+    public async Task RemovePanel(Int32 index)
+    {
+        _tabs.RemoveAt(index);
+        await InvokeAsync(StateHasChanged);
+    }
+
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/TabsAddingRemovingTabsTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/TabsAddingRemovingTabsTest.razor
@@ -6,7 +6,7 @@
 <MudTabs Elevation="1">
     @foreach (var tab in _tabs)
     {
-        <MudTabPanel Text="@tab">
+        <MudTabPanel @key="tab" Text="@tab">
             <MudText>@tab</MudText>
         </MudTabPanel>
     }    
@@ -19,14 +19,18 @@
     private List<string> _tabs = new List<string>();
     private int i = 0;
 
-    private void AddTab()
+    private async Task AddTab()
     {
         _tabs.Add($"Tab {i++}");
+        await InvokeAsync(StateHasChanged);
     }
 
-    private void RemoveLast()
+    private async Task RemoveLast()
     {
         if(_tabs.Any())
-            _tabs.RemoveAt(_tabs.Count-1);
+        {
+            _tabs.RemoveAt(_tabs.Count - 1);
+            await InvokeAsync(StateHasChanged);
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/ExpansionPanelTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ExpansionPanelTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Bunit;
 using FluentAssertions;

--- a/src/MudBlazor.UnitTests/Components/ExpansionPanelTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ExpansionPanelTests.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+using System.Linq;
+using Bunit;
+using FluentAssertions;
+using MudBlazor.UnitTests.TestComponents;
+using NUnit.Framework;
+namespace MudBlazor.UnitTests.Components
+{
+    [TestFixture]
+    public class ExpansionPanelTests
+    {
+        private Bunit.TestContext ctx;
+
+        [SetUp]
+        public void Setup()
+        {
+            ctx = new Bunit.TestContext();
+            ctx.AddTestServices();
+        }
+
+        [TearDown]
+        public void TearDown() => ctx.Dispose();
+
+        /// <summary>
+        /// Expansion panel must expand and collapse in the right order
+        /// Here we are open the first, then the third and then the second
+        /// </summary>
+        [Test]
+        public void MudExpansionPanel_Respects_Collapsing_Order()
+        {
+            var comp = ctx.RenderComponent<ExpansionPanelExpansions>();
+            //the order in which the panels are going to be clicked
+            //First, the first; then, the third, and then the second
+            var sequence = new List<int> { 0, 2, 1 };
+            foreach (var item in sequence)
+            {
+                var header = comp.FindAll(".mud-expand-panel-header")[item];
+                header.Click();
+
+                var panels = comp.FindAll(".mud-expand-panel").ToList();
+
+                //just the panel that was clicked has the expanded class
+                panels[item].OuterHtml.Should().Contain("mud-panel-expanded");
+                foreach (var other in sequence.Where(it => it != item))
+                {
+                    //the other panels haven't the class expanded
+                    panels[other].OuterHtml.Should().NotContain("mud-panel-expanded");
+                }
+            }
+
+        }
+
+
+        /// <summary>
+        /// MultiExpansion panel should not collapse other panels
+        /// </summary>
+        [Test]
+        public void MudExpansionPanel_MultiExpansion_Doesnt_Collapse_Others()
+        {
+            var comp = ctx.RenderComponent<ExpansionPanelMultiExpansion>();
+
+            //click in the three headers 
+            foreach (var header in comp.FindAll(".mud-expand-panel-header"))
+            {
+                header.Click();
+            }
+
+            //the three panels must be expanded
+            var panels = comp.FindAll(".mud-panel-expanded").ToList();
+            panels.Count.Should().Be(3);
+
+        }
+
+
+
+
+    }
+}
+
+
+

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -608,7 +608,7 @@ namespace MudBlazor.UnitTests.Components
             // Check first run attribute
             EditFormIssue1229.TestAttribute.ValidationContextOnCall.Should().BeEmpty();
             // Trigger change
-            var input= comp.Find("input");
+            var input = comp.Find("input");
             input.Change("Test");
             input.Blur();
             // Verify context was set

--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -1,0 +1,309 @@
+﻿#pragma warning disable CS1998 // async without await
+#pragma warning disable IDE1006 // leading underscore
+#pragma warning disable BL0005 // Set parameter outside component
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using Bunit;
+using FluentAssertions;
+using FluentValidation;
+using Microsoft.AspNetCore.Components;
+using MudBlazor.UnitTests.TestComponents.NumericField;
+using NUnit.Framework;
+using static Bunit.ComponentParameterFactory;
+
+namespace MudBlazor.UnitTests
+{
+
+    [TestFixture]
+    public class NumericFieldTests
+    {
+        private Bunit.TestContext ctx;
+
+        [SetUp]
+        public void Setup()
+        {
+            ctx = new Bunit.TestContext();
+            ctx.AddTestServices();
+        }
+
+        [TearDown]
+        public void TearDown() => ctx.Dispose();
+
+        /// <summary>
+        /// Initial Text for double should be 0, with F1 format it should be 0.0
+        /// </summary>
+        [Test]
+        public async Task NumericFieldTest1()
+        {
+            var comp = ctx.RenderComponent<MudNumericField<double>>();
+            // print the generated html
+            Console.WriteLine(comp.Markup);
+            // select elements needed for the test
+            var numericField = comp.Instance;
+            numericField.Value.Should().Be(0.0);
+            numericField.Text.Should().Be("0");
+            //
+            0.0.ToString("F1", CultureInfo.InvariantCulture).Should().Be("0.0");
+            //
+            await comp.InvokeAsync(() => numericField.Format = "F1");
+            await comp.InvokeAsync(() => numericField.Culture = CultureInfo.InvariantCulture);
+            numericField.Value.Should().Be(0.0);
+            numericField.Text.Should().Be("0.0");
+            comp.FindAll("div.mud-input-error").Count.Should().Be(0);
+        }
+
+        /// <summary>
+        /// Initial Text for double? should be null
+        /// </summary>
+        [Test]
+        public void NumericFieldTest2()
+        {
+            var comp = ctx.RenderComponent<MudNumericField<double?>>();
+            // print the generated html
+            Console.WriteLine(comp.Markup);
+            // select elements needed for the test
+            var numericField = comp.Instance;
+            numericField.Value.Should().Be(null);
+            numericField.Text.Should().BeNullOrEmpty();
+            comp.FindAll("div.mud-input-error").Count.Should().Be(0);
+        }
+
+        /// <summary>
+        /// Setting the value to null should not cause a validation error
+        /// </summary>
+        [Test]
+        public async Task NumericFieldWithNullableTypes()
+        {
+            var comp = ctx.RenderComponent<MudNumericField<int?>>(ComponentParameter.CreateParameter("Value", 17));
+            // print the generated html
+            Console.WriteLine(comp.Markup);
+            comp.SetParametersAndRender(ComponentParameter.CreateParameter("Value", null));
+            comp.Find("input").Blur();
+            comp.FindAll("div.mud-input-error").Count.Should().Be(0);
+            comp.Find("input").Change("");
+            comp.Find("input").Blur();
+            comp.FindAll("div.mud-input-error").Count.Should().Be(0);
+        }
+
+        /// <summary>
+        /// Setting an invalid number should show the conversion error message
+        /// </summary>
+        [Test]
+        public async Task NumericFieldConversionError()
+        {
+            var comp = ctx.RenderComponent<MudNumericField<int?>>();
+            // print the generated html
+            //Console.WriteLine(comp.Markup);
+            comp.Find("input").Change("seventeen");
+            comp.Find("input").Blur();
+            Console.WriteLine(comp.Markup);
+            comp.FindAll("p.mud-input-error").Count.Should().Be(1);
+            comp.Find("p.mud-input-error").TextContent.Trim().Should().Be("Not a valid number");
+        }
+
+        /// <summary>
+        /// If Debounce Interval is null or 0, Value should change immediately
+        /// </summary>
+        [Test]
+        public void WithNoDebounceIntervalValueShouldChangeImmediatelyTest()
+        {
+            //no interval passed, so, by default is 0
+            // We pass the Immediate parameter set to true, in order to bind to oninput
+            var immediate = Parameter(nameof(MudNumericField<int?>.Immediate), true);
+            var comp = ctx.RenderComponent<MudNumericField<int?>>(immediate);
+            var numericField = comp.Instance;
+            var input = comp.Find("input");
+            //Act
+            input.Input(new ChangeEventArgs() { Value = "100" });
+            //Assert
+            //input value has changed, DebounceInterval is 0, so Value should change in NumericField immediately
+            numericField.Value.Should().Be(100);
+            numericField.Text.Should().Be("100");
+        }
+
+
+        /// <summary>
+        /// Value should not change immediately. Should respect the Debounce Interval
+        /// </summary>
+        [Test]
+        public async Task ShouldRespectDebounceIntervalPropertyInNumericFieldTest()
+        {
+            var interval = Parameter(nameof(MudNumericField<int?>.DebounceInterval), 200d);
+            var comp = ctx.RenderComponent<MudNumericField<int?>>(interval);
+            var numericField = comp.Instance;
+            var input = comp.Find("input");
+            //Act
+            input.Input(new ChangeEventArgs() { Value = "100" });
+            //Assert
+            //if DebounceInterval is set, Immediate should be true by default
+            numericField.Immediate.Should().BeTrue();
+            //input value has changed, but elapsed time is 0, so Value should not change in NumericField
+            numericField.Value.Should().BeNull();
+            numericField.Text.Should().Be("100");
+            //DebounceInterval is 200 ms, so at 100 ms Value should not change in NumericField
+            await Task.Delay(100);
+            numericField.Value.Should().BeNull();
+            numericField.Text.Should().Be("100");
+            //More than 200 ms had elapsed, so Value should be updated
+            await Task.Delay(150);
+            numericField.Value.Should().Be(100);
+            numericField.Text.Should().Be("100");
+        }
+
+        /// <summary>
+        /// Label and placeholder should not overlap.
+        /// When placeholder is set, label should shrink
+        /// </summary>
+        [Test]
+        public void LableShouldShrinkWhenPlaceholderIsSet()
+        {
+            //Arrange
+            using var ctx = new Bunit.TestContext();
+            var label = Parameter(nameof(MudNumericField<int?>.Label), "label");
+            var placeholder = Parameter(nameof(MudNumericField<int?>.Placeholder), "placeholder");
+            //with no placeholder, label is not shrinked
+            var comp = ctx.RenderComponent<MudNumericField<int?>>(label);
+            comp.Markup.Should().NotContain("shrink");
+            //with placeholder label is shrinked
+            comp.SetParametersAndRender(placeholder);
+            comp.Markup.Should().Contain("shrink");
+        }
+
+        /// <summary>
+        /// A glue class to make it easy to define validation rules for single values using FluentValidation
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        public class FluentValueValidator<T> : AbstractValidator<T>
+        {
+            public FluentValueValidator(Action<IRuleBuilderInitial<T, T>> rule)
+            {
+                rule(RuleFor(x => x));
+            }
+
+            private IEnumerable<string> ValidateValue(T arg)
+            {
+                var result = Validate(arg);
+                if (result.IsValid)
+                    return Array.Empty<string>();
+                return result.Errors.Select(e => e.ErrorMessage);
+            }
+
+            public Func<T, IEnumerable<string>> Validation => ValidateValue;
+        }
+
+        /// <summary>
+        /// FluentValidation rules can be used for validating a NumericFields
+        /// </summary>
+        [Test]
+        public async Task NumericFieldFluentValidationTest1()
+        {
+            var validator = new FluentValueValidator<string>(x => x.Cascade(CascadeMode.Stop)
+                .NotEmpty()
+                .Length(1, 100));
+            var comp = ctx.RenderComponent<MudNumericField<decimal>>(Parameter(nameof(MudNumericField<decimal>.Validation), validator.Validation), Parameter(nameof(MudNumericField<decimal>.Max), 100M));
+            var numericField = comp.Instance;
+            Console.WriteLine(comp.Markup);
+            // first try a valid value
+            comp.Find("input").Change(99);
+            numericField.Error.Should().BeFalse(because: "The value is < 100");
+            numericField.ErrorText.Should().BeNullOrEmpty();
+            // now try something that's outside of range
+            comp.Find("input").Change("100.1");
+            numericField.Error.Should().BeFalse(because: "The value should be set to Max (100)");
+            numericField.Value.Should().Be(100M);
+            Console.WriteLine("Error message: " + numericField.ErrorText);
+            numericField.ErrorText.Should().BeNullOrEmpty();
+        }
+
+
+        /// <summary>
+        /// An unstable converter should not cause an infinite update loop. This test must complete in under 1 sec!
+        /// </summary>
+        [Test, Timeout(1000)]
+        public async Task NumericFieldUpdateLoopProtectionTest()
+        {
+            var comp = ctx.RenderComponent<MudNumericField<int>>();
+            // these conversion funcs are nonsense of course, but they are designed this way to
+            // test against an infinite update loop that numericFields and other inputs are now protected against.
+            var numericField = comp.Instance;
+            numericField.Converter.SetFunc = s => s.ToString();
+            numericField.Converter.GetFunc = s => int.Parse(s);
+            comp.SetParametersAndRender(ComponentParameter.CreateParameter("Value", 1));
+            numericField.Value.Should().Be(1);
+            numericField.Text.Should().Be("1");
+            comp.Find("input").Change("3");
+            numericField.Value.Should().Be(3);
+            numericField.Text.Should().Be("3");
+        }
+
+        [Test]
+        public async Task NumericField_Should_FireValueChangedOnTextParameterChange()
+        {
+            int changed_value = 4;
+            var comp = ctx.RenderComponent<MudNumericField<int>>(EventCallback<int>("ValueChanged", x => changed_value = x));
+            comp.SetParametersAndRender(ComponentParameter.CreateParameter("Text", "4"));
+            changed_value.Should().Be(4);
+        }
+
+        [Test]
+        public async Task NumericField_Should_FireTextChangedOnValueParameterChange()
+        {
+            string changed_text = "4";
+            var comp = ctx.RenderComponent<MudNumericField<int>>(EventCallback<string>("TextChanged", x => changed_text = x));
+            comp.SetParametersAndRender(ComponentParameter.CreateParameter("Value", 4));
+            changed_text.Should().Be("4");
+        }
+
+        [Test]
+        public async Task NumericField_Should_FireTextAndValueChangedOnTextInput()
+        {
+            int changed_value = 4;
+            string changed_text = null;
+            var comp = ctx.RenderComponent<MudNumericField<int>>(
+                EventCallback<int>("ValueChanged", x => changed_value = x),
+                EventCallback<string>("TextChanged", x => changed_text = x)
+            );
+            comp.Find("input").Change("4");
+            changed_value.Should().Be(4);
+            changed_text.Should().Be("4");
+        }
+
+        /// <summary>
+        /// Instead of RequiredError it should show the conversion error, because typing something (even if not a number) should
+        /// already fulfill the requirement of Required="true". If it is a valid value is a different question.
+        /// </summary>
+        /// <returns></returns>
+        [Test]
+        public async Task NumericField_ShouldNot_ShowRequiredErrorWhenThereIsAConversionError()
+        {
+            var comp = ctx.RenderComponent<MudNumericField<int?>>(ComponentParameter.CreateParameter("Required", true));
+            var numericField = comp.Instance;
+            comp.Find("input").Change("A");
+            comp.Find("input").Blur();
+            numericField.Value.Should().BeNull();
+            numericField.HasErrors.Should().Be(true);
+            numericField.ErrorText.Should().Be("Not a valid number");
+        }
+
+        /// <summary>
+        /// Instead of RequiredError it should show the conversion error, because typing something (even if not a number) should
+        /// already fulfill the requirement of Required="true". If it is a valid value is a different question.
+        /// </summary>
+        /// <returns></returns>
+        [Test]
+        public async Task NumericField_ShouldNot_ShowRequiredErrorWhenInitialTextIsEmpty()
+        {
+            var comp = ctx.RenderComponent<NumericFieldRequiredTest>();
+            var numericField = comp.FindComponent<MudNumericField<int?>>().Instance;
+            numericField.Touched.Should().BeFalse();
+            numericField.ErrorText.Should().BeNullOrEmpty();
+            numericField.HasErrors.Should().Be(false);
+        }
+
+    }
+
+}

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -380,7 +380,7 @@ namespace MudBlazor.UnitTests.Components
             select.SetParam(x => x.Validation, (object)new Func<string, bool>(value =>
               {
                   validatedValue = value; // NOTE: select does only update the value for T string
-                return true;
+                  return true;
               }));
             var menu = comp.Find("div.mud-popover");
             var input = comp.Find("div.mud-input-control");

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using MudBlazor.Interop;
 using MudBlazor.Services;
+using MudBlazor.UnitTests.Mocks;
 using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
 
@@ -36,7 +37,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task AddingAndRemovingTabPanels()
         {
-            ctx.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockedIResizeObserver()));
+            ctx.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockResizeObserver()));
 
             var comp = ctx.RenderComponent<TabsAddingRemovingTabsTest>();
             Console.WriteLine(comp.Markup);
@@ -77,7 +78,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task KeepTabsAliveTest()
         {
-            ctx.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockedIResizeObserver()));
+            ctx.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockResizeObserver()));
 
             var comp = ctx.RenderComponent<TabsKeepAliveTest>();
             Console.WriteLine(comp.Markup);
@@ -137,7 +138,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task KeepTabs_Not_AliveTest()
         {
-            ctx.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockedIResizeObserver()));
+            ctx.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockResizeObserver()));
 
             var comp = ctx.RenderComponent<TabsKeepAliveTest>(ComponentParameter.CreateParameter("KeepPanelsAlive", false));
             Console.WriteLine(comp.Markup);
@@ -178,7 +179,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task ScrollToItem_NoScrollingNeedded()
         {
-            ctx.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockedIResizeObserver()));
+            ctx.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockResizeObserver()));
 
             var comp = ctx.RenderComponent<ScrollableTabsTest>();
             Console.WriteLine(comp.Markup);
@@ -207,7 +208,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(100.0, 200)]
         public async Task ScrollToItem_CentralizeViewAroundActiveItem(Double totalSize, Double expectedTranslation)
         {
-            var observer = new MockedIResizeObserver
+            var observer = new MockResizeObserver
             {
                 PanelSize = 100.0,
                 PanelTotalSize = totalSize + 10,
@@ -238,7 +239,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(100.0, 200)]
         public async Task ScrollToItem_CentralizeViewAroundActiveItem_ScrollVertically(Double totalSize, Double expectedTranslation)
         {
-            var observer = new MockedIResizeObserver
+            var observer = new MockResizeObserver
             {
                 PanelSize = 100.0,
                 PanelTotalSize = totalSize + 10,
@@ -268,7 +269,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task ScrollToItem_CentralizeView_ActivateAllItems()
         {
-            var observer = new MockedIResizeObserver
+            var observer = new MockResizeObserver
             {
                 PanelSize = 100.0,
                 PanelTotalSize = 200 + 10,
@@ -308,7 +309,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Scroll_NotEnabled_EnoughSpace()
         {
-            ctx.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockedIResizeObserver()));
+            ctx.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockResizeObserver()));
 
             var comp = ctx.RenderComponent<ScrollableTabsTest>();
             Console.WriteLine(comp.Markup);
@@ -326,7 +327,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task ScrollNext_EnabledStates()
         {
-            var observer = new MockedIResizeObserver
+            var observer = new MockResizeObserver
             {
                 PanelSize = 100.0,
                 PanelTotalSize = 200,
@@ -352,7 +353,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task ScrollPrev_EnabledStates()
         {
-            var observer = new MockedIResizeObserver
+            var observer = new MockResizeObserver
             {
                 PanelSize = 100.0,
                 PanelTotalSize = 200,
@@ -377,7 +378,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task ScrollNext()
         {
-            var observer = new MockedIResizeObserver
+            var observer = new MockResizeObserver
             {
                 PanelSize = 100.0,
                 PanelTotalSize = 200,
@@ -424,7 +425,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task ScrollPrev()
         {
-            var observer = new MockedIResizeObserver
+            var observer = new MockResizeObserver
             {
                 PanelSize = 100.0,
                 PanelTotalSize = 200,
@@ -473,7 +474,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Handle_ResizeOfPanel()
         {
-            var observer = new MockedIResizeObserver
+            var observer = new MockResizeObserver
             {
                 PanelSize = 100.0,
                 PanelTotalSize = 300,
@@ -500,7 +501,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Handle_ResizeOfElement()
         {
-            var observer = new MockedIResizeObserver
+            var observer = new MockResizeObserver
             {
                 PanelSize = 100.0,
                 PanelTotalSize = 300,
@@ -526,7 +527,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Handle_Add()
         {
-            var observer = new MockedIResizeObserver
+            var observer = new MockResizeObserver
             {
                 PanelSize = 100.0,
                 PanelTotalSize = 300,
@@ -564,7 +565,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Handle_Remove_BeforeSelection()
         {
-            var observer = new MockedIResizeObserver
+            var observer = new MockResizeObserver
             {
                 PanelSize = 100.0,
                 PanelTotalSize = 300,
@@ -600,7 +601,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Handle_Remove_AfterSelection()
         {
-            var observer = new MockedIResizeObserver
+            var observer = new MockResizeObserver
             {
                 PanelSize = 100.0,
                 PanelTotalSize = 300,
@@ -654,101 +655,7 @@ namespace MudBlazor.UnitTests.Components
             return value;
         }
 
-        private class MockedIResizeObserver : IResizeObserver
-        {
-            private Dictionary<ElementReference, BoundingClientRect> _cachedValues = new();
-
-            public Boolean IsVertical { get; set; } = false;
-
-            public event SizeChanged OnResized;
-
-            public void UpdateTotalPanelSize(Double newSize)
-            {
-                var entry = _cachedValues.Last();
-
-                if (IsVertical == false)
-                {
-                    entry.Value.Width = newSize;
-                }
-                else
-                {
-                    entry.Value.Height = newSize;
-                }
-
-                OnResized?.Invoke(new Dictionary<ElementReference, BoundingClientRect> {
-                    { entry.Key, entry.Value  },
-                });
-            }
-
-            public void UpdatePanelSize(Int32 index, Double newSize)
-            {
-                var entry = _cachedValues.ElementAt(index);
-
-                if (IsVertical == false)
-                {
-                    entry.Value.Width = newSize;
-                }
-                else
-                {
-                    entry.Value.Height = newSize;
-                }
-
-                OnResized?.Invoke(new Dictionary<ElementReference, BoundingClientRect> {
-                    { entry.Key, entry.Value  },
-                });
-            }
-
-            public Double PanelSize { get; set; } = 250;
-            public Double PanelTotalSize { get; set; } = 3000;
-
-            public async Task<BoundingClientRect> Observe(ElementReference element) => (await Observe(new[] { element })).FirstOrDefault();
-
-            public Task<IEnumerable<BoundingClientRect>> Observe(IEnumerable<ElementReference> elements)
-            {
-                List<BoundingClientRect> result = new List<BoundingClientRect>();
-                foreach (var item in elements)
-                {
-                    Double size = PanelSize;
-                    // last element is alaways TabsContentSize
-                    if (item.Id == elements.Last().Id && elements.Count() > 1)
-                    {
-                        size = PanelTotalSize;
-                    }
-                    var rect = new BoundingClientRect { Width = size };
-                    if (IsVertical == true)
-                    {
-                        rect = new BoundingClientRect { Height = size };
-                    }
-                    _cachedValues.Add(item, rect);
-                }
-
-                return Task.FromResult<IEnumerable<BoundingClientRect>>(result);
-            }
-
-            public Task Unobserve(ElementReference element)
-            {
-                _cachedValues.Remove(element);
-                return Task.CompletedTask;
-            }
-
-            public ValueTask DisposeAsync()
-            {
-                return ValueTask.CompletedTask;
-            }
-
-            public BoundingClientRect GetSizeInfo(ElementReference reference)
-            {
-                if (_cachedValues.ContainsKey(reference) == false)
-                {
-                    return null;
-                }
-
-                return _cachedValues[reference];
-            }
-            public double GetHeight(ElementReference reference) => GetSizeInfo(reference)?.Height ?? 0.0;
-            public double GetWidth(ElementReference reference) => GetSizeInfo(reference)?.Width ?? 0.0;
-            public Boolean IsElementObserved(ElementReference reference) => _cachedValues.ContainsKey(reference);
-        }
+       
 
 
         #endregion

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -177,7 +177,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task ScrollToItem_NoScrollingNeedded()
+        public void ScrollToItem_NoScrollingNeedded()
         {
             ctx.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockResizeObserver()));
 
@@ -186,7 +186,7 @@ namespace MudBlazor.UnitTests.Components
 
             for (int i = 0; i < 6; i++)
             {
-                await comp.Instance.SetPanelActive(i);
+                comp.Instance.SetPanelActive(i);
 
                 var toolbarWrappter = comp.Find(".mud-tabs-toolbar-wrapper");
 
@@ -206,7 +206,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(300.0, 100)]
         [TestCase(200.0, 200)]
         [TestCase(100.0, 200)]
-        public async Task ScrollToItem_CentralizeViewAroundActiveItem(Double totalSize, Double expectedTranslation)
+        public void ScrollToItem_CentralizeViewAroundActiveItem(double totalSize, double expectedTranslation)
         {
             var observer = new MockResizeObserver
             {
@@ -219,7 +219,7 @@ namespace MudBlazor.UnitTests.Components
             var comp = ctx.RenderComponent<ScrollableTabsTest>();
             Console.WriteLine(comp.Markup);
 
-            await comp.Instance.SetPanelActive(2);
+            comp.Instance.SetPanelActive(2);
 
             var toolbarWrappter = comp.Find(".mud-tabs-toolbar-wrapper");
 
@@ -237,7 +237,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(300.0, 100)]
         [TestCase(200.0, 200)]
         [TestCase(100.0, 200)]
-        public async Task ScrollToItem_CentralizeViewAroundActiveItem_ScrollVertically(Double totalSize, Double expectedTranslation)
+        public void ScrollToItem_CentralizeViewAroundActiveItem_ScrollVertically(double totalSize, double expectedTranslation)
         {
             var observer = new MockResizeObserver
             {
@@ -252,8 +252,7 @@ namespace MudBlazor.UnitTests.Components
             comp.SetParametersAndRender(p => p.Add(x => x.Position, Position.Left));
             Console.WriteLine(comp.Markup);
 
-            await comp.Instance.SetPanelActive(2);
-            
+            comp.Instance.SetPanelActive(2);
 
             var toolbarWrappter = comp.Find(".mud-tabs-toolbar-wrapper");
 
@@ -263,11 +262,11 @@ namespace MudBlazor.UnitTests.Components
             var styleAttr = toolbarWrappter.GetAttribute("style");
 
             styleAttr.Should().Be($"transform:translateY(-{expectedTranslation.ToString(CultureInfo.InvariantCulture)}px);");
-            GetSliderValue(comp,"top").Should().Be(2 * 100.0);
+            GetSliderValue(comp, "top").Should().Be(2 * 100.0);
         }
 
         [Test]
-        public async Task ScrollToItem_CentralizeView_ActivateAllItems()
+        public void ScrollToItem_CentralizeView_ActivateAllItems()
         {
             var observer = new MockResizeObserver
             {
@@ -280,7 +279,7 @@ namespace MudBlazor.UnitTests.Components
             var comp = ctx.RenderComponent<ScrollableTabsTest>();
             Console.WriteLine(comp.Markup);
 
-            Dictionary<Int32, Double> expectedTranslations = new Dictionary<int, double>
+            Dictionary<int, double> expectedTranslations = new Dictionary<int, double>
             {
                 { 0, 0 },
                 { 1, 100 },
@@ -292,7 +291,7 @@ namespace MudBlazor.UnitTests.Components
 
             for (int i = 0; i < 6; i++)
             {
-                await comp.Instance.SetPanelActive(i);
+                comp.Instance.SetPanelActive(i);
 
                 var toolbarWrappter = comp.Find(".mud-tabs-toolbar-wrapper");
 
@@ -325,7 +324,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task ScrollNext_EnabledStates()
+        public void ScrollNext_EnabledStates()
         {
             var observer = new MockResizeObserver
             {
@@ -342,16 +341,16 @@ namespace MudBlazor.UnitTests.Components
 
             for (int i = 0; i < 6; i++)
             {
-                await comp.Instance.SetPanelActive(i);
+                comp.Instance.SetPanelActive(i);
 
-                Boolean shouldBeDisabled = i >= 4;
+                var shouldBeDisabled = i >= 4;
 
                 scrollButtons.Last().Instance.Disabled.Should().Be(shouldBeDisabled);
             }
         }
 
         [Test]
-        public async Task ScrollPrev_EnabledStates()
+        public void ScrollPrev_EnabledStates()
         {
             var observer = new MockResizeObserver
             {
@@ -368,9 +367,9 @@ namespace MudBlazor.UnitTests.Components
 
             for (int i = 5; i <= 0; i--)
             {
-                await comp.Instance.SetPanelActive(i);
+                comp.Instance.SetPanelActive(i);
 
-                Boolean shouldBeDisabled = i == 0;
+                var shouldBeDisabled = i == 0;
                 scrollButtons.First().Instance.Disabled.Should().Be(shouldBeDisabled);
             }
         }
@@ -391,7 +390,7 @@ namespace MudBlazor.UnitTests.Components
             var scrollButtons = comp.FindComponents<MudIconButton>();
             scrollButtons.Should().HaveCount(2);
 
-            Double expectedTranslation = 0.0;
+            double expectedTranslation = 0.0;
 
             for (int i = 0; i < 2; i++)
             {
@@ -423,7 +422,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task ScrollPrev()
+        public void ScrollPrev()
         {
             var observer = new MockResizeObserver
             {
@@ -438,9 +437,9 @@ namespace MudBlazor.UnitTests.Components
             var scrollButtons = comp.FindComponents<MudIconButton>();
             scrollButtons.Should().HaveCount(2);
 
-            await comp.Instance.SetPanelActive(5);
+            comp.Instance.SetPanelActive(5);
 
-            Double expectedTranslation = 400.0;
+            double expectedTranslation = 400.0;
 
             for (int i = 0; i < 2; i++)
             {
@@ -472,7 +471,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task Handle_ResizeOfPanel()
+        public void Handle_ResizeOfPanel()
         {
             var observer = new MockResizeObserver
             {
@@ -485,7 +484,7 @@ namespace MudBlazor.UnitTests.Components
             var comp = ctx.RenderComponent<ScrollableTabsTest>();
             Console.WriteLine(comp.Markup);
 
-            await comp.Instance.SetPanelActive(1);
+            comp.Instance.SetPanelActive(1);
 
             var scrollButtons = comp.FindComponents<MudIconButton>();
 
@@ -499,7 +498,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task Handle_ResizeOfElement()
+        public void Handle_ResizeOfElement()
         {
             var observer = new MockResizeObserver
             {
@@ -512,7 +511,7 @@ namespace MudBlazor.UnitTests.Components
             var comp = ctx.RenderComponent<ScrollableTabsTest>();
             Console.WriteLine(comp.Markup);
 
-            await comp.Instance.SetPanelActive(1);
+            comp.Instance.SetPanelActive(1);
 
             var scrollButtons = comp.FindComponents<MudIconButton>();
             scrollButtons.First().Instance.Disabled.Should().BeTrue();
@@ -538,7 +537,7 @@ namespace MudBlazor.UnitTests.Components
             var comp = ctx.RenderComponent<ScrollableTabsTest>();
             Console.WriteLine(comp.Markup);
 
-            await comp.Instance.SetPanelActive(4);
+            comp.Instance.SetPanelActive(4);
 
             GetSliderValue(comp).Should().Be(4 * 100.0);
 
@@ -550,9 +549,9 @@ namespace MudBlazor.UnitTests.Components
             scrollButtons.Should().HaveCount(2);
 
             scrollButtons.Last().Instance.Disabled.Should().BeFalse();
-            await comp.Instance.SetPanelActive(5);
+            comp.Instance.SetPanelActive(5);
             scrollButtons.Last().Instance.Disabled.Should().BeTrue();
-            await comp.Instance.SetPanelActive(6);
+            comp.Instance.SetPanelActive(6);
 
             var toolbarWrappter = comp.Find(".mud-tabs-toolbar-wrapper");
             toolbarWrappter.Should().NotBeNull();
@@ -576,7 +575,7 @@ namespace MudBlazor.UnitTests.Components
             var comp = ctx.RenderComponent<ScrollableTabsTest>();
             Console.WriteLine(comp.Markup);
 
-            await comp.Instance.SetPanelActive(2);
+            comp.Instance.SetPanelActive(2);
 
             GetSliderValue(comp).Should().Be(2 * 100.0);
 
@@ -594,7 +593,7 @@ namespace MudBlazor.UnitTests.Components
             var styleAttr = toolbarWrappter.GetAttribute("style");
             styleAttr.Should().Be($"transform:translateX(-0px);");
 
-            Double sliderValue = GetSliderValue(comp);
+            double sliderValue = GetSliderValue(comp);
             GetSliderValue(comp).Should().Be(1 * 100.0);
         }
 
@@ -612,7 +611,7 @@ namespace MudBlazor.UnitTests.Components
             var comp = ctx.RenderComponent<ScrollableTabsTest>();
             Console.WriteLine(comp.Markup);
 
-            await comp.Instance.SetPanelActive(2);
+            comp.Instance.SetPanelActive(2);
 
             var scrollButtons = comp.FindComponents<MudIconButton>();
 
@@ -642,20 +641,20 @@ namespace MudBlazor.UnitTests.Components
 
         #region Helper
 
-        private static Double GetSliderValue(IRenderedComponent<ScrollableTabsTest> comp, String attribute = "left")
+        private static double GetSliderValue(IRenderedComponent<ScrollableTabsTest> comp, string attribute = "left")
         {
             var slider = comp.Find(".mud-tab-slider");
             slider.HasAttribute("style").Should().Be(true);
 
-            String styleAttribute = slider.GetAttribute("style");
-            Int32 indexToSplit = styleAttribute.IndexOf($"{attribute}:");
-            String substring = styleAttribute.Substring(indexToSplit + attribute.Length + 1);
+            var styleAttribute = slider.GetAttribute("style");
+            var indexToSplit = styleAttribute.IndexOf($"{attribute}:");
+            var substring = styleAttribute.Substring(indexToSplit + attribute.Length + 1);
             substring = substring.Remove(substring.Length - 3);
-            Double value = Double.Parse(substring, CultureInfo.InvariantCulture);
+            var value = double.Parse(substring, CultureInfo.InvariantCulture);
             return value;
         }
 
-       
+
 
 
         #endregion

--- a/src/MudBlazor.UnitTests/Generated/ApiDocsTests.cs
+++ b/src/MudBlazor.UnitTests/Generated/ApiDocsTests.cs
@@ -26,6 +26,7 @@ namespace MudBlazor.UnitTests.Components
             ctx.Services.AddTransient<IScrollManager, MockScrollManager>();
             ctx.Services.AddTransient<IScrollListener, MockScrollListener>();
             ctx.Services.AddTransient<IJsApiService, MockJsApiServices>();
+            ctx.Services.AddTransient<IResizeObserver, MockResizeObserver>();
             ctx.Services.AddSingleton<IHeadElementHelper>(new MockHeadElementHelper());
             ctx.Services.AddSingleton<IBrowserWindowSizeProvider>(new MockBrowserWindowSizeProvider());
             ctx.Services.AddScoped(sp => new HttpClient());

--- a/src/MudBlazor.UnitTests/Generated/ExampleDocsTests.cs
+++ b/src/MudBlazor.UnitTests/Generated/ExampleDocsTests.cs
@@ -29,6 +29,7 @@ namespace MudBlazor.UnitTests.Components
             ctx.Services.AddTransient<IScrollListener, MockScrollListener>();
             ctx.Services.AddTransient<IJsApiService, MockJsApiServices>();
             ctx.Services.AddSingleton<IHeadElementHelper>(new MockHeadElementHelper());
+            ctx.Services.AddTransient<IResizeObserver, MockResizeObserver>();
             ctx.Services.AddSingleton<IBrowserWindowSizeProvider>(new MockBrowserWindowSizeProvider());
             ctx.Services.AddOptions();
             ctx.Services.AddScoped(sp =>

--- a/src/MudBlazor.UnitTests/Mocks/MockResizeObserver.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockResizeObserver.cs
@@ -1,0 +1,108 @@
+﻿
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using MudBlazor.Interop;
+using MudBlazor.Services;
+
+namespace MudBlazor.UnitTests.Mocks
+{
+    public class MockResizeObserver : IResizeObserver
+    {
+        private Dictionary<ElementReference, BoundingClientRect> _cachedValues = new();
+
+        public Boolean IsVertical { get; set; } = false;
+
+        public event SizeChanged OnResized;
+
+        public void UpdateTotalPanelSize(Double newSize)
+        {
+            var entry = _cachedValues.Last();
+
+            if (IsVertical == false)
+            {
+                entry.Value.Width = newSize;
+            }
+            else
+            {
+                entry.Value.Height = newSize;
+            }
+
+            OnResized?.Invoke(new Dictionary<ElementReference, BoundingClientRect> {
+                    { entry.Key, entry.Value  },
+                });
+        }
+
+        public void UpdatePanelSize(Int32 index, Double newSize)
+        {
+            var entry = _cachedValues.ElementAt(index);
+
+            if (IsVertical == false)
+            {
+                entry.Value.Width = newSize;
+            }
+            else
+            {
+                entry.Value.Height = newSize;
+            }
+
+            OnResized?.Invoke(new Dictionary<ElementReference, BoundingClientRect> {
+                    { entry.Key, entry.Value  },
+                });
+        }
+
+        public Double PanelSize { get; set; } = 250;
+        public Double PanelTotalSize { get; set; } = 3000;
+
+        public async Task<BoundingClientRect> Observe(ElementReference element) => (await Observe(new[] { element })).FirstOrDefault();
+
+        public Task<IEnumerable<BoundingClientRect>> Observe(IEnumerable<ElementReference> elements)
+        {
+            List<BoundingClientRect> result = new List<BoundingClientRect>();
+            foreach (var item in elements)
+            {
+                Double size = PanelSize;
+                // last element is alaways TabsContentSize
+                if (item.Id == elements.Last().Id && elements.Count() > 1)
+                {
+                    size = PanelTotalSize;
+                }
+                var rect = new BoundingClientRect { Width = size };
+                if (IsVertical == true)
+                {
+                    rect = new BoundingClientRect { Height = size };
+                }
+                _cachedValues.Add(item, rect);
+            }
+
+            return Task.FromResult<IEnumerable<BoundingClientRect>>(result);
+        }
+
+        public Task Unobserve(ElementReference element)
+        {
+            _cachedValues.Remove(element);
+            return Task.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        public BoundingClientRect GetSizeInfo(ElementReference reference)
+        {
+            if (_cachedValues.ContainsKey(reference) == false)
+            {
+                return null;
+            }
+
+            return _cachedValues[reference];
+        }
+        public double GetHeight(ElementReference reference) => GetSizeInfo(reference)?.Height ?? 0.0;
+        public double GetWidth(ElementReference reference) => GetSizeInfo(reference)?.Width ?? 0.0;
+        public Boolean IsElementObserved(ElementReference reference) => _cachedValues.ContainsKey(reference);
+    }
+}

--- a/src/MudBlazor.UnitTests/Services/JavascriptBasedResizeObserverTests.cs
+++ b/src/MudBlazor.UnitTests/Services/JavascriptBasedResizeObserverTests.cs
@@ -1,0 +1,289 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+using Moq;
+using MudBlazor.Interop;
+using MudBlazor.Services;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Services
+{
+    [TestFixture]
+    public class JavascriptBasedResizeObserverTests
+    {
+        private class PseudoElementReferenceContext : ElementReferenceContext
+        {
+
+        }
+
+        private Mock<IJSRuntime> _runtimeMock;
+        private JavascriptBasedResizeObserver _service;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _runtimeMock = new Mock<IJSRuntime>(MockBehavior.Strict);
+            _service = new JavascriptBasedResizeObserver(_runtimeMock.Object);
+        }
+
+        [Test]
+        public async Task ObserveAndCache()
+        {
+            // Arrange
+            Random random = new Random();
+
+            List<ElementReference> allReferences = new();
+            List<ElementReference> notObservedReferences = new();
+            Dictionary<ElementReference, BoundingClientRect> resolvedElements = new();
+
+            Int32 amount = 13;
+            for (int i = 1; i <= amount; i++)
+            {
+                ElementReference reference = new ElementReference(Guid.NewGuid().ToString(), new PseudoElementReferenceContext());
+                var rect = GetRandomRect(random);
+
+                if (i % 4 == 0)
+                {
+                    reference = new ElementReference();
+                    notObservedReferences.Add(reference);
+                }
+                else if (i % 5 == 0)
+                {
+                    reference = new ElementReference(Guid.NewGuid().ToString());
+                    notObservedReferences.Add(reference);
+                }
+                else
+                {
+                    resolvedElements.Add(reference, rect);
+                }
+
+                allReferences.Add(reference);
+            }
+
+            _runtimeMock.Setup(x => x.InvokeAsync<IEnumerable<BoundingClientRect>>(
+                "mudResizeObserver.connect",
+                It.Is<object[]>(z =>
+                    (Guid)z[0] != default &&
+                    (z[1] is DotNetObjectReference<JavascriptBasedResizeObserver>) == true &&
+                    (z[2] is IEnumerable<ElementReference>) == true &&
+                    (z[3] is IEnumerable<Guid>) == true &&
+                    (z[4] is ResizeObserverOptions) == true && ((ResizeObserverOptions)z[4]).EnableLogging == false && ((ResizeObserverOptions)z[4]).ReportRate == 200
+                )
+            )).ReturnsAsync(resolvedElements.Values).Verifiable();
+
+            // Act
+            var actual = await _service.Observe(allReferences);
+
+            // Assert
+            actual.Should().BeEquivalentTo(resolvedElements.Values);
+
+            foreach (var item in resolvedElements.Keys)
+            {
+                _service.IsElementObserved(item).Should().BeTrue();
+
+                var size = _service.GetSizeInfo(item);
+
+                size.Should().BeEquivalentTo(resolvedElements[item]);
+
+                size.Width.Should().Be(_service.GetWidth(item));
+                size.Height.Should().Be(_service.GetHeight(item));
+            }
+
+            foreach (var item in notObservedReferences)
+            {
+                _service.IsElementObserved(item).Should().BeFalse();
+
+                var size = _service.GetSizeInfo(item);
+
+                size.Should().BeNull();
+
+                _service.GetWidth(item).Should().Be(0.0);
+                _service.GetHeight(item).Should().Be(0.0);
+            }
+
+            _runtimeMock.Verify();
+        }
+
+        [Test]
+        public async Task NotValidElementsToObserve()
+        {
+            // Arrange
+            List<ElementReference> notObservedReferences = new();
+
+            Int32 amount = 10;
+            for (int i = 1; i <= amount; i++)
+            {
+                ElementReference reference = new ElementReference(Guid.NewGuid().ToString(), new PseudoElementReferenceContext());
+
+                if (i % 2 == 0)
+                {
+                    reference = new ElementReference();
+                }
+                else
+                {
+                    reference = new ElementReference(Guid.NewGuid().ToString());
+                }
+                notObservedReferences.Add(reference);
+            }
+
+            // Act
+            var actual = await _service.Observe(notObservedReferences);
+
+            // Assert
+            actual.Should().BeEmpty();
+        }
+
+        [Test]
+        public async Task Unobserve()
+        {
+            // Arrange
+            Random random = new Random();
+
+            Dictionary<ElementReference, BoundingClientRect> resolvedElements = new();
+
+            Int32 amount = 13;
+            for (int i = 1; i <= amount; i++)
+            {
+                ElementReference reference = new ElementReference(Guid.NewGuid().ToString(), new PseudoElementReferenceContext());
+                var rect = GetRandomRect(random);
+
+                resolvedElements.Add(reference, rect);
+            }
+
+            List<Guid> ids = new();
+            Guid observerId = Guid.Empty;
+
+            _runtimeMock.Setup(x => x.InvokeAsync<IEnumerable<BoundingClientRect>>(
+                "mudResizeObserver.connect",
+                It.Is<object[]>(z =>
+                    (Guid)z[0] != default &&
+                    (z[1] is DotNetObjectReference<JavascriptBasedResizeObserver>) == true &&
+                    (z[2] is IEnumerable<ElementReference>) == true &&
+                    (z[3] is IEnumerable<Guid>) == true &&
+                    (z[4] is ResizeObserverOptions) == true && ((ResizeObserverOptions)z[4]).EnableLogging == false && ((ResizeObserverOptions)z[4]).ReportRate == 200
+                )
+            )).ReturnsAsync(resolvedElements.Values).Callback<String, object[]>((x, y) => { observerId = (Guid)y[0]; ids = new List<Guid>((IEnumerable<Guid>)y[3]); }).Verifiable();
+
+
+            foreach (var item in resolvedElements)
+            {
+                _runtimeMock.Setup(x => x.InvokeAsync<Object>(
+                "mudResizeObserver.disconnect",
+                It.Is<object[]>(z =>
+                    (Guid)z[0] == observerId &&
+                    ids.Contains((Guid)z[1]) == true
+                )
+            )).ReturnsAsync(new Object()).Callback<String, Object[]>((x, y) => { ids.Remove((Guid)y[1]); }).Verifiable();
+            }
+
+            await _service.Observe(resolvedElements.Keys);
+
+            foreach (var item in resolvedElements.Keys)
+            {
+                _service.IsElementObserved(item).Should().BeTrue();
+
+                //Act
+                await _service.Unobserve(item);
+
+                //Assert
+                _service.IsElementObserved(item).Should().BeFalse();
+            }
+
+            _runtimeMock.Verify();
+        }
+
+        [Test]
+        public async Task OnSizeChanged()
+        {
+            // Arrange
+            Random random = new Random();
+
+            Dictionary<ElementReference, BoundingClientRect> resolvedElements = new();
+
+            Int32 amount = 13;
+            for (int i = 1; i <= amount; i++)
+            {
+                ElementReference reference = new ElementReference(Guid.NewGuid().ToString(), new PseudoElementReferenceContext());
+                var rect = GetRandomRect(random);
+
+                resolvedElements.Add(reference, rect);
+            }
+
+            List<Guid> ids = new();
+
+            _runtimeMock.Setup(x => x.InvokeAsync<IEnumerable<BoundingClientRect>>(
+                "mudResizeObserver.connect",
+                It.Is<object[]>(z =>
+                    (Guid)z[0] != default &&
+                    (z[1] is DotNetObjectReference<JavascriptBasedResizeObserver>) == true &&
+                    (z[2] is IEnumerable<ElementReference>) == true &&
+                    (z[3] is IEnumerable<Guid>) == true &&
+                    (z[4] is ResizeObserverOptions) == true && ((ResizeObserverOptions)z[4]).EnableLogging == false && ((ResizeObserverOptions)z[4]).ReportRate == 200
+                )
+            )).ReturnsAsync(resolvedElements.Values).Callback<String, object[]>((x, y) => { ids = new List<Guid>((IEnumerable<Guid>)y[3]); }).Verifiable();
+
+            await _service.Observe(resolvedElements.Keys);
+
+            var changes = new List<JavascriptBasedResizeObserver.SizeChangeUpdateInfo>();
+
+            Dictionary<ElementReference, BoundingClientRect> expectedRects = new();
+
+            for (int i = 0; i < resolvedElements.Count(); i++)
+            {
+                var item = resolvedElements.ElementAt(i);
+                var correspondingId = ids[i];
+
+                if (random.NextDouble() > 0.5)
+                {
+                    changes.Add(new JavascriptBasedResizeObserver.SizeChangeUpdateInfo(Guid.NewGuid(), GetRandomRect(random)));
+                }
+                else
+                {
+                    var rect = GetRandomRect(random);
+                    expectedRects.Add(item.Key, rect);
+                    changes.Add(new JavascriptBasedResizeObserver.SizeChangeUpdateInfo(correspondingId, rect));
+                }
+            }
+
+            Boolean sizeChangesChecked = false;
+
+            _service.OnResized += (sizeChanges) =>
+            {
+                //Assertion of event content
+                sizeChanges.Should().NotBeEmpty().And.BeEquivalentTo(expectedRects);
+
+                sizeChangesChecked = true;
+            };
+
+            //Act
+            _service.OnSizeChanged(changes);
+
+            //Assertion
+            sizeChangesChecked.Should().BeTrue();
+            _runtimeMock.Verify();
+        }
+
+        #region Helper
+
+        private static BoundingClientRect GetRandomRect(Random random)
+        {
+            return new BoundingClientRect
+            {
+                Bottom = random.Next(10, 200) + random.NextDouble(),
+                Height = random.Next(10, 200) + random.NextDouble(),
+                Left = random.Next(10, 200) + random.NextDouble(),
+                Right = random.Next(10, 200) + random.NextDouble(),
+                Top = random.Next(10, 200) + random.NextDouble(),
+                Width = random.Next(10, 200) + random.NextDouble(),
+                X = random.Next(10, 200) + random.NextDouble(),
+                Y = random.Next(10, 200) + random.NextDouble(),
+            };
+        }
+
+        #endregion
+    }
+}

--- a/src/MudBlazor.UnitTests/Services/JavascriptBasedResizeObserverTests.cs
+++ b/src/MudBlazor.UnitTests/Services/JavascriptBasedResizeObserverTests.cs
@@ -249,6 +249,11 @@ namespace MudBlazor.UnitTests.Services
                 }
             }
 
+            foreach (var item in expectedRects)
+            {
+                resolvedElements[item.Key] = item.Value;
+            }
+
             Boolean sizeChangesChecked = false;
 
             _service.OnResized += (sizeChanges) =>
@@ -264,6 +269,14 @@ namespace MudBlazor.UnitTests.Services
 
             //Assertion
             sizeChangesChecked.Should().BeTrue();
+
+            foreach (var item in resolvedElements)
+            {
+               var sizeInfo = _service.GetSizeInfo(item.Key);
+
+                sizeInfo.Should().BeEquivalentTo(item.Value);
+            }
+
             _runtimeMock.Verify();
         }
 

--- a/src/MudBlazor.UnitTests/Services/ResizeObserverTests.cs
+++ b/src/MudBlazor.UnitTests/Services/ResizeObserverTests.cs
@@ -13,7 +13,7 @@ using NUnit.Framework;
 namespace MudBlazor.UnitTests.Services
 {
     [TestFixture]
-    public class JavascriptBasedResizeObserverTests
+    public class ResizeObserverTests
     {
         private class PseudoElementReferenceContext : ElementReferenceContext
         {
@@ -21,13 +21,13 @@ namespace MudBlazor.UnitTests.Services
         }
 
         private Mock<IJSRuntime> _runtimeMock;
-        private JavascriptBasedResizeObserver _service;
+        private ResizeObserver _service;
 
         [SetUp]
         public void SetUp()
         {
             _runtimeMock = new Mock<IJSRuntime>(MockBehavior.Strict);
-            _service = new JavascriptBasedResizeObserver(_runtimeMock.Object);
+            _service = new ResizeObserver(_runtimeMock.Object);
         }
 
         [Test]
@@ -68,7 +68,7 @@ namespace MudBlazor.UnitTests.Services
                 "mudResizeObserver.connect",
                 It.Is<object[]>(z =>
                     (Guid)z[0] != default &&
-                    (z[1] is DotNetObjectReference<JavascriptBasedResizeObserver>) == true &&
+                    (z[1] is DotNetObjectReference<ResizeObserver>) == true &&
                     (z[2] is IEnumerable<ElementReference>) == true &&
                     (z[3] is IEnumerable<Guid>) == true &&
                     (z[4] is ResizeObserverOptions) == true && ((ResizeObserverOptions)z[4]).EnableLogging == false && ((ResizeObserverOptions)z[4]).ReportRate == 200
@@ -161,7 +161,7 @@ namespace MudBlazor.UnitTests.Services
                 "mudResizeObserver.connect",
                 It.Is<object[]>(z =>
                     (Guid)z[0] != default &&
-                    (z[1] is DotNetObjectReference<JavascriptBasedResizeObserver>) == true &&
+                    (z[1] is DotNetObjectReference<ResizeObserver>) == true &&
                     (z[2] is IEnumerable<ElementReference>) == true &&
                     (z[3] is IEnumerable<Guid>) == true &&
                     (z[4] is ResizeObserverOptions) == true && ((ResizeObserverOptions)z[4]).EnableLogging == false && ((ResizeObserverOptions)z[4]).ReportRate == 200
@@ -219,7 +219,7 @@ namespace MudBlazor.UnitTests.Services
                 "mudResizeObserver.connect",
                 It.Is<object[]>(z =>
                     (Guid)z[0] != default &&
-                    (z[1] is DotNetObjectReference<JavascriptBasedResizeObserver>) == true &&
+                    (z[1] is DotNetObjectReference<ResizeObserver>) == true &&
                     (z[2] is IEnumerable<ElementReference>) == true &&
                     (z[3] is IEnumerable<Guid>) == true &&
                     (z[4] is ResizeObserverOptions) == true && ((ResizeObserverOptions)z[4]).EnableLogging == false && ((ResizeObserverOptions)z[4]).ReportRate == 200
@@ -228,7 +228,7 @@ namespace MudBlazor.UnitTests.Services
 
             await _service.Observe(resolvedElements.Keys);
 
-            var changes = new List<JavascriptBasedResizeObserver.SizeChangeUpdateInfo>();
+            var changes = new List<ResizeObserver.SizeChangeUpdateInfo>();
 
             Dictionary<ElementReference, BoundingClientRect> expectedRects = new();
 
@@ -239,13 +239,13 @@ namespace MudBlazor.UnitTests.Services
 
                 if (random.NextDouble() > 0.5)
                 {
-                    changes.Add(new JavascriptBasedResizeObserver.SizeChangeUpdateInfo(Guid.NewGuid(), GetRandomRect(random)));
+                    changes.Add(new ResizeObserver.SizeChangeUpdateInfo(Guid.NewGuid(), GetRandomRect(random)));
                 }
                 else
                 {
                     var rect = GetRandomRect(random);
                     expectedRects.Add(item.Key, rect);
-                    changes.Add(new JavascriptBasedResizeObserver.SizeChangeUpdateInfo(correspondingId, rect));
+                    changes.Add(new ResizeObserver.SizeChangeUpdateInfo(correspondingId, rect));
                 }
             }
 

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -191,7 +191,7 @@ namespace MudBlazor
             set => _value = value;
         }
 
-        protected async Task SetValueAsync(T value, bool updateText = true)
+        protected virtual async Task SetValueAsync(T value, bool updateText = true)
         {
             if (!EqualityComparer<T>.Default.Equals(Value, value))
             {

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Globalization;

--- a/src/MudBlazor/Components/Chart/Interpolation/Matrix.cs
+++ b/src/MudBlazor/Components/Chart/Interpolation/Matrix.cs
@@ -1,12 +1,4 @@
-﻿// Not Used
-
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace MudBlazor.Components.Chart
+﻿namespace MudBlazor.Components.Chart
 {
     public class Matrix
     {

--- a/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanels.razor.cs
+++ b/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanels.razor.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.Utilities;

--- a/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanels.razor.cs
+++ b/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanels.razor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.Utilities;
@@ -75,6 +75,7 @@ namespace MudBlazor
                     last.NextPanelExpanded = panel.IsExpanded;
                 last = panel;
             }
+            StateHasChanged();
         }
 
         public void CloseAllExcept(MudExpansionPanel panel)

--- a/src/MudBlazor/Components/Input/MudInput.razor
+++ b/src/MudBlazor/Components/Input/MudInput.razor
@@ -4,10 +4,10 @@
 @using MudBlazor.Internal
 
 <div class="@Classname" style="@Style">
-    @if (Adornment == Adornment.Start)
-    {
-        <MudInputAdornment Class="@AdornmentClassname" Icon="@AdornmentIcon" Color="@AdornmentColor" Size="@IconSize" Text="@AdornmentText" Edge="@Edge.Start" AdornmentClick="@OnAdornmentClick" />
-    }
+	@if (Adornment == Adornment.Start)
+	{
+	 <MudInputAdornment Class="@AdornmentClassname" Icon="@AdornmentIcon" Color="@AdornmentColor" Size="@IconSize" Text="@AdornmentText" Edge="@Edge.Start" AdornmentClick="@OnAdornmentClick" />
+	}
 
 	@if (Lines > 1)
 	{
@@ -36,8 +36,20 @@
 	 <MudInputAdornment Class="@AdornmentClassname" Icon="@AdornmentIcon" Color="@AdornmentColor" Size="@IconSize" Text="@AdornmentText" Edge="@Edge.End" AdornmentClick="@OnAdornmentClick" />
 	}
 
-    @if (Variant == Variant.Outlined)
-    {
-        <div class="mud-input-outlined-border"></div>
-    }
+	@if (Variant == Variant.Outlined)
+	{
+	 <div class="mud-input-outlined-border"></div>
+	}
+
+	@if (InputType == InputType.Number && !HideSpinButtons)
+	{
+	 <div class="mud-input-numeric-spin">
+	  <MudButton Variant="Variant.Text" @onclick="OnIncrement" Disabled="@(Disabled || ReadOnly)" tabindex="-1"><MudIcon Icon="@Icons.Material.Filled.KeyboardArrowUp" Size="@GetButtonSize()" /></MudButton>
+	  <MudButton Variant="Variant.Text" @onclick="OnDecrement" Disabled="@(Disabled || ReadOnly)" tabindex="-1"><MudIcon Icon="@Icons.Material.Filled.KeyboardArrowDown" Size="@GetButtonSize()" /></MudButton>
+	 </div>
+	}
 </div>
+
+@code {
+	private Size GetButtonSize() => Margin == Margin.Dense ? Size.Small : Size.Medium;
+}

--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -62,6 +62,24 @@ namespace MudBlazor
         /// The short hint displayed in the input before the user enters a value.
         /// </summary>
         [Parameter] public string Placeholder { get; set; }
+
+
+        /// <summary>
+        /// Invokes the callback when the Up arrow button is clicked when the input is set to <see cref="InputType.Number"/>.
+        /// Note: use the optimized control <see cref="MudNumericField{T}"/> if you need to deal with numbers.
+        /// </summary>
+        [Parameter] public EventCallback OnIncrement { get; set; }
+
+        /// <summary>
+        /// Invokes the callback when the Down arrow button is clicked when the input is set to <see cref="InputType.Number"/>.
+        /// Note: use the optimized control <see cref="MudNumericField{T}"/> if you need to deal with numbers.
+        /// </summary>
+        [Parameter] public EventCallback OnDecrement { get; set; }
+
+        /// <summary>
+        /// Hides the spin buttons for <see cref="MudNumericField{T}"/>
+        /// </summary>
+        [Parameter] public bool HideSpinButtons { get; set; }
     }
 
     public class MudInputString : MudInput<string> { }

--- a/src/MudBlazor/Components/Link/MudLink.razor.cs
+++ b/src/MudBlazor/Components/Link/MudLink.razor.cs
@@ -15,7 +15,7 @@ namespace MudBlazor
           .AddClass($"mud-link-disabled", Disabled)
           .AddClass(Class)
         .Build();
-        
+
         private Dictionary<string, object> Attributes
         {
             get => Disabled ? UserAttributes : new Dictionary<string, object>(UserAttributes)

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor
@@ -1,0 +1,39 @@
+﻿@namespace MudBlazor
+@typeparam T
+@inherits MudDebouncedInput<T>
+
+@using System.Globalization;
+
+<CascadingValue Name="Standalone" Value="@Standalone" IsFixed="true">
+	<MudInputControl Label="@Label" Variant="@Variant" HelperText="@HelperText" FullWidth="@FullWidth" Class="@Classname"
+					 Error="@HasErrors" ErrorText="@GetErrorText()" Disabled="@Disabled" Margin="@Margin" Required="@Required">
+		<InputContent>
+			<MudInput T="string" @ref="_elementReference" @attributes="UserAttributes" InputType="InputType.Number" Style="@Style" Variant="@Variant"
+					  Value="@Text" ValueChanged="(v) => SetTextAsync(v)" Converter="s_inputConverter" Placeholder="@Placeholder"
+					  Disabled=@Disabled DisableUnderLine="@DisableUnderLine" ReadOnly="@ReadOnly" Adornment="@Adornment"
+					  AdornmentText="@AdornmentText" AdornmentIcon="@AdornmentIcon" AdornmentColor="@AdornmentColor" IconSize="@IconSize"
+					  OnAdornmentClick="@OnAdornmentClick" Error="@Error" Immediate="@Immediate" Margin="@Margin"
+					  OnBlur="@OnBlurred" OnKeyDown="@InterceptArrowKey" OnKeyPress="@InvokeKeyPress" OnKeyUp="@InvokeKeyUp"
+					  KeyDownPreventDefault="_keyDownPreventDefault" KeyPressPreventDefault="KeyPressPreventDefault" KeyUpPreventDefault="KeyUpPreventDefault"
+					  OnIncrement="Increment" OnDecrement="Decrement" HideSpinButtons="@HideSpinButtons" Validation="_validateInstance"
+					  min="@(_minHasValue ? FormatParam(_min) : null)"
+					  max="@(_maxHasValue ? FormatParam(_max): null)"
+					  step="@(_stepHasValue ? FormatParam(_step) : null)" />
+		</InputContent>
+	</MudInputControl>
+</CascadingValue>
+
+@code{
+	//avoids the format to use scientific notation for large or small number in floating points types, while covering all options
+	//https://stackoverflow.com/questions/1546113/double-to-string-conversion-without-scientific-notation
+	private const string TagFormat = "0.###################################################################################################################################################################################################################################################################################################################################################";
+
+	private string FormatParam(T value)
+	{
+		if (value is IFormattable f)
+			return f.ToString(TagFormat, CultureInfo.InvariantCulture.NumberFormat);
+		else
+			return null;
+	}
+
+}

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -1,0 +1,403 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using MudBlazor.Utilities;
+
+namespace MudBlazor
+{
+    public partial class MudNumericField<T> : MudDebouncedInput<T>
+    {
+        public MudNumericField() : base()
+        {
+            //With input[type=number] the browser reads and sets the value using dot as decimal separator, while showing and parsing the text in the user Locale setting.
+            //Since this is completely transparent to us, we need to use a Converter using an InvariantCulture.
+            SetConverter(new DefaultConverter<T> { Culture = CultureInfo.InvariantCulture });
+
+            _validateInstance = new Func<T, Task<bool>>(ValidateInput);
+
+            #region parameters default depending on T
+            //sbyte
+            if (typeof(T) == typeof(sbyte) || typeof(T) == typeof(sbyte?))
+            {
+                _minDefault = (T)(object)sbyte.MinValue;
+                _maxDefault = (T)(object)sbyte.MaxValue;
+                _stepDefault = (T)(object)1;
+            }
+            // byte
+            else if (typeof(T) == typeof(byte) || typeof(T) == typeof(byte?))
+            {
+                _minDefault = (T)(object)byte.MinValue;
+                _maxDefault = (T)(object)byte.MaxValue;
+                _stepDefault = (T)(object)1;
+            }
+            // short
+            else if (typeof(T) == typeof(short) || typeof(T) == typeof(short?))
+            {
+                _minDefault = (T)(object)short.MinValue;
+                _maxDefault = (T)(object)short.MaxValue;
+                _stepDefault = (T)(object)1;
+            }
+            // ushort
+            else if (typeof(T) == typeof(ushort) || typeof(T) == typeof(ushort?))
+            {
+                _minDefault = (T)(object)ushort.MinValue;
+                _maxDefault = (T)(object)ushort.MaxValue;
+                _stepDefault = (T)(object)1;
+            }
+            // int
+            else if (typeof(T) == typeof(int) || typeof(T) == typeof(int?))
+            {
+                _minDefault = (T)(object)int.MinValue;
+                _maxDefault = (T)(object)int.MaxValue;
+                _stepDefault = (T)(object)1;
+            }
+            // uint
+            else if (typeof(T) == typeof(uint) || typeof(T) == typeof(uint?))
+            {
+                _minDefault = (T)(object)uint.MinValue;
+                _maxDefault = (T)(object)uint.MaxValue;
+                _stepDefault = (T)(object)1;
+            }
+            // long
+            else if (typeof(T) == typeof(long) || typeof(T) == typeof(long?))
+            {
+                _minDefault = (T)(object)long.MinValue;
+                _maxDefault = (T)(object)long.MaxValue;
+                _stepDefault = (T)(object)1;
+            }
+            // ulong
+            else if (typeof(T) == typeof(ulong) || typeof(T) == typeof(ulong?))
+            {
+                _minDefault = (T)(object)ulong.MinValue;
+                _maxDefault = (T)(object)ulong.MaxValue;
+                _stepDefault = (T)(object)1;
+            }
+            // float
+            else if (typeof(T) == typeof(float) || typeof(T) == typeof(float?))
+            {
+                _minDefault = (T)(object)float.MinValue;
+                _maxDefault = (T)(object)float.MaxValue;
+                _stepDefault = (T)(object)1.0f;
+            }
+            // double
+            else if (typeof(T) == typeof(double) || typeof(T) == typeof(double?))
+            {
+                _minDefault = (T)(object)double.MinValue;
+                _maxDefault = (T)(object)double.MaxValue;
+                _stepDefault = (T)(object)1.0;
+            }
+            // decimal
+            else if (typeof(T) == typeof(decimal) || typeof(T) == typeof(decimal?))
+            {
+                _minDefault = (T)(object)decimal.MinValue;
+                _maxDefault = (T)(object)decimal.MaxValue;
+                _stepDefault = (T)(object)1M;
+            }
+            #endregion
+        }
+
+        protected string Classname =>
+           new CssBuilder("mud-input-input-control mud-input-number-control " + (HideSpinButtons ? "mud-input-nospin" : "mud-input-showspin"))
+           .AddClass(Class)
+           .Build();
+
+        private Func<T, Task<bool>> _validateInstance;
+
+        private MudInput<string> _elementReference;
+
+        private static Converter<string> s_inputConverter = new DefaultConverter<string> { Culture = CultureInfo.InvariantCulture };
+
+        public override ValueTask FocusAsync()
+        {
+            return _elementReference.FocusAsync();
+        }
+
+        public override ValueTask SelectAsync()
+        {
+            return _elementReference.SelectAsync();
+        }
+
+        public override ValueTask SelectRangeAsync(int pos1, int pos2)
+        {
+            return _elementReference.SelectRangeAsync(pos1, pos2);
+        }
+
+        protected override async Task SetValueAsync(T value, bool updateText = true)
+        {
+            bool valueChanged;
+            (value, valueChanged) = ConstrainBoundaries(value);
+            await base.SetValueAsync(ConstrainBoundaries(value).value, valueChanged || updateText);
+        }
+
+        protected async Task<bool> ValidateInput(T value)
+        {
+            bool valueChanged;
+            (value, valueChanged) = ConstrainBoundaries(value);
+            if (valueChanged)
+                await SetValueAsync(value, true);
+            return true;//Don't show errors
+        }
+
+
+        #region Numeric range
+        public async Task Increment()
+        {
+            dynamic val;
+            try
+            {
+                checked
+                {
+                    val = Value switch
+                    {
+                        sbyte b => b + (sbyte)(object)Step,
+                        byte b => b + (byte)(object)Step,
+                        short i => i + (short)(object)Step,
+                        ushort i => i + (ushort)(object)Step,
+                        int i => i + (int)(object)Step,
+                        uint i => i + (uint)(object)Step,
+                        long i => i + (long)(object)Step,
+                        ulong i => i + (ulong)(object)Step,
+                        float f => f + (float)(object)Step,
+                        double d => d + (double)(object)Step,
+                        decimal d => d + (decimal)(object)Step,
+                        _ => Value
+                    };
+                }
+            }
+            catch (OverflowException)
+            {
+                val = Max;
+            }
+
+            await SetValueAsync(ConstrainBoundaries((T)val).value);
+        }
+
+        public async Task Decrement()
+        {
+            dynamic val;
+            try
+            {
+                checked
+                {
+                    val = Value switch
+                    {
+                        sbyte b => b - (sbyte)(object)Step,
+                        byte b => b - (byte)(object)Step,
+                        short i => i - (short)(object)Step,
+                        ushort i => i - (ushort)(object)Step,
+                        int i => i - (int)(object)Step,
+                        uint i => i - (uint)(object)Step,
+                        long i => i - (long)(object)Step,
+                        ulong i => i - (ulong)(object)Step,
+                        float f => f - (float)(object)Step,
+                        double d => d - (double)(object)Step,
+                        decimal d => d - (decimal)(object)Step,
+                        _ => Value,
+                    };
+                }
+            }
+            catch (OverflowException)
+            {
+                val = Min;
+            }
+
+            await SetValueAsync(ConstrainBoundaries((T)val).value);
+        }
+
+        /// <summary>
+        /// Checks if the value respects the boundaries set for this instance.
+        /// </summary>
+        /// <param name="value">Value to check.</param>
+        /// <returns>Returns a valid value and if it has been changed.</returns>
+        protected (T value, bool changed) ConstrainBoundaries(T value)
+        {
+            //check if Max/Min has value, if not use MaxValue/MinValue for that data type
+            switch (value)
+            {
+                case sbyte b:
+                    if (b > (sbyte)(object)Max)
+                        return (Max, true);
+                    else if (b < (sbyte)(object)Min)
+                        return (Min, true);
+                    break;
+
+                case byte b:
+                    if (b > (byte)(object)Max)
+                        return (Max, true);
+                    else if (b < (byte)(object)Min)
+                        return (Min, true);
+                    break;
+
+                case short i:
+                    if (i > (short)(object)Max)
+                        return (Max, true);
+                    else if (i < (short)(object)Min)
+                        return (Min, true);
+                    break;
+
+                case ushort i:
+                    if (i > (ushort)(object)Max)
+                        return (Max, true);
+                    else if (i < (ushort)(object)Min)
+                        return (Min, true);
+                    break;
+
+                case int i:
+                    if (i > (int)(object)Max)
+                        return (Max, true);
+                    else if (i < (int)(object)Min)
+                        return (Min, true);
+                    break;
+
+                case uint i:
+                    if (i > (uint)(object)Max)
+                        return (Max, true);
+                    else if (i < (uint)(object)Min)
+                        return (Min, true);
+                    break;
+
+                case long i:
+                    if (i > (long)(object)Max)
+                        return (Max, true);
+                    else if (i < (long)(object)Min)
+                        return (Min, true);
+                    break;
+
+                case ulong i:
+                    if (i > (ulong)(object)Max)
+                        return (Max, true);
+                    else if (i < (ulong)(object)Min)
+                        return (Min, true);
+                    break;
+
+                case float f:
+                    if (f > (float)(object)Max)
+                        return (Max, true);
+                    else if (f < (float)(object)Min)
+                        return (Min, true);
+                    break;
+
+                case double d:
+                    if (d > (double)(object)Max)
+                        return (Max, true);
+                    else if (d < (double)(object)Min)
+                        return (Min, true);
+                    break;
+
+                case decimal d:
+                    if (d > (decimal)(object)Max)
+                        return (Max, true);
+                    else if (d < (decimal)(object)Min)
+                        return (Min, true);
+                    break;
+            };
+
+            return (value, false);
+        }
+
+        #endregion
+
+        private bool _keyDownPreventDefault;
+        /// <summary>
+        /// Overrides KeyDown event, intercepts Arrow Up/Down and uses them to add/substract the value manually by the step value.
+        /// Relying on the browser mean the steps are each integer multiple from <see cref="Min"/> up until <see cref="Max"/>.
+        /// This align the behaviour with the spinner buttons.
+        /// </summary>
+        /// <remarks>https://try.mudblazor.com/snippet/QamlkdvmBtrsuEtb</remarks>
+        protected async Task InterceptArrowKey(KeyboardEventArgs obj)
+        {
+            if (obj.Type == "keydown")//KeyDown or repeat, blazor never fire InvokeKeyPress
+            {
+                if (obj.Key == "ArrowUp")
+                {
+                    await Increment();
+                    return;
+                }
+                else if (obj.Key == "ArrowDown")
+                {
+                    await Decrement();
+                    return;
+                }
+            }
+            _keyDownPreventDefault = KeyDownPreventDefault;
+            OnKeyPress.InvokeAsync(obj).AndForget();
+        }
+
+        /// <summary>
+        /// The short hint displayed in the input before the user enters a value.
+        /// </summary>
+        [Parameter] public string Placeholder { get; set; }
+
+        /// <summary>
+        /// If string has value the label text will be displayed in the input, and scaled down at the top if the input has value.
+        /// </summary>
+        [Parameter] public string Label { get; set; }
+
+
+        //Tracks if Min has a value.
+        private bool _minHasValue = false;
+        //default value for the type
+        private T _minDefault;
+        private T _min;
+        /// <summary>
+        /// The minimum value for the input.
+        /// </summary>
+        [Parameter]
+        public T Min
+        {
+            get => _minHasValue ? _min : _minDefault;
+            set
+            {
+                _minHasValue = value != null;
+                _min = value;
+            }
+        }
+
+        //Tracks if Max has a value.
+        private bool _maxHasValue = false;
+        //default value for the type
+        private T _maxDefault;
+        private T _max;
+        /// <summary>
+        /// The maximum value for the input.
+        /// </summary>
+        [Parameter]
+        public T Max
+        {
+            get => _maxHasValue ? _max : _maxDefault;
+            set
+            {
+                _maxHasValue = value != null;
+                _max = value;
+            }
+        }
+
+        //Tracks if Max has a value.
+        private bool _stepHasValue = false;
+        //default value for the type, it's useful for decimal type to avoid constant evaluation
+        private T _stepDefault;
+        private T _step;
+
+        /// <summary>
+        /// The increment added/subtracted by the spin buttons.
+        /// </summary>
+        [Parameter]
+        public T Step
+        {
+            get => _stepHasValue ? _step : _stepDefault;
+            set
+            {
+                _stepHasValue = value != null;
+                _step = value;
+            }
+        }
+
+        /// <summary>
+        /// Hides the spin buttons, the user can still change value with keyboard arrows and manual update.
+        /// </summary>
+        [Parameter] public bool HideSpinButtons { get; set; }
+    }
+}

--- a/src/MudBlazor/Components/Tabs/MudTabPanel.razor
+++ b/src/MudBlazor/Components/Tabs/MudTabPanel.razor
@@ -70,15 +70,6 @@ else
     /// </summary>
     [Parameter] public string ToolTip { get; set; }
 
-    protected override async Task OnInitializedAsync()
-    {
-        await base.OnInitializedAsync();
-        if(Parent != null)
-        {
-            await Parent.AddPanel(this);
-        }
-    }
-
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         await base.OnAfterRenderAsync(firstRender);
@@ -94,6 +85,11 @@ else
         //if (Parent == null)
         //    throw new ArgumentNullException(nameof(Parent), "TabPanel must exist within a Tabs component");
         base.OnInitialized();
+
+        if (Parent != null)
+        {
+            Parent.AddPanel(this);
+        }
     }
 
     protected virtual void Dispose(bool disposing)

--- a/src/MudBlazor/Components/Tabs/MudTabPanel.razor
+++ b/src/MudBlazor/Components/Tabs/MudTabPanel.razor
@@ -82,7 +82,7 @@ else
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         await base.OnAfterRenderAsync(firstRender);
-        if(firstRender == true)
+        if(firstRender == true && Parent != null)
         {
             await Parent.SetPanelRef(PanelRef);
         }

--- a/src/MudBlazor/Components/Tabs/MudTabPanel.razor
+++ b/src/MudBlazor/Components/Tabs/MudTabPanel.razor
@@ -1,5 +1,6 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
+@implements IAsyncDisposable
 @implements IDisposable
 
 
@@ -69,21 +70,52 @@ else
     /// </summary>
     [Parameter] public string ToolTip { get; set; }
 
+    protected override async Task OnInitializedAsync()
+    {
+        await base.OnInitializedAsync();
+        if(Parent != null)
+        {
+            await Parent.AddPanel(this);
+        }
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        await base.OnAfterRenderAsync(firstRender);
+        if(firstRender == true)
+        {
+            await Parent.SetPanelRef(PanelRef);
+        }
+    }
+
     protected override void OnInitialized()
     {
         // NOTE: we must not throw here because we need the component to be able to live for the API docs to be able to infer default values
         //if (Parent == null)
         //    throw new ArgumentNullException(nameof(Parent), "TabPanel must exist within a Tabs component");
         base.OnInitialized();
-        Parent?.AddPanel(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
     }
 
     public void Dispose()
     {
-        try
-        {
-            Parent?.RemovePanel(this);
-        }
-        catch { }
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual async ValueTask DisposeAsyncCore()
+    {
+        await Parent?.RemovePanel(this);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await DisposeAsyncCore();
+
+        Dispose(false);
+        GC.SuppressFinalize(this);
     }
 }

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor
@@ -12,9 +12,9 @@
                         <MudIconButton Icon="@PrevIcon" Color="@ScrollIconColor" OnClick="@((e) => ScrollPrev())" Disabled="@_prevButtonDisabled" />
                     </div>
                 }  
-                <div @ref="@TabsContentSize" class="mud-tabs-toolbar-content">
+                <div @ref="@_tabsContentSize" class="mud-tabs-toolbar-content">
                     <div class="@WrapperClassnames" style="@WrapperScrollStyle">
-                        @foreach (MudTabPanel panel in Panels)
+                        @foreach (MudTabPanel panel in _panels)
                         {
                             <MudTooltip Placement="@GetTooltipPlacement()" Text="@panel.ToolTip">
                                 <div @ref="panel.PanelRef" class="@GetTabClass(panel)" style="@GetTabStyle(panel)" @onclick=@( e => ActivatePanel(panel, e, false) )>

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -193,37 +193,6 @@ namespace MudBlazor
             _resizeObserver.OnResized -= OnResized;
         }
 
-        #region Life cycle management
-
-        protected override void OnParametersSet()
-        {
-            Rerender();
-        }
-
-        protected override async Task OnAfterRenderAsync(bool firstRender)
-        {
-            if (firstRender)
-            {
-                var items = Panels.Select(x => x.PanelRef).ToList();
-                items.Add(TabsContentSize);
-
-                await ResizeObserver.Observe(items);
-
-                ResizeObserver.OnResized += OnResized;
-
-                Rerender();
-                await InvokeAsync(StateHasChanged);
-
-                _isRendered = true;
-            }
-        }
-
-        protected virtual void Dispose(bool disposing)
-        {
-            _isDisposed = true;
-            ResizeObserver.OnResized -= OnResized;
-        }
-
         public void Dispose()
         {
             Dispose(true);
@@ -391,7 +360,7 @@ namespace MudBlazor
             .Build();
 
         protected string SliderStyle =>
-        new StyleBuilder()
+            new StyleBuilder()
             .AddStyle("width", $"{_size.ToString(CultureInfo.InvariantCulture)}px", Position == Position.Top || Position == Position.Bottom)
             .AddStyle("left", $"{_position.ToString(CultureInfo.InvariantCulture)}px", Position == Position.Top || Position == Position.Bottom)
             .AddStyle("height", $"{_size.ToString(CultureInfo.InvariantCulture)}px", Position == Position.Left || Position == Position.Right)
@@ -408,20 +377,7 @@ namespace MudBlazor
               .AddClass(panel.Class)
               .Build();
 
-        public async Task ActivatePanel(int index)
-        {
-            var panel = Panels[index];
-            await ActivatePanel(panel, null, _showScrollButtons);
-        }
-
-        public async Task ActivatePanel(object id)
-        {
-            var panel = Panels.Where((p) => p.ID == id).FirstOrDefault();
-            if (panel != null)
-                await ActivatePanel(panel, null, _showScrollButtons);
-        }
-
-            return tabStyle;
+            return tabClass;
         }
 
         private Placement GetTooltipPlacement()
@@ -434,6 +390,15 @@ namespace MudBlazor
                 return Placement.Top;
             else
                 return Placement.Bottom;
+        }
+
+        string GetTabStyle(MudTabPanel panel)
+        {
+            var tabStyle = new StyleBuilder()
+            .AddStyle(panel.Style)
+            .Build();
+
+            return tabStyle;
         }
 
         #endregion
@@ -504,7 +469,6 @@ namespace MudBlazor
         private double GetPanelLength(MudTabPanel panel) => panel == null ? 0.0 : GetRelevantSize(panel.PanelRef);
 
         #endregion
-
 
         #region scrolling 
 

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -25,7 +25,6 @@ namespace MudBlazor
         private double _position;
         private double _toolbarContentSize;
         private double _allTabsSize;
-        private double _scrollValue;
         private double _scrollPosition;
 
         [Inject] public IResizeObserver ResizeObserver { get; set; }

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -6,14 +6,17 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Extensions;
+using MudBlazor.Interop;
 using MudBlazor.Services;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
 {
-    public partial class MudTabs : MudComponentBase, IDisposable
+    public partial class MudTabs : MudComponentBase, IDisposable, IAsyncDisposable
     {
         private bool _isDisposed;
+        private int _activePanelIndex = 0;
+        private Boolean _isRendered = false;
         private bool _prevButtonDisabled;
         private bool _nextButtonDisabled;
         private bool _showScrollButtons;
@@ -25,68 +28,7 @@ namespace MudBlazor
         private double _scrollValue;
         private double _scrollPosition;
 
-        [Inject] public IResizeListenerService ResizeListener { get; set; }
-
-        protected string TabsClassnames =>
-            new CssBuilder("mud-tabs")
-            .AddClass($"mud-tabs-rounded", ApplyEffectsToContainer && Rounded)
-            .AddClass($"mud-paper-outlined", ApplyEffectsToContainer && Outlined)
-            .AddClass($"mud-elevation-{Elevation}", ApplyEffectsToContainer && Elevation != 0)
-            .AddClass($"mud-tabs-reverse", Position == Position.Bottom)
-            .AddClass($"mud-tabs-vertical", Position == Position.Left || Position == Position.Right)
-            .AddClass($"mud-tabs-vertical-reverse", Position == Position.Right)
-            .AddClass(Class)
-            .Build();
-
-        protected string ToolbarClassnames =>
-            new CssBuilder("mud-tabs-toolbar")
-            .AddClass($"mud-tabs-rounded", !ApplyEffectsToContainer && Rounded)
-            .AddClass($"mud-tabs-vertical", Position == Position.Left || Position == Position.Right)
-            .AddClass($"mud-tabs-toolbar-{Color.ToDescriptionString()}", Color != Color.Default)
-            .AddClass($"mud-tabs-border-{Position.ToDescriptionString()}", Border)
-            .AddClass($"mud-paper-outlined", !ApplyEffectsToContainer && Outlined)
-            .AddClass($"mud-elevation-{Elevation}", !ApplyEffectsToContainer && Elevation != 0)
-            .Build();
-
-        protected string WrapperClassnames =>
-            new CssBuilder("mud-tabs-toolbar-wrapper")
-            .AddClass($"mud-tabs-centered", Centered)
-            .AddClass($"mud-tabs-vertical", Position == Position.Left || Position == Position.Right)
-            .Build();
-
-        protected string WrapperScrollStyle =>
-        new StyleBuilder()
-            .AddStyle("transform", $"translateX({_scrollPosition.ToString(CultureInfo.InvariantCulture)}px)", Position == Position.Top || Position == Position.Bottom)
-            .AddStyle("transform", $"translateY({_scrollPosition.ToString(CultureInfo.InvariantCulture)}px)", Position == Position.Left || Position == Position.Right)
-        .Build();
-
-        protected string PanelsClassnames =>
-            new CssBuilder("mud-tabs-panels")
-            .AddClass($"mud-tabs-vertical", Position == Position.Left || Position == Position.Right)
-            .AddClass(PanelClass)
-            .Build();
-
-        protected string SliderClass =>
-            new CssBuilder("mud-tab-slider")
-            .AddClass($"mud-{Color.ToDescriptionString()}", SliderColor != Color.Inherit)
-            .AddClass($"mud-tab-slider-horizontal", Position == Position.Top || Position == Position.Bottom)
-            .AddClass($"mud-tab-slider-vertical", Position == Position.Left || Position == Position.Right)
-            .AddClass($"mud-tab-slider-horizontal-reverse", Position == Position.Bottom)
-            .AddClass($"mud-tab-slider-vertical-reverse", Position == Position.Right)
-            .Build();
-
-        protected string MaxHeightStyles =>
-            new StyleBuilder()
-            .AddStyle("max-height", $"{MaxHeight}px", MaxHeight != null)
-            .Build();
-
-        protected string SliderStyle =>
-        new StyleBuilder()
-            .AddStyle("width", $"{_size.ToString(CultureInfo.InvariantCulture)}px", Position == Position.Top || Position == Position.Bottom)
-            .AddStyle("left", $"{_position.ToString(CultureInfo.InvariantCulture)}px", Position == Position.Top || Position == Position.Bottom)
-            .AddStyle("height", $"{_size.ToString(CultureInfo.InvariantCulture)}px", Position == Position.Left || Position == Position.Right)
-            .AddStyle("top", $"{_position.ToString(CultureInfo.InvariantCulture)}px", Position == Position.Left || Position == Position.Right)
-        .Build();
+        [Inject] public IResizeObserver ResizeObserver { get; set; }
 
         /// <summary>
         /// If true, render all tabs and hide (display:none) every non-active.
@@ -173,7 +115,6 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public bool ApplyEffectsToContainer { get; set; }
 
-
         /// <summary>
         /// If true, disables ripple effect.
         /// </summary>
@@ -196,8 +137,6 @@ namespace MudBlazor
 
         public MudTabPanel ActivePanel { get; set; }
 
-        private int _activePanelIndex = 0;
-
         /// <summary>
         /// The current active panel index. Also with Bidirectional Binding
         /// </summary>
@@ -210,7 +149,7 @@ namespace MudBlazor
                 if (_activePanelIndex != value)
                 {
                     _activePanelIndex = value;
-                    ActivatePanel(_activePanelIndex);
+                    ActivePanel = Panels[_activePanelIndex];
                     ActivePanelIndexChanged.InvokeAsync(value);
                 }
             }
@@ -224,35 +163,221 @@ namespace MudBlazor
 
         public List<MudTabPanel> Panels = new List<MudTabPanel>();
 
-        public void Dispose()
+        #region Life cycle management
+
+        protected override void OnParametersSet()
         {
-            _isDisposed = true;
-            ResizeListener.OnResized -= OnResized;
+            Rerender();
         }
 
-        internal void AddPanel(MudTabPanel tabPanel)
+        protected override async Task OnAfterRenderAsync(bool firstRender)
+        {
+            if (firstRender)
+            {
+                var items = Panels.Select(x => x.PanelRef).ToList();
+                items.Add(TabsContentSize);
+
+                await ResizeObserver.Observe(items);
+
+                ResizeObserver.OnResized += OnResized;
+
+                Rerender();
+                await InvokeAsync(StateHasChanged);
+
+                _isRendered = true;
+            }
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            _isDisposed = true;
+            ResizeObserver.OnResized -= OnResized;
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual async ValueTask DisposeAsyncCore()
+        {
+            _isDisposed = true;
+            await ResizeObserver.DisposeAsync();
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await DisposeAsyncCore();
+
+            Dispose(false);
+            GC.SuppressFinalize(this);
+        }
+
+        #endregion
+
+        #region Children
+
+        internal async Task AddPanel(MudTabPanel tabPanel)
         {
             Panels.Add(tabPanel);
             if (Panels.Count == 1)
                 ActivePanel = tabPanel;
-            StateHasChanged();
+
+            await InvokeAsync(StateHasChanged);
         }
 
-        internal void RemovePanel(MudTabPanel tabPanel)
+        internal async Task SetPanelRef(ElementReference reference)
+        {
+            if (_isRendered == true && ResizeObserver.IsElementObserved(reference) == false)
+            {
+                await ResizeObserver.Observe(reference);
+                Rerender();
+                await InvokeAsync(StateHasChanged);
+            }
+        }
+
+        internal async Task RemovePanel(MudTabPanel tabPanel)
         {
             if (_isDisposed)
                 return;
 
             var index = Panels.IndexOf(tabPanel);
+            var newIndex = index;
             if (ActivePanelIndex == index && index == Panels.Count - 1)
             {
-                ActivePanelIndex = index > 0 ? index - 1 : 0;
+                newIndex = index > 0 ? index - 1 : 0;
                 if (Panels.Count == 1)
+                {
                     ActivePanel = null;
+                }
             }
+            else if (_activePanelIndex > index)
+            {
+                _activePanelIndex--;
+                await ActivePanelIndexChanged.InvokeAsync(_activePanelIndex);
+            }
+
+            if(index != newIndex)
+            {
+                _activePanelIndex = newIndex;
+                ActivePanel = Panels[newIndex];
+               await ActivePanelIndexChanged.InvokeAsync(newIndex);
+            }
+
+            //Double size = GetRelevantSize(tabPanel.PanelRef);
+            //Double positon = GetLengthOfPanelItems(tabPanel);
+            //if(_scrollPosition > positon)
+            //{
+            //    _scrollPosition -= size;
+            //}
+
             Panels.Remove(tabPanel);
-            StateHasChanged();
+            await ResizeObserver.Unobserve(tabPanel.PanelRef);
+            Rerender();
+            await InvokeAsync(StateHasChanged);
         }
+
+        public async Task ActivatePanel(MudTabPanel panel)
+        {
+            await ActivatePanel(panel, null, _showScrollButtons);
+        }
+
+        public async Task ActivatePanel(int index)
+        {
+            var panel = Panels[index];
+            await ActivatePanel(panel, null, _showScrollButtons);
+        }
+
+        public async Task ActivatePanel(object id)
+        {
+            var panel = Panels.Where((p) => p.ID == id).FirstOrDefault();
+            if (panel != null)
+                await ActivatePanel(panel, null, _showScrollButtons);
+        }
+
+        private async Task ActivatePanel(MudTabPanel panel, MouseEventArgs ev, bool scrollToActivePanel)
+        {
+            if (!panel.Disabled)
+            {
+                ActivePanel = panel;
+                _activePanelIndex = Panels.IndexOf(panel);
+                await ActivePanelIndexChanged.InvokeAsync(_activePanelIndex);
+
+                if (ev != null)
+                    await ActivePanel.OnClick.InvokeAsync(ev);
+
+                CenterScrollPositionAroundSelectedItem();
+                SetSliderState();
+                SetScrollabilityStates();
+                await InvokeAsync(StateHasChanged);
+            }
+        }
+
+        #endregion
+
+        #region Style and classes
+
+        protected string TabsClassnames =>
+            new CssBuilder("mud-tabs")
+            .AddClass($"mud-tabs-rounded", ApplyEffectsToContainer && Rounded)
+            .AddClass($"mud-paper-outlined", ApplyEffectsToContainer && Outlined)
+            .AddClass($"mud-elevation-{Elevation}", ApplyEffectsToContainer && Elevation != 0)
+            .AddClass($"mud-tabs-reverse", Position == Position.Bottom)
+            .AddClass($"mud-tabs-vertical", Position == Position.Left || Position == Position.Right)
+            .AddClass($"mud-tabs-vertical-reverse", Position == Position.Right)
+            .AddClass(Class)
+            .Build();
+
+        protected string ToolbarClassnames =>
+            new CssBuilder("mud-tabs-toolbar")
+            .AddClass($"mud-tabs-rounded", !ApplyEffectsToContainer && Rounded)
+            .AddClass($"mud-tabs-vertical", Position == Position.Left || Position == Position.Right)
+            .AddClass($"mud-tabs-toolbar-{Color.ToDescriptionString()}", Color != Color.Default)
+            .AddClass($"mud-tabs-border-{Position.ToDescriptionString()}", Border)
+            .AddClass($"mud-paper-outlined", !ApplyEffectsToContainer && Outlined)
+            .AddClass($"mud-elevation-{Elevation}", !ApplyEffectsToContainer && Elevation != 0)
+            .Build();
+
+        protected string WrapperClassnames =>
+            new CssBuilder("mud-tabs-toolbar-wrapper")
+            .AddClass($"mud-tabs-centered", Centered)
+            .AddClass($"mud-tabs-vertical", Position == Position.Left || Position == Position.Right)
+            .Build();
+
+        protected string WrapperScrollStyle =>
+        new StyleBuilder()
+            .AddStyle("transform", $"translateX({ (-1 * _scrollPosition).ToString(CultureInfo.InvariantCulture)}px)", Position == Position.Top || Position == Position.Bottom)
+            .AddStyle("transform", $"translateY({ (-1 * _scrollPosition).ToString(CultureInfo.InvariantCulture)}px)", Position == Position.Left || Position == Position.Right)
+            .Build();
+
+        protected string PanelsClassnames =>
+            new CssBuilder("mud-tabs-panels")
+            .AddClass($"mud-tabs-vertical", Position == Position.Left || Position == Position.Right)
+            .AddClass(PanelClass)
+            .Build();
+
+        protected string SliderClass =>
+            new CssBuilder("mud-tab-slider")
+            .AddClass($"mud-{Color.ToDescriptionString()}", SliderColor != Color.Inherit)
+            .AddClass($"mud-tab-slider-horizontal", Position == Position.Top || Position == Position.Bottom)
+            .AddClass($"mud-tab-slider-vertical", Position == Position.Left || Position == Position.Right)
+            .AddClass($"mud-tab-slider-horizontal-reverse", Position == Position.Bottom)
+            .AddClass($"mud-tab-slider-vertical-reverse", Position == Position.Right)
+            .Build();
+
+        protected string MaxHeightStyles =>
+            new StyleBuilder()
+            .AddStyle("max-height", $"{MaxHeight}px", MaxHeight != null)
+            .Build();
+
+        protected string SliderStyle =>
+        new StyleBuilder()
+            .AddStyle("width", $"{_size.ToString(CultureInfo.InvariantCulture)}px", Position == Position.Top || Position == Position.Bottom)
+            .AddStyle("left", $"{_position.ToString(CultureInfo.InvariantCulture)}px", Position == Position.Top || Position == Position.Bottom)
+            .AddStyle("height", $"{_size.ToString(CultureInfo.InvariantCulture)}px", Position == Position.Left || Position == Position.Right)
+            .AddStyle("top", $"{_position.ToString(CultureInfo.InvariantCulture)}px", Position == Position.Left || Position == Position.Right)
+            .Build();
 
         string GetTabClass(MudTabPanel panel)
         {
@@ -262,7 +387,7 @@ namespace MudBlazor
               .AddClass($"mud-ripple", !DisableRipple)
               .AddClass(TabPanelClass)
               .AddClass(panel.Class)
-            .Build();
+              .Build();
 
             return tabClass;
         }
@@ -274,37 +399,6 @@ namespace MudBlazor
             .Build();
 
             return tabStyle;
-        }
-        void ActivatePanel(MudTabPanel panel, MouseEventArgs ev, bool scrollToActivePanel)
-        {
-            if (!panel.Disabled)
-            {
-                ActivePanel = panel;
-                _activePanelIndex = Panels.IndexOf(panel);
-                ActivePanelIndexChanged.InvokeAsync(_activePanelIndex);
-
-                _ = UpdateSlider(scrollToActivePanel);
-                if (ev != null)
-                    ActivePanel.OnClick.InvokeAsync(ev);
-            }
-        }
-
-        public void ActivatePanel(MudTabPanel panel)
-        {
-            ActivatePanel(panel, null, _showScrollButtons);
-        }
-
-        public void ActivatePanel(int index)
-        {
-            var panel = Panels[index];
-            ActivatePanel(panel, null, _showScrollButtons);
-        }
-
-        public void ActivatePanel(object id)
-        {
-            var panel = Panels.Where((p) => p.ID == id).FirstOrDefault();
-            if (panel != null)
-                ActivatePanel(panel, null, _showScrollButtons);
         }
 
         private Placement GetTooltipPlacement()
@@ -319,137 +413,189 @@ namespace MudBlazor
                 return Placement.Bottom;
         }
 
-        protected override async Task OnAfterRenderAsync(bool firstRender)
+        #endregion
+
+        #region Rendering and placement
+
+        private void Rerender()
         {
-            if (firstRender)
-            {
-                await CalculateTabsSize();
-                ResizeListener.OnResized += OnResized;
-            }
+            GetToolbarContentSize();
+            GetAllTabsSize();
+            SetScrollButtonVisibility();
+            CenterScrollPositionAroundSelectedItem();
+            SetSliderState();
+            SetScrollabilityStates();
         }
 
-        private async void OnResized(object sender, BrowserWindowSize size)
+        private async void OnResized(IDictionary<ElementReference, BoundingClientRect> changes)
         {
-            await CalculateTabsSize();
+            Rerender();
             await InvokeAsync(StateHasChanged);
         }
 
-        private async Task CalculateTabsSize()
+        private void SetSliderState()
         {
-            await UpdateSlider(true);
+            if (ActivePanel == null) { return; }
 
-            await GetToolbarContentSize();
-            await GetAllTabsSize();
-
-            if (AlwaysShowScrollButtons || _allTabsSize > _toolbarContentSize)
-            {
-                _showScrollButtons = true;
-                if (_scrollValue >= 0)
-                    _prevButtonDisabled = true;
-                else
-                    _prevButtonDisabled = false;
-                if (Math.Abs(_scrollValue) + _toolbarContentSize >= _allTabsSize)
-                    _nextButtonDisabled = true;
-                else
-                    _nextButtonDisabled = false;
-            }
-            else
-            {
-                _scrollPosition = 0;
-                _showScrollButtons = false;
-            }
-            StateHasChanged();
+            _position = GetLengthOfPanelItems(ActivePanel);
+            _size = GetRelevantSize(ActivePanel.PanelRef);
         }
 
-        private async Task UpdateSlider(bool scrollToActivePanel)
-        {
-            if (HideSlider && !scrollToActivePanel)
-                return;
+        private void GetToolbarContentSize() => _toolbarContentSize = GetRelevantSize(TabsContentSize);
 
-            if (ActivePanel != null)
-            {
-                if (Position == Position.Top || Position == Position.Bottom)
-                    _size = (await ActivePanel.PanelRef.MudGetBoundingClientRectAsync())?.Width ?? 0;
-                else
-                    _size = (await ActivePanel.PanelRef.MudGetBoundingClientRectAsync())?.Height ?? 0;
-
-                _position = 0;
-
-                if (ActivePanelIndex != 0)
-                {
-                    double position = 0;
-                    var counter = 0;
-                    foreach (var panel in Panels) if (counter < ActivePanelIndex)
-                        {
-                            if (Position == Position.Top || Position == Position.Bottom)
-                                position += (await panel.PanelRef.MudGetBoundingClientRectAsync())?.Width ?? 0;
-                            else
-                                position += (await panel.PanelRef.MudGetBoundingClientRectAsync())?.Height ?? 0;
-                            counter++;
-                        }
-                    _position = position;
-                    if (scrollToActivePanel)
-                    {
-                        _scrollPosition = -position;
-                    }
-                }
-                else if (scrollToActivePanel)
-                {
-                    _scrollPosition = 0;
-                }
-                StateHasChanged();
-            }
-        }
-
-        private async Task GetToolbarContentSize()
-        {
-            if (Position == Position.Top || Position == Position.Bottom)
-                _toolbarContentSize = (await TabsContentSize.MudGetBoundingClientRectAsync())?.Width ?? 0;
-            else
-                _toolbarContentSize = (await TabsContentSize.MudGetBoundingClientRectAsync())?.Height ?? 0;
-        }
-
-        private async Task GetAllTabsSize()
+        private void GetAllTabsSize()
         {
             double totalTabsSize = 0;
 
             foreach (var panel in Panels)
             {
-                if (Position == Position.Top || Position == Position.Bottom)
-                    totalTabsSize += (await panel.PanelRef.MudGetBoundingClientRectAsync())?.Width ?? 0;
-                else
-                    totalTabsSize += (await panel.PanelRef.MudGetBoundingClientRectAsync())?.Height ?? 0;
+                totalTabsSize += GetRelevantSize(panel.PanelRef);
             }
 
             _allTabsSize = totalTabsSize;
         }
 
+
+        private Double GetRelevantSize(ElementReference reference) => Position switch
+        {
+            Position.Top or Position.Bottom => ResizeObserver.GetWidth(reference),
+            _ => ResizeObserver.GetHeight(reference)
+        };
+
+        private Double GetLengthOfPanelItems(MudTabPanel panel)
+        {
+            Double value = 0.0;
+            foreach (var item in Panels)
+            {
+                if (item == panel)
+                {
+                    break;
+                }
+
+                value += GetRelevantSize(item.PanelRef);
+            }
+
+            return value;
+        }
+
+        private Double GetPanelLength(MudTabPanel panel) => panel == null ? 0.0 : GetRelevantSize(panel.PanelRef);
+
+        #endregion
+
+
+        #region scrolling 
+
+        private void SetScrollButtonVisibility()
+        {
+            _showScrollButtons = AlwaysShowScrollButtons || _allTabsSize > _toolbarContentSize;
+        }
+
         private void ScrollPrev()
         {
-            _nextButtonDisabled = false;
-            _scrollValue += _toolbarContentSize;
-            if (_scrollValue >= 0)
+            Double scrollValue = _scrollPosition - _toolbarContentSize;
+            if (scrollValue < 0)
             {
-                _scrollPosition = 0;
-                _prevButtonDisabled = true;
+                scrollValue = 0;
             }
-            else
-            {
-                _scrollPosition = _scrollValue;
-            }
+
+            _scrollPosition = scrollValue;
+
+            SetScrollabilityStates();
         }
 
         private void ScrollNext()
         {
-            _prevButtonDisabled = false;
-            _scrollValue -= _toolbarContentSize;
-            if (Math.Abs(_scrollValue) + _toolbarContentSize >= _allTabsSize)
+            Double scrollValue = _scrollPosition + _toolbarContentSize;
+
+            if (scrollValue > _allTabsSize)
+            {
+                scrollValue = _allTabsSize - _toolbarContentSize - 96;
+            }
+
+            _scrollPosition = scrollValue;
+
+            SetScrollabilityStates();
+        }
+
+        private void ScrollToItem(MudTabPanel panel)
+        {
+            Double position = GetLengthOfPanelItems(panel);
+            _scrollPosition = position;
+        }
+
+        private Boolean IsAfterLastPanelIndex(Int32 index) => index >= Panels.Count;
+        private Boolean IsBeforeFirstPanelIndex(Int32 index) => index < 0;
+
+        private void CenterScrollPositionAroundSelectedItem()
+        {
+            MudTabPanel panelToStart = ActivePanel;
+            Double length = GetPanelLength(panelToStart);
+            if (length >= _toolbarContentSize)
+            {
+                ScrollToItem(panelToStart);
+                return;
+            }
+
+            Int32 indexCorrection = 1;
+            while (true)
+            {
+                Int32 panelAfterIndex = _activePanelIndex + indexCorrection;
+                if (IsAfterLastPanelIndex(panelAfterIndex) == false)
+                {
+                    length += GetPanelLength(Panels[panelAfterIndex]);
+                }
+
+                if (length >= _toolbarContentSize)
+                {
+                    ScrollToItem(panelToStart);
+                    break;
+                }
+
+                length = _toolbarContentSize - length;
+
+                Int32 panelBeforeindex = _activePanelIndex - indexCorrection;
+                if (IsBeforeFirstPanelIndex(panelBeforeindex) == false)
+                {
+                    length -= GetPanelLength(Panels[panelBeforeindex]);
+                }
+                else
+                {
+                    break;
+                }
+
+                if (length < 0)
+                {
+                    ScrollToItem(panelToStart);
+                    break;
+                }
+
+                length = _toolbarContentSize - length;
+                panelToStart = Panels[_activePanelIndex - indexCorrection];
+
+                indexCorrection++;
+            }
+
+            ScrollToItem(panelToStart);
+
+            SetScrollabilityStates();
+        }
+
+        private void SetScrollabilityStates()
+        {
+            Boolean isEnoughSpace = _allTabsSize <= _toolbarContentSize;
+
+            if (isEnoughSpace == true)
             {
                 _nextButtonDisabled = true;
-                _scrollPosition = _toolbarContentSize - _allTabsSize - 96;
+                _prevButtonDisabled = true;
             }
             else
-                _scrollPosition = _scrollValue;
+            {
+                _nextButtonDisabled = (_scrollPosition + _toolbarContentSize) >= _allTabsSize;
+                _prevButtonDisabled = _scrollPosition <= 0;
+            }
         }
+
+        #endregion
     }
 }

--- a/src/MudBlazor/Components/TextField/MudTextField.razor
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor
@@ -8,7 +8,8 @@
             <MudInput T="string" @ref="_elementReference" @attributes="UserAttributes" InputType="@InputType" Lines="@Lines" Style="@Style" Variant="@Variant" Value="@Text" ValueChanged="(s) => SetTextAsync(s)" Placeholder="@Placeholder" Disabled=@Disabled DisableUnderLine="@DisableUnderLine" ReadOnly="@ReadOnly"
                       Adornment="@Adornment" AdornmentText="@AdornmentText" AdornmentIcon="@AdornmentIcon" AdornmentColor="@AdornmentColor" IconSize="@IconSize" OnAdornmentClick="@OnAdornmentClick" Error="@Error" Immediate="@Immediate" Margin="@Margin"
                       OnBlur="@OnBlurred" OnKeyDown="@InvokeKeyDown" OnKeyPress="@InvokeKeyPress" OnKeyUp="@InvokeKeyUp"
-                      KeyDownPreventDefault="KeyDownPreventDefault" KeyPressPreventDefault="KeyPressPreventDefault" KeyUpPreventDefault="KeyUpPreventDefault" />
+                      KeyDownPreventDefault="KeyDownPreventDefault" KeyPressPreventDefault="KeyPressPreventDefault" KeyUpPreventDefault="KeyUpPreventDefault"
+                      HideSpinButtons="true" />
         </InputContent>
     </MudInputControl>
 </CascadingValue>

--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -15,7 +15,7 @@
   <PropertyGroup>
     <Title>MudBlazor</Title>
     <PackageId>MudBlazor</PackageId>
-    <Version>5.0.6</Version>
+    <Version>5.0.7</Version>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageIcon>Nuget.png</PackageIcon>
     <Company>MudBlazor</Company>

--- a/src/MudBlazor/Services/ReseizeObserver/IResizeObserver.cs
+++ b/src/MudBlazor/Services/ReseizeObserver/IResizeObserver.cs
@@ -1,0 +1,30 @@
+﻿// Not Used
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using MudBlazor.Interop;
+
+namespace MudBlazor.Services
+{
+
+    public delegate void SizeChanged(IDictionary<ElementReference,BoundingClientRect> changes);
+
+    public interface IResizeObserver : IAsyncDisposable
+    {
+        Task<BoundingClientRect> Observe(ElementReference element);
+        Task<IEnumerable<BoundingClientRect>> Observe(IEnumerable<ElementReference> elements);
+        Task Unobserve(ElementReference element);
+
+        Double GetWidth(ElementReference reference);
+        Double GetHeight(ElementReference reference);
+        BoundingClientRect GetSizeInfo(ElementReference reference);
+
+        event SizeChanged OnResized;
+
+        Boolean IsElementObserved(ElementReference reference);
+    }
+}

--- a/src/MudBlazor/Services/ReseizeObserver/IResizeObserverFactory.cs
+++ b/src/MudBlazor/Services/ReseizeObserver/IResizeObserverFactory.cs
@@ -1,0 +1,15 @@
+﻿// Not Used
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MudBlazor.Services
+{
+    public interface IResizeObserverFactory
+    {
+        IResizeObserver Create(ResizeObserverOptions options);
+    }
+}

--- a/src/MudBlazor/Services/ReseizeObserver/JavascriptBasedResizeObserver.cs
+++ b/src/MudBlazor/Services/ReseizeObserver/JavascriptBasedResizeObserver.cs
@@ -10,9 +10,9 @@ using MudBlazor.Interop;
 
 namespace MudBlazor.Services
 {
-    public class JavascriptBasedResizeObserver : IResizeObserver
+    public class ResizeObserver : IResizeObserver
     {
-        private readonly DotNetObjectReference<JavascriptBasedResizeObserver> _dotNetRef;
+        private readonly DotNetObjectReference<ResizeObserver> _dotNetRef;
         private readonly IJSRuntime _jsRuntime;
 
         private readonly Dictionary<Guid, ElementReference> _cachedValueIds = new();
@@ -21,14 +21,14 @@ namespace MudBlazor.Services
         private Guid _id = Guid.NewGuid();
         private ResizeObserverOptions _options;
 
-        public JavascriptBasedResizeObserver(IJSRuntime jsRuntime, ResizeObserverOptions options)
+        public ResizeObserver(IJSRuntime jsRuntime, ResizeObserverOptions options)
         {
             _dotNetRef = DotNetObjectReference.Create(this);
             _jsRuntime = jsRuntime;
             _options = options;
         }
 
-        public JavascriptBasedResizeObserver(IJSRuntime jsRuntime, IOptions<ResizeObserverOptions> options = null) : this(jsRuntime, options?.Value ?? new ResizeObserverOptions())
+        public ResizeObserver(IJSRuntime jsRuntime, IOptions<ResizeObserverOptions> options = null) : this(jsRuntime, options?.Value ?? new ResizeObserverOptions())
         {
         }
 

--- a/src/MudBlazor/Services/ReseizeObserver/JavascriptBasedResizeObserver.cs
+++ b/src/MudBlazor/Services/ReseizeObserver/JavascriptBasedResizeObserver.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Options;
+using Microsoft.JSInterop;
+using MudBlazor.Interop;
+
+namespace MudBlazor.Services
+{
+    public class JavascriptBasedResizeObserver : IResizeObserver
+    {
+        private readonly DotNetObjectReference<JavascriptBasedResizeObserver> _dotNetRef;
+        private readonly IJSRuntime _jsRuntime;
+
+        private readonly Dictionary<Guid, ElementReference> _cachedValueIds = new();
+        private readonly Dictionary<ElementReference, BoundingClientRect> _cachedValues = new();
+
+        private Guid _id = Guid.NewGuid();
+        private ResizeObserverOptions _options;
+
+        public JavascriptBasedResizeObserver(IJSRuntime jsRuntime, ResizeObserverOptions options)
+        {
+            _dotNetRef = DotNetObjectReference.Create(this);
+            _jsRuntime = jsRuntime;
+            _options = options;
+        }
+
+        public JavascriptBasedResizeObserver(IJSRuntime jsRuntime, IOptions<ResizeObserverOptions> options = null) : this(jsRuntime, options?.Value ?? new ResizeObserverOptions())
+        {
+        }
+
+        public async Task<BoundingClientRect> Observe(ElementReference element) => (await Observe(new[] { element })).FirstOrDefault();
+
+        public async Task<IEnumerable<BoundingClientRect>> Observe(IEnumerable<ElementReference> elements)
+        {
+            var filteredElements = elements.Where(x => x.Context != null && _cachedValues.ContainsKey(x) == false).ToList();
+            if (filteredElements.Any() == false)
+            {
+                return Array.Empty<BoundingClientRect>();
+            }
+
+            List<Guid> elementIds = new();
+
+            foreach (var item in filteredElements)
+            {
+                Guid id = Guid.NewGuid();
+                elementIds.Add(id);
+                _cachedValueIds.Add(id, item);
+            }
+
+            var result = await _jsRuntime.InvokeAsync<IEnumerable<BoundingClientRect>>("mudResizeObserver.connect", _id, _dotNetRef, filteredElements, elementIds, _options);
+            Int32 counter = 0;
+            foreach (var item in result)
+            {
+                _cachedValues.Add(filteredElements.ElementAt(counter), item);
+                counter++;
+            }
+
+            return result;
+        }
+
+        public async Task Unobserve(ElementReference element)
+        {
+            Guid elementId = _cachedValueIds.FirstOrDefault(x => x.Value.Id == element.Id).Key;
+            if (elementId == default) { return; }
+
+            await _jsRuntime.InvokeVoidAsync($"mudResizeObserver.disconnect", _id, elementId);
+
+            _cachedValueIds.Remove(elementId);
+            _cachedValues.Remove(element);
+        }
+
+        public Boolean IsElementObserved(ElementReference reference) => _cachedValues.ContainsKey(reference);
+
+        public record SizeChangeUpdateInfo(Guid Id, BoundingClientRect Size);
+
+        [JSInvokable]
+        public void OnSizeChanged(IEnumerable<SizeChangeUpdateInfo> changes)
+        {
+            Dictionary<ElementReference, BoundingClientRect> parsedChanges = new();
+            foreach (var item in changes)
+            {
+                if (_cachedValueIds.ContainsKey(item.Id) == false) { continue; }
+
+                var elementRef = _cachedValueIds[item.Id];
+                _cachedValues[elementRef] = item.Size;
+                parsedChanges.Add(elementRef, item.Size);
+            }
+
+            OnResized?.Invoke(parsedChanges);
+        }
+
+        public event SizeChanged OnResized;
+
+        public BoundingClientRect GetSizeInfo(ElementReference reference)
+        {
+            if (_cachedValues.ContainsKey(reference) == false)
+            {
+                return null;
+            }
+
+            return _cachedValues[reference];
+        }
+
+        public double GetHeight(ElementReference reference) => GetSizeInfo(reference)?.Height ?? 0.0;
+        public double GetWidth(ElementReference reference) => GetSizeInfo(reference)?.Width ?? 0.0;
+
+        protected virtual void Dispose(bool disposing)
+        {
+            _dotNetRef.Dispose();
+            _cachedValueIds.Clear();
+            _cachedValues.Clear();
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual async ValueTask DisposeAsyncCore()
+        {
+            _dotNetRef.Dispose();
+            _cachedValueIds.Clear();
+            _cachedValues.Clear();
+            await _jsRuntime.InvokeVoidAsync($"mudResizeObserver.cancelListener", _id);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await DisposeAsyncCore();
+
+            Dispose(false);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/src/MudBlazor/Services/ReseizeObserver/JavascriptBasedResizeObserverFactory.cs
+++ b/src/MudBlazor/Services/ReseizeObserver/JavascriptBasedResizeObserverFactory.cs
@@ -1,0 +1,25 @@
+﻿// Not Used
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.JSInterop;
+
+namespace MudBlazor.Services
+{
+    public class JavascriptBasedResizeObserverFactory : IResizeObserverFactory
+    {
+        private readonly IServiceProvider _provider;
+
+        public JavascriptBasedResizeObserverFactory(IServiceProvider provider)
+        {
+            _provider = provider;
+        }
+
+        public IResizeObserver Create(ResizeObserverOptions options) =>
+            new JavascriptBasedResizeObserver(_provider.GetRequiredService<IJSRuntime>() , options);
+    }
+}

--- a/src/MudBlazor/Services/ReseizeObserver/ResizeObserverFactory.cs
+++ b/src/MudBlazor/Services/ReseizeObserver/ResizeObserverFactory.cs
@@ -10,16 +10,16 @@ using Microsoft.JSInterop;
 
 namespace MudBlazor.Services
 {
-    public class JavascriptBasedResizeObserverFactory : IResizeObserverFactory
+    public class ResizeObserverFactory : IResizeObserverFactory
     {
         private readonly IServiceProvider _provider;
 
-        public JavascriptBasedResizeObserverFactory(IServiceProvider provider)
+        public ResizeObserverFactory(IServiceProvider provider)
         {
             _provider = provider;
         }
 
         public IResizeObserver Create(ResizeObserverOptions options) =>
-            new JavascriptBasedResizeObserver(_provider.GetRequiredService<IJSRuntime>() , options);
+            new ResizeObserver(_provider.GetRequiredService<IJSRuntime>() , options);
     }
 }

--- a/src/MudBlazor/Services/ReseizeObserver/ResizeObserverOptions.cs
+++ b/src/MudBlazor/Services/ReseizeObserver/ResizeObserverOptions.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+
+namespace MudBlazor.Services
+{
+    public class ResizeObserverOptions
+    {
+        /// <summary>
+        /// Timepsan in milliseconds after the browser detect the last chance and notify the interop service.
+        /// Setting this value too low can cause poor application performance.
+        /// </summary>
+        public int ReportRate { get; set; } = 200;
+
+        /// <summary>
+        /// Report resize events in the browser's console.
+        /// </summary>
+        public bool EnableLogging { get; set; } = false;
+    }
+}

--- a/src/MudBlazor/Services/ServiceCollectionExtensions.cs
+++ b/src/MudBlazor/Services/ServiceCollectionExtensions.cs
@@ -84,6 +84,47 @@ namespace MudBlazor.Services
         }
 
         /// <summary>
+        /// Adds a IResizeObserver as a Transient instance.
+        /// </summary>
+        /// <param name="services">IServiceCollection</param>
+        /// <param name="options">Defines ResizeObserverOptions for this instance</param>
+        /// <returns>Continues the IServiceCollection chain.</returns>
+        public static IServiceCollection AddMudBlazorResizeObserver(this IServiceCollection services, Action<ResizeObserverOptions> options)
+        {
+            services.TryAddTransient<IResizeObserver, JavascriptBasedResizeObserver>();
+            services.Configure(options);
+            return services;
+        }
+
+        /// <summary>
+        /// Adds a IResizeObserver as a Transient instance.
+        /// </summary>
+        /// <param name="services">IServiceCollection</param>
+        /// <param name="options">Defines ResizeObserverOptions for this instance</param>
+        /// <returns>Continues the IServiceCollection chain.</returns>
+        public static IServiceCollection AddMudBlazorResizeObserver(this IServiceCollection services, ResizeObserverOptions options = null)
+        {
+            if (options == null)
+                options = new ResizeObserverOptions();
+            services.AddMudBlazorResizeObserver(o =>
+            {
+                o = options;
+            });
+            return services;
+        }
+
+        /// <summary>
+        /// Adds a IResizeObserverFactory as a Singelton instance.
+        /// </summary>
+        /// <param name="services">IServiceCollection</param>
+        /// <returns>Continues the IServiceCollection chain.</returns>
+        public static IServiceCollection AddMudBlazorResizeObserverFactory(this IServiceCollection services)
+        {
+            services.TryAddSingleton<IResizeObserverFactory, JavascriptBasedResizeObserverFactory>();
+            return services;
+        }
+
+        /// <summary>
         /// Adds ScrollManager as a transient instance.
         /// </summary>
         /// <param name="services">IServiceCollection</param>
@@ -127,6 +168,8 @@ namespace MudBlazor.Services
                 .AddMudBlazorDialog()
                 .AddMudBlazorSnackbar(configuration.SnackbarConfiguration)
                 .AddMudBlazorResizeListener(configuration.ResizeOptions)
+                .AddMudBlazorResizeObserver(configuration.ResizeObserverOptions)
+                .AddMudBlazorResizeObserverFactory()
                 .AddMudBlazorScrollManager()
                 .AddMudBlazorScrollListener()
                 .AddMudBlazorJsApi();
@@ -148,6 +191,8 @@ namespace MudBlazor.Services
                 .AddMudBlazorDialog()
                 .AddMudBlazorSnackbar(options.SnackbarConfiguration)
                 .AddMudBlazorResizeListener(options.ResizeOptions)
+                .AddMudBlazorResizeObserver(options.ResizeObserverOptions)
+                .AddMudBlazorResizeObserverFactory()
                 .AddMudBlazorScrollManager()
                 .AddMudBlazorScrollListener()
                 .AddMudBlazorJsApi();

--- a/src/MudBlazor/Services/ServiceCollectionExtensions.cs
+++ b/src/MudBlazor/Services/ServiceCollectionExtensions.cs
@@ -91,7 +91,7 @@ namespace MudBlazor.Services
         /// <returns>Continues the IServiceCollection chain.</returns>
         public static IServiceCollection AddMudBlazorResizeObserver(this IServiceCollection services, Action<ResizeObserverOptions> options)
         {
-            services.TryAddTransient<IResizeObserver, JavascriptBasedResizeObserver>();
+            services.TryAddTransient<IResizeObserver, ResizeObserver>();
             services.Configure(options);
             return services;
         }
@@ -120,7 +120,7 @@ namespace MudBlazor.Services
         /// <returns>Continues the IServiceCollection chain.</returns>
         public static IServiceCollection AddMudBlazorResizeObserverFactory(this IServiceCollection services)
         {
-            services.TryAddSingleton<IResizeObserverFactory, JavascriptBasedResizeObserverFactory>();
+            services.TryAddSingleton<IResizeObserverFactory, ResizeObserverFactory>();
             return services;
         }
 

--- a/src/MudBlazor/Services/ServiceConfiguration.cs
+++ b/src/MudBlazor/Services/ServiceConfiguration.cs
@@ -9,5 +9,6 @@
     {
         public SnackbarConfiguration SnackbarConfiguration { get; set; } = new SnackbarConfiguration();
         public ResizeOptions ResizeOptions { get; set; } = new ResizeOptions();
+        public ResizeObserverOptions ResizeObserverOptions { get; set; } = new ResizeObserverOptions();
     }
 }

--- a/src/MudBlazor/Styles/components/_input.scss
+++ b/src/MudBlazor/Styles/components/_input.scss
@@ -20,8 +20,8 @@
     }
 
     &.mud-disabled > .mud-input-adornment {
-      color: var(--mud-palette-text-disabled);
-      pointer-events: none;
+        color: var(--mud-palette-text-disabled);
+        pointer-events: none;
     }
 
     &.mud-input-underline {
@@ -433,12 +433,21 @@
   &.mud-text {
     margin-right: 8px;
   }
+
   &.mud-icon {
   }
 }
 
 .mud-input-adornment-end {
   margin-left: 8px;
+}
+
+.mud-input-number-control.mud-input-showspin .mud-input-adornment-end {
+    margin-right: 12px;
+}
+
+.mud-input-number-control.mud-input-showspin .mud-input-underline:not(.mud-input-filled) .mud-input-adornment-end {
+    margin-right: 24px;
 }
 
 .mud-input-adornment-disable-pointerevents {

--- a/src/MudBlazor/Styles/components/_inputcontrol.scss
+++ b/src/MudBlazor/Styles/components/_inputcontrol.scss
@@ -50,7 +50,7 @@
         line-height: 1;
         letter-spacing: 0.00938em;
         z-index: 0;
-        pointer-events:none;
+        pointer-events: none;
 
         &.mud-disabled {
             color: var(--mud-palette-text-disabled);
@@ -63,6 +63,38 @@
 
     &.mud-input-required > .mud-input-label::after {
         content: "*";
+    }
+
+    &.mud-input-number-control {
+        & input::-webkit-outer-spin-button,
+        & input::-webkit-inner-spin-button {
+            -webkit-appearance: none;
+            margin: 0;
+        }
+
+        & input[type=number] {
+            -moz-appearance: textfield;
+        }
+
+        & .mud-input-numeric-spin {
+            display: inline-flex;
+            flex-direction: column;
+            justify-content: space-between;
+            position: absolute;
+            right: 0;
+            top: 0;
+            bottom: 0;
+
+            & button {
+                padding: 2px;
+                min-width: unset;
+                min-height: unset;
+            }
+        }
+
+        & .mud-input-underline .mud-input-numeric-spin button {
+            padding: 2px 0;
+        }
     }
 }
 

--- a/src/MudBlazor/TScripts/mudResizeObserver.js
+++ b/src/MudBlazor/TScripts/mudResizeObserver.js
@@ -1,0 +1,128 @@
+﻿class MudResizeObserverFactory {
+    constructor() {
+        this._maps = {};
+    }
+
+    connect(id, dotNetRef, elements, elementIds, options) {
+        var existingEntry = this._maps[id];
+        if (!existingEntry) {
+            var observer = new MudResizeObserver(dotNetRef, options);
+            this._maps[id] = observer;
+        }
+
+        var result = this._maps[id].connect(elements, elementIds);
+        return result;
+    }
+
+    disconnect(id, element) {
+        this._maps[id].disconnect(element);
+    }
+
+    cancelListener(id) {
+        this._maps[id].cancelListener();
+        delete this._maps[id];
+    }
+}
+
+class MudResizeObserver {
+
+    constructor(dotNetRef, options) {
+        this.logger = options.enableLogging ? console.log : (message) => { };
+        this.options = options;
+        this._dotNetRef = dotNetRef
+
+        var delay = (this.options || {}).reportRate || 200;
+
+        this.throttleResizeHandlerId = -1;
+
+        var observervedElements = [];
+        this._observervedElements = observervedElements;
+
+        this.logger('[MudBlazor | ResizeObserver] Observer initilized');
+
+        this._resizeObserver = new ResizeObserver(entries => {
+            var changes = [];
+            this.logger('[MudBlazor | ResizeObserver] changes detected');
+            for (let entry of entries) {
+                var target = entry.target;
+                var affectedObservedElement = observervedElements.find((x) => x.element == target);
+                if (affectedObservedElement) {
+
+                    var size = entry.target.getBoundingClientRect();
+                    if (affectedObservedElement.isInitilized == true) {
+
+                        changes.push({ id: affectedObservedElement.id, size: size });
+                    }
+                    else {
+                        affectedObservedElement.isInitilized = true;
+                    }
+                }
+            }
+
+            if (changes.length > 0) {
+                if (this.throttleResizeHandlerId >= 0) {
+                    clearTimeout(this.throttleResizeHandlerId);
+                }
+
+                this.throttleResizeHandlerId = window.setTimeout(this.resizeHandler.bind(this, changes), delay);
+
+            }
+        });
+    }
+
+    resizeHandler(changes) {
+        try {
+            this.logger("[MudBlazor | ResizeObserver] OnSizeChanged handler invoked");
+            this._dotNetRef.invokeMethodAsync("OnSizeChanged", changes);
+        } catch (error) {
+            this.logger("[MudBlazor | ResizeObserver] Error in OnSizeChanged handler:", { error });
+        }
+    }
+
+    connect(elements, ids) {
+        var result = [];
+        this.logger('[MudBlazor | ResizeObserver] Start observing elements...');
+
+        for (var i = 0; i < elements.length; i++) {
+            var newEntry = {
+                element: elements[i],
+                id: ids[i],
+                isInitilized: false,
+            };
+
+            this.logger("[MudBlazor | ResizeObserver] Start observing element:", { newEntry });
+
+            result.push(elements[i].getBoundingClientRect());
+
+            this._observervedElements.push(newEntry);
+            this._resizeObserver.observe(elements[i]);
+        }
+
+        return result;
+    }
+
+    disconnect(elementId) {
+        this.logger('[MudBlazor | ResizeObserver] Try to unobserve element with id', { elementId });
+
+        var affectedObservedElement = this._observervedElements.find((x) => x.id == elementId);
+        if (affectedObservedElement) {
+
+            var element = affectedObservedElement.element;
+            this._resizeObserver.unobserve(element);
+            this.logger('[MudBlazor | ResizeObserver] Element found. Ubobserving size changes of element', { element });
+
+            var index = this._observervedElements.indexOf(affectedObservedElement);
+            this._observervedElements.splice(index, 1);
+        }
+    }
+
+    cancelListener() {
+        this.logger('[MudBlazor | ResizeObserver] Closing ResizeObserver. Detaching all observed elements');
+
+        this._resizeObserver.disconnect();
+        this._dotNetRef = undefined;
+    }
+}
+
+
+window.mudResizeObserver = new MudResizeObserverFactory();


### PR DESCRIPTION
I've worked on the scroll features of MudTab in conjunction with resizing. 

Currently, Mudtabs has a panel div item, which is as long as its children's sum. If it doesn't fit the screen, scrolling is necessary. Scrolling is done by setting translateX (or translateY) accordingly. 

The existing code has had some issues and errors where the state hasn't been updated accordingly. 

A major flaw where excessive javascript interop calls to get the size of elements. Besides, the inability to be updated when the tabs sizes (not the document) changes made some major changes necessary.

### New features
- [x] When a tab is selected, the viewport is centered around the item. Other items are displayed right and left if there are items and enough space 

### Fixes

- [x] The Disabled/Enabled states of the scrolling buttons are now updated accordingly 
- [x] Resizing hasn't taken into account that a single tab could have been resized
- [x] Resizing hasn't taken into account that only the parent container's size could change but not the document size
- [x] ActivePanelIndex hasn't been updated when a Tab has been removed 

### Improvements

- [x] Reduced calls to JS interop. Only once, while initializing, or as soon as a resize occurred, or if a tab is added
- [x] Unitests for scrolling, selecting items

### New Service: IResizeObserver

The ```IResizeListenerService``` is attached to the entire window/document's resize event, while the IResizeObserver is observing DOM elements. Hence, in the circumstances where the document size hasn't changed but the size of the DOM element, the IResizeObserver fires an event. Besides, the IResizeObserver has a cache for the ```bounding rectangle``` of each observed element. 

### Breaking changes

There are no breaking changes, except, changes in accessibility, But I assume (or hope) that these fields haven't been used before by anyone. 

Before
```C#
public ElementReference TabsContentSize
public List<MudTabPanel> Panels {get; set; } = new List<MudTabPanel>();
```

``` C#
private ElementReference _tabsContentSize
private List<MudTabPanel> _panels = new List<MudTabPanel>();
```