### PR TITLE
Add MudSelectList

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/SelectList/Examples/SelectListCustomConverterExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/SelectList/Examples/SelectListCustomConverterExample.razor
@@ -1,0 +1,43 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudGrid>
+    <MudItem xs="12" sm="6" md="4">
+        <MudPaper>
+            <MudSelectList T="Pizza" SelectionChanged="@((item) => pizza = item)" ToStringFunc="@converter">
+                @foreach (var pizza in menu)
+                {
+                    <MudSelectListItem Item="pizza" />
+                }
+            </MudSelectList>
+        </MudPaper>
+    </MudItem>
+    <MudItem xs="12" sm="6" md="4">
+        @if(pizza == null)
+        {
+            <MudText Class="mt-5">Nothing selected yet.</MudText>
+        }        
+        else
+        {
+            <MudText Class="mt-5">Pizza: @pizza.Name</MudText>
+        }
+    </MudItem>    
+</MudGrid>
+
+@code {
+    Pizza pizza;
+
+    List<Pizza> menu = new List<Pizza>
+    {
+        new Pizza() { Name="Cardinale" },
+        new Pizza() { Name="Diavola" },
+        new Pizza() { Name="Margherita" },
+        new Pizza() { Name="Spinaci" }
+    };
+
+    public class Pizza
+    {
+        public string Name { get; set; }
+    }
+
+    Func<Pizza,string> converter = p => p?.Name.ToUpper();
+}

--- a/src/MudBlazor.Docs/Pages/Components/SelectList/Examples/SelectListMultiSelectionExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/SelectList/Examples/SelectListMultiSelectionExample.razor
@@ -1,0 +1,69 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudPaper Width="300px">
+    <MudSelectList T="Drink" @bind-SelectedItems="selectedItems" SelectionChanged="SelectionChanged" MultiSelection="true">
+        <MudListSubheader>
+            Your drinks:
+            @foreach (var item in selectedItems)
+            {
+                <MudChip Color="@(item == lastSelection ? Color.Primary : Color.Secondary)">
+                    @item.Name
+                </MudChip>
+            }
+        </MudListSubheader>
+        @foreach (var category in menu)
+        {
+            @if (category.Drinks.Count == 0)
+            {
+                <MudSelectListItem Item="category" Text="@category.Name" />
+            }
+            else
+            {
+                <MudSelectListGroup T="Drink" Text="@category.Name" InitiallyExpanded="true">
+                    <NestedList>
+                        @foreach (var drink in category.Drinks)
+                        {
+                            <MudSelectListItem Item="drink" Text="@drink.Name" />
+                        }
+                    </NestedList>
+                </MudSelectListGroup>
+            }
+        }
+    </MudSelectList>
+</MudPaper>
+
+
+@code
+{
+    HashSet<Drink> selectedItems = new();
+    Drink lastSelection;
+
+    public List<Drink> menu = new List<Drink> {
+        new Drink { Name = "Sparkling Water" },
+        new Drink{ Name = "Teas",
+        Drinks = new List<Drink>{
+            new Drink { Name = "Earl Grey" },
+            new Drink { Name = "Matcha" },
+            new Drink { Name = "Pu'er" }
+            }
+        },
+        new Drink{ Name = "Coffes",
+            Drinks = new List<Drink>{
+                new Drink { Name = "Irish Coffee" },
+                new Drink { Name = "Double Expresso" },
+                new Drink { Name = "Cafe Latte" }
+            }
+        }
+    };
+
+    private void SelectionChanged(Drink drink)
+    {
+        lastSelection = drink;
+    }
+
+    public class Drink
+    {
+        public string Name { get; set; }
+        public List<Drink> Drinks { get; init; } = new();
+    }
+}

--- a/src/MudBlazor.Docs/Pages/Components/SelectList/Examples/SelectListRadioModeExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/SelectList/Examples/SelectListRadioModeExample.razor
@@ -1,0 +1,26 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudPaper Width="300px">
+    <MudSelectList T="Pizza" RadioBehaviour="true">
+        @foreach (var pizza in menu)
+        {
+            <MudSelectListItem Item="pizza" Text="@pizza.Name" />
+        }
+    </MudSelectList>
+</MudPaper>
+
+@code
+{
+    List<Pizza> menu = new List<Pizza>
+                {
+        new Pizza() { Name="Cardinale" },
+        new Pizza() { Name="Diavola" },
+        new Pizza() { Name="Margherita" },
+        new Pizza() { Name="Spinaci" }
+    };
+
+    public class Pizza
+    {
+        public string Name { get; set; }
+    }
+}

--- a/src/MudBlazor.Docs/Pages/Components/SelectList/Examples/SelectListSingleSelectionExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/SelectList/Examples/SelectListSingleSelectionExample.razor
@@ -1,0 +1,47 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudPaper Width="300px">
+    <MudSelectList @bind-SelectedItems="selectedItems">
+        <MudListSubheader>
+            Your drink:
+            <MudChip Color="Color.Secondary">
+                @(selectedItems?.FirstOrDefault() ?? "You are dry")
+            </MudChip>
+        </MudListSubheader>
+        @foreach (var category in menu)
+        {
+            @if (category.Items.Count == 0)
+            {
+                <MudSelectListItem Item="category.Category" Text="@category.Category" />
+            }
+            else
+            {
+                <MudSelectListGroup T="string" Text="@category.Category">
+                    <NestedList>
+                        @foreach (var drink in category.Items)
+                        {
+                            <MudSelectListItem Item="drink" Text="@drink" />
+                        }
+                    </NestedList>
+                </MudSelectListGroup>
+            }
+        }
+    </MudSelectList>
+</MudPaper>
+
+@code
+{
+    HashSet<string> selectedItems = new();
+
+    public List<DrinkCategory> menu = new List<DrinkCategory> {
+        new DrinkCategory { Category = "Sparkling Water" },
+    new DrinkCategory{ Category = "Teas", Items = new List<string>{ "Earl Grey", "Matcha", "Pu'er" } },
+    new DrinkCategory{ Category = "Coffes", Items = new List<string>{ "Irish Coffee", "Double Expresso", "Cafe Latte" } }
+    };
+
+    public class DrinkCategory
+    {
+        public string Category { get; set; }
+        public List<string> Items { get; init; } = new();
+    }
+}

--- a/src/MudBlazor.Docs/Pages/Components/SelectList/SelectListPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/SelectList/SelectListPage.razor
@@ -1,0 +1,83 @@
+﻿@page "/components/selectlist"
+
+<DocsPage>
+    <DocsPageHeader Title="Selectable Lists" SubTitle="Select List fields allows users to provide information from a rich list of options, leaving them always visible.">
+        <Description>
+            <CodeInline>MudSelectList</CodeInline> looks and behaves the same as <MudLink Href="/components/list">MudList</MudLink>. Refer to it for the layout option, with added benefits of the custom converter.<br />
+            MudSelectList supports your objects instead of relying on its own list items, and  The main difference is the multi-selection feature, and better binding for complex items.
+        </Description>
+    </DocsPageHeader>
+    <DocsPageContent>
+
+        <DocsPageSection>
+            <SectionHeader>
+                <Title>Custom converter</Title>
+                <Description>
+                    SelectList has a built-in <CodeInline>DefaultConverter</CodeInline> which converts the values from any primitive type to string for presentation of the selected value.
+                    You can customize that converter as described under <MudLink Href="/features/converters">Converters</MudLink>. Here we use <CodeInline>ToStringFunc</CodeInline> to
+                    convert objects of type Pizza to their string representation. Note how the <CodeInline Tag="true">MudSelectListItem</CodeInline> uses that string representation if you don't
+                    specify a render fragement.
+                    <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">Note: priority order for the item content is the following:
+                    <ol>
+                        <li>Child content</li>
+                        <li>Text attribute</li>
+                        <li>ToStringFunc</li>
+                        <li>Default object string conversion</li>
+                    </ol>
+                    </MudAlert>
+                </Description>
+            </SectionHeader>
+            <SectionContent Outlined="true" DisplayFlex="true">
+                <MudContainer Class="py-6">
+                    <SelectListCustomConverterExample />
+                </MudContainer>
+            </SectionContent>
+            <SectionSource ShowCode="true" Code="SelectListCustomConverterExample" GitHubFolderName="Select" />
+        </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader>
+                <Title>Single Selection</Title>
+                <Description>
+                    MudSelectList will manage an exclusive single-selection across all its nested lists for you.
+                    <CodeInline>SelectedItems</CodeInline> contains the list of selected items, it can be empty and can be bound. <CodeInline>SelectedItemsChanges</CodeInline> callback fires every time the list changes.
+                </Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" DisplayFlex="true">
+                <SelectListSingleSelectionExample />
+            </SectionContent>
+            <SectionSource ShowCode="false" Code="SelectListSingleSelectionExample" GitHubFolderName="List" />
+        </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader>
+                <Title>Multi Selection</Title>
+                <Description>
+                    Setting <CodeInline>MultiSelection="true"</CodeInline> MudSelectList will manage a multiple selection across all its nested lists for you.<br />
+                    Note that <CodeInline>SelectionChanged</CodeInline> callback returns the last selected item when it's selected, but it won't be called on deselection.
+                </Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" DisplayFlex="true">
+                <SelectListMultiSelectionExample />
+            </SectionContent>
+            <SectionSource ShowCode="false" Code="SelectListMultiSelectionExample " GitHubFolderName="List" />
+        </DocsPageSection>
+    </DocsPageContent>
+
+    <DocsPageSection>
+        <SectionHeader>
+            <Title>Radio-like behaviour</Title>
+            <Description>
+                Setting <CodeInline>RadioBehaviour</CodeInline> to true, you may prevent the user to remove the last selected item, acting like a radio button in case of single selection, working across all the nested lists.<br />
+                Please note that it can be used in conjunction with <CodeInline>MultiSelection</CodeInline>, items can be removed but it cannot be cleared.
+            </Description>
+        </SectionHeader>
+        <SectionContent Outlined="true" DisplayFlex="true">
+            <MudContainer Class="py-6">
+                <SelectListRadioModeExample />
+            </MudContainer>
+        </SectionContent>
+        <SectionSource ShowCode="false" Code="SelectListRadioModeExample" GitHubFolderName="Select" />
+    </DocsPageSection>
+
+</DocsPage>

--- a/src/MudBlazor.Docs/Services/MenuService.cs
+++ b/src/MudBlazor.Docs/Services/MenuService.cs
@@ -77,6 +77,7 @@ namespace MudBlazor.Docs.Services
                 .AddItem("Radio", typeof(MudRadio<T>))
                 .AddItem("Checkbox", typeof(MudCheckBox<T>))
                 .AddItem("Select", typeof(MudSelect<T>))
+                .AddItem("Select List", typeof(MudSelectList<T>))
                 .AddItem("Slider", typeof(MudSlider<T>))
                 .AddItem("Switch", typeof(MudSwitch<T>))
                 .AddItem("Text Field", typeof(MudTextField<T>))

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/SelectList/SelectListChangeSelectionTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/SelectList/SelectListChangeSelectionTest.razor
@@ -1,0 +1,54 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudSelectList T="string" @bind-SelectedItems="selectedItems" SelectionChanged="SelectionChanged" MultiSelection="true">
+    <MudListSubheader>
+        Your drink:
+        @if (selectedItems != null && selectedItems.Count > 0)
+        {
+            @foreach (var item in selectedItems)
+            {
+                <MudChip Color="@(item == lastSelection ? Color.Primary : Color.Secondary)">
+                    @item
+                </MudChip>
+            }
+        }
+        else
+        {
+            <MudText>You are dry</MudText>
+        }
+    </MudListSubheader>
+    <MudSelectListItem Item="@("Sparkling Water")" />
+    <MudSelectListGroup T="string" Text="Teas">
+        <NestedList>
+            <MudSelectListItem Item="@("Earl Grey")" />
+            <MudSelectListItem Item="@("Matcha")" />
+            <MudSelectListItem Item="@("Pu'er")" />
+        </NestedList>
+    </MudSelectListGroup>
+    <MudSelectListGroup T="string" Text="Coffees">
+        <NestedList>
+            <MudSelectListItem Item="@("Irish Coffee")" />
+            <MudSelectListItem Item="@("Double Espresso")" />
+            <MudSelectListItem Item="@("Cafe Latte")" />
+        </NestedList>
+    </MudSelectListGroup>
+</MudSelectList>
+
+<MudButton OnClick="ChangeSelection">Change</MudButton>
+
+@code
+{ public static string __description__ = "Clicking the drinks selects them. The child lists are updated accordingly.";
+    HashSet<string> selectedItems = new HashSet<string> { "Sparkling Water", "Matcha" };
+    string lastSelection;
+
+    private void SelectionChanged(string drink)
+    {
+        lastSelection = drink;
+    }
+
+    private void ChangeSelection()
+    {
+        selectedItems = new HashSet<string> { "Irish Coffee", "Pu'er" };
+        StateHasChanged();
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/SelectList/SelectListMultiSelectionTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/SelectList/SelectListMultiSelectionTest.razor
@@ -1,0 +1,45 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudSelectList T="string" @bind-SelectedItems="selectedItems" SelectionChanged="SelectionChanged" MultiSelection="true">
+    <MudListSubheader>
+        Your drink:
+        @if (selectedItems != null && selectedItems.Count > 0)
+        {
+            @foreach (var item in selectedItems)
+            {
+                <MudChip Color="@(item == lastSelection ? Color.Primary : Color.Secondary)">
+                    @item
+                </MudChip>
+            }
+        }
+        else
+        {
+            <MudText>You are dry</MudText>
+        }
+    </MudListSubheader>
+    <MudSelectListItem Item="@("Sparkling Water")" />
+    <MudSelectListGroup T="string" Text="Teas">
+        <NestedList>
+            <MudSelectListItem Item="@("Earl Grey")" />
+            <MudSelectListItem Item="@("Matcha")" />
+            <MudSelectListItem Item="@("Pu'er")" />
+        </NestedList>
+    </MudSelectListGroup>
+    <MudSelectListGroup T="string" Text="Coffees">
+        <NestedList>
+            <MudSelectListItem Item="@("Irish Coffee")" />
+            <MudSelectListItem Item="@("Double Espresso")" />
+            <MudSelectListItem Item="@("Cafe Latte")" />
+        </NestedList>
+    </MudSelectListGroup>
+</MudSelectList>
+
+@code
+{ public static string __description__ = "Clicking the drinks selects them. The child lists are updated accordingly.";
+    HashSet<string> selectedItems;
+    string lastSelection;
+
+    private void SelectionChanged(string drink)
+    {
+        lastSelection = drink;
+    }}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/SelectList/SelectListRadioSelectionTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/SelectList/SelectListRadioSelectionTest.razor
@@ -1,0 +1,29 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudSelectList @bind-SelectedItems="selectedItem" RadioBehaviour="true">
+    <MudListSubheader>
+        Your drink:
+        <MudChip Color="Color.Secondary">
+            @(selectedItem?.FirstOrDefault() ?? "You are dry")
+        </MudChip>
+    </MudListSubheader>
+    <MudSelectListItem Item="@("Sparkling Water")" />
+    <MudSelectListGroup T="string" Text="Teas">
+        <NestedList>
+            <MudSelectListItem Item="@("Earl Grey")" />
+            <MudSelectListItem Item="@("Matcha")" />
+            <MudSelectListItem Item="@("Pu'er")" />
+        </NestedList>
+    </MudSelectListGroup>
+    <MudSelectListGroup T="string" Text="Coffees">
+        <NestedList>
+            <MudSelectListItem Item="@("Irish Coffee")" />
+            <MudSelectListItem Item="@("Double Espresso")" />
+            <MudSelectListItem Item="@("Cafe Latte")" />
+        </NestedList>
+    </MudSelectListGroup>
+</MudSelectList>
+
+@code
+{ public static string __description__ = "Clicking the drinks selects them. The child lists are updated accordingly.";
+            HashSet<string> selectedItem; }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/SelectList/SelectListSelectionTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/SelectList/SelectListSelectionTest.razor
@@ -1,0 +1,29 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudSelectList @bind-SelectedItems="selectedItem">
+    <MudListSubheader>
+        Your drink:
+        <MudChip Color="Color.Secondary">
+            @(selectedItem?.FirstOrDefault() ?? "You are dry")
+        </MudChip>
+    </MudListSubheader>
+    <MudSelectListItem Item="@("Sparkling Water")" />
+    <MudSelectListGroup T="string" Text="Teas">
+        <NestedList>
+            <MudSelectListItem Item="@("Earl Grey")" />
+            <MudSelectListItem Item="@("Matcha")" />
+            <MudSelectListItem Item="@("Pu'er")" />
+        </NestedList>
+    </MudSelectListGroup>
+    <MudSelectListGroup T="string" Text="Coffees">
+        <NestedList>
+            <MudSelectListItem Item="@("Irish Coffee")" />
+            <MudSelectListItem Item="@("Double Espresso")" />
+            <MudSelectListItem Item="@("Cafe Latte")" />
+        </NestedList>
+    </MudSelectListGroup>
+</MudSelectList>
+
+@code
+{ public static string __description__ = "Clicking the drinks selects them. The child lists are updated accordingly.";
+            HashSet<string> selectedItem; }

--- a/src/MudBlazor.UnitTests/Components/SelectListTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectListTests.cs
@@ -1,0 +1,167 @@
+﻿#pragma warning disable CS1998 // async without await
+#pragma warning disable IDE1006 // leading underscore
+
+using System;
+using System.Threading.Tasks;
+using Bunit;
+using FluentAssertions;
+using MudBlazor.UnitTests.TestComponents;
+using NUnit.Framework;
+using System.Linq;
+
+namespace MudBlazor.UnitTests.Components
+{
+    [TestFixture]
+    public class SelectListTests
+    {
+        private Bunit.TestContext ctx;
+
+        [SetUp]
+        public void Setup()
+        {
+            ctx = new Bunit.TestContext();
+            ctx.AddTestServices();
+        }
+
+        [TearDown]
+        public void TearDown() => ctx.Dispose();
+
+        /// <summary>
+        /// Clicking the drinks selects them, clicking it again deselects it. The child lists are updated accordingly, meaning, only ever 1 list item can have the active class.
+        /// </summary>
+        [Test]
+        public async Task SelectListSelectionTest()
+        {
+            var comp = ctx.RenderComponent<SelectListSelectionTest>();
+            Console.WriteLine(comp.Markup);
+            var list = comp.FindComponent<MudSelectList<string>>().Instance;
+            list.SelectedItems.Count.Should().Be(0);
+            // we have seven choices, none is active
+            comp.FindAll("div.mud-list-item").Count.Should().Be(9); // 7 choices, 2 groups
+            comp.FindAll("div.mud-selected-item").Count.Should().Be(0);
+            // click water
+            comp.FindAll("div.mud-list-item")[0].Click();
+            list.SelectedItems.Count.Should().Be(1);
+            list.SelectedItems.First().Should().Be("Sparkling Water");
+            comp.FindAll("div.mud-selected-item").Count.Should().Be(1);
+            comp.FindComponents<MudSelectListItem<string>>()[0].Markup.Should().Contain("mud-selected-item");
+            // click Pu'er, a heavily fermented Chinese tea that tastes like an old leather glove
+            comp.FindAll("div.mud-list-item")[4].Click();
+            list.SelectedItems.Count.Should().Be(1);
+            list.SelectedItems.First().Should().Be("Pu'er");
+            comp.FindAll("div.mud-selected-item").Count.Should().Be(1);
+            comp.FindComponents<MudSelectListItem<string>>()[3].Markup.Should().Contain("mud-selected-item");//4th MudSelectListItem, not 5th "div.mud-list-item", because of the group
+            // click Cafe Latte
+            comp.FindAll("div.mud-list-item")[8].Click();
+            list.SelectedItems.Count.Should().Be(1);
+            list.SelectedItems.First().Should().Be("Cafe Latte");
+            comp.FindAll("div.mud-selected-item").Count.Should().Be(1);
+            comp.FindComponents<MudSelectListItem<string>>()[6].Markup.Should().Contain("mud-selected-item");//6th MudSelectListItem, not 8th "div.mud-list-item", because of the group
+
+            // click AGAIN Cafe Latte, deselects it
+            comp.FindAll("div.mud-list-item")[8].Click();
+            list.SelectedItems.Count.Should().Be(0);
+            comp.FindAll("div.mud-selected-item").Count.Should().Be(0);
+            comp.FindComponents<MudSelectListItem<string>>()[6].Markup.Should().NotContain("mud-selected-item");//6th MudSelectListItem, not 8th "div.mud-list-item", because of the group
+        }
+
+        /// <summary>
+        /// Clicking the drinks selects them and cannot be unselected. The child lists are updated accordingly, meaning, only ever 1 list item can have the active class.
+        /// </summary>
+        [Test]
+        public async Task SelectListRadioSelectionTest()
+        {
+            var comp = ctx.RenderComponent<SelectListRadioSelectionTest>();
+            Console.WriteLine(comp.Markup);
+            var list = comp.FindComponent<MudSelectList<string>>().Instance;
+            list.SelectedItems.Count.Should().Be(0);
+            // we have seven choices, none is active
+            comp.FindAll("div.mud-list-item").Count.Should().Be(9); // 7 choices, 2 groups
+            comp.FindAll("div.mud-selected-item").Count.Should().Be(0);
+            // click water
+            comp.FindAll("div.mud-list-item")[0].Click();
+            list.SelectedItems.Count.Should().Be(1);
+            list.SelectedItems.First().Should().Be("Sparkling Water");
+            comp.FindAll("div.mud-selected-item").Count.Should().Be(1);
+            comp.FindComponents<MudSelectListItem<string>>()[0].Markup.Should().Contain("mud-selected-item");
+            // click Pu'er, a heavily fermented Chinese tea that tastes like an old leather glove
+            comp.FindAll("div.mud-list-item")[4].Click();
+            list.SelectedItems.Count.Should().Be(1);
+            list.SelectedItems.First().Should().Be("Pu'er");
+            comp.FindAll("div.mud-selected-item").Count.Should().Be(1);
+            comp.FindComponents<MudSelectListItem<string>>()[3].Markup.Should().Contain("mud-selected-item");//4th MudSelectListItem, not 5th "div.mud-list-item", because of the group
+            // click Cafe Latte
+            comp.FindAll("div.mud-list-item")[8].Click();
+            list.SelectedItems.Count.Should().Be(1);
+            list.SelectedItems.First().Should().Be("Cafe Latte");
+            comp.FindAll("div.mud-selected-item").Count.Should().Be(1);
+            comp.FindComponents<MudSelectListItem<string>>()[6].Markup.Should().Contain("mud-selected-item");//6th MudSelectListItem, not 8th "div.mud-list-item", because of the group
+            // click AGAIN Cafe Latte, it shouldn't have any effect
+            comp.FindAll("div.mud-list-item")[8].Click();
+            list.SelectedItems.Count.Should().Be(1);
+            list.SelectedItems.First().Should().Be("Cafe Latte");
+            comp.FindAll("div.mud-selected-item").Count.Should().Be(1);
+            comp.FindComponents<MudSelectListItem<string>>()[6].Markup.Should().Contain("mud-selected-item");//6th MudSelectListItem, not 8th "div.mud-list-item", because of the group
+        }
+
+
+        /// <summary>
+        /// Clicking the drinks selects them, clicking it again deselects it. The child lists are updated accordingly, meaning, only ever 1 list item can have the active class.
+        /// </summary>
+        [Test]
+        public async Task SelectListMultiSelectionTest()
+        {
+            var comp = ctx.RenderComponent<SelectListMultiSelectionTest>();
+            Console.WriteLine(comp.Markup);
+            var list = comp.FindComponent<MudSelectList<string>>().Instance;
+            list.SelectedItems.Count.Should().Be(0);
+            // we have seven choices, none is active
+            comp.FindAll("div.mud-list-item").Count.Should().Be(9); // 7 choices, 2 groups
+            comp.FindAll("div.mud-selected-item").Count.Should().Be(0);
+            // click water
+            comp.FindAll("div.mud-list-item")[0].Click();
+            list.SelectedItems.Count.Should().Be(1);
+            list.SelectedItems.First().Should().Be("Sparkling Water");
+            comp.FindAll("div.mud-selected-item").Count.Should().Be(1);
+            comp.FindComponents<MudSelectListItem<string>>()[0].Markup.Should().Contain("mud-selected-item");
+            // click Pu'er, a heavily fermented Chinese tea that tastes like an old leather glove
+            comp.FindAll("div.mud-list-item")[4].Click();
+            list.SelectedItems.Count.Should().Be(2);
+            list.SelectedItems.Contains("Sparkling Water").Should().BeTrue();
+            list.SelectedItems.Contains("Pu'er").Should().BeTrue();
+            comp.FindAll("div.mud-selected-item").Count.Should().Be(2);
+            comp.FindComponents<MudSelectListItem<string>>()[0].Markup.Should().Contain("mud-selected-item");
+            comp.FindComponents<MudSelectListItem<string>>()[3].Markup.Should().Contain("mud-selected-item");//4th MudSelectListItem, not 5th "div.mud-list-item", because of the group
+            // click Cafe Latte
+            comp.FindAll("div.mud-list-item")[8].Click();
+            list.SelectedItems.Count.Should().Be(3);
+            list.SelectedItems.Contains("Sparkling Water").Should().BeTrue();
+            list.SelectedItems.Contains("Pu'er").Should().BeTrue();
+            list.SelectedItems.Contains("Cafe Latte").Should().BeTrue();
+            comp.FindAll("div.mud-selected-item").Count.Should().Be(3);
+            comp.FindComponents<MudSelectListItem<string>>()[0].Markup.Should().Contain("mud-selected-item");
+            comp.FindComponents<MudSelectListItem<string>>()[3].Markup.Should().Contain("mud-selected-item");//4th MudSelectListItem, not 5th "div.mud-list-item", because of the group
+            comp.FindComponents<MudSelectListItem<string>>()[6].Markup.Should().Contain("mud-selected-item");//6th MudSelectListItem, not 8th "div.mud-list-item", because of the group
+
+            // click AGAIN Cafe Latte, deselects it
+            comp.FindAll("div.mud-list-item")[8].Click();
+            list.SelectedItems.Count.Should().Be(2);
+            list.SelectedItems.Contains("Sparkling Water").Should().BeTrue();
+            list.SelectedItems.Contains("Pu'er").Should().BeTrue();
+            comp.FindAll("div.mud-selected-item").Count.Should().Be(2);
+            comp.FindComponents<MudSelectListItem<string>>()[0].Markup.Should().Contain("mud-selected-item");
+            comp.FindComponents<MudSelectListItem<string>>()[3].Markup.Should().Contain("mud-selected-item");//4th MudSelectListItem, not 5th "div.mud-list-item", because of the group
+            comp.FindComponents<MudSelectListItem<string>>()[6].Markup.Should().NotContain("mud-selected-item");//6th MudSelectListItem, not 8th "div.mud-list-item", because of the group
+            // click water, deselects it
+            comp.FindAll("div.mud-list-item")[0].Click();
+            list.SelectedItems.Count.Should().Be(1);
+            list.SelectedItems.Contains("Pu'er").Should().BeTrue();
+            comp.FindAll("div.mud-selected-item").Count.Should().Be(1);
+            comp.FindComponents<MudSelectListItem<string>>()[3].Markup.Should().Contain("mud-selected-item");//4th MudSelectListItem, not 5th "div.mud-list-item", because of the group
+            // click Pu'er, deselects it
+            comp.FindAll("div.mud-list-item")[4].Click();
+            list.SelectedItems.Count.Should().Be(0);
+            comp.FindAll("div.mud-selected-item").Count.Should().Be(0);
+        }
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/SelectListTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectListTests.cs
@@ -106,7 +106,7 @@ namespace MudBlazor.UnitTests.Components
 
 
         /// <summary>
-        /// Clicking the drinks selects them, clicking it again deselects it. The child lists are updated accordingly, meaning, only ever 1 list item can have the active class.
+        /// Test multi selection
         /// </summary>
         [Test]
         public async Task SelectListMultiSelectionTest()
@@ -162,6 +162,33 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("div.mud-list-item")[4].Click();
             list.SelectedItems.Count.Should().Be(0);
             comp.FindAll("div.mud-selected-item").Count.Should().Be(0);
+        }
+
+
+        /// <summary>
+        /// Programmatically change the list should reflect on the component
+        /// </summary>
+        [Test]
+        public async Task SelectListChangeSelectionTest()
+        {
+            var comp = ctx.RenderComponent<SelectListChangeSelectionTest>();
+            Console.WriteLine(comp.Markup);
+            var list = comp.FindComponent<MudSelectList<string>>().Instance;
+            list.SelectedItems.Count.Should().Be(2);
+            list.SelectedItems.Contains("Sparkling Water").Should().BeTrue();
+            list.SelectedItems.Contains("Matcha").Should().BeTrue();
+            comp.FindAll("div.mud-list-item").Count.Should().Be(9); // 7 choices, 2 groups
+            comp.FindAll("div.mud-selected-item").Count.Should().Be(2);
+            comp.FindComponents<MudSelectListItem<string>>()[0].Markup.Should().Contain("mud-selected-item");
+            comp.FindComponents<MudSelectListItem<string>>()[2].Markup.Should().Contain("mud-selected-item");
+            // click button and change
+            comp.Find(".mud-button").Click();
+            list.SelectedItems.Count.Should().Be(2);
+            list.SelectedItems.Contains("Irish Coffee").Should().BeTrue();
+            list.SelectedItems.Contains("Pu'er").Should().BeTrue();
+            comp.FindAll("div.mud-selected-item").Count.Should().Be(2);
+            comp.FindComponents<MudSelectListItem<string>>()[3].Markup.Should().Contain("mud-selected-item");
+            comp.FindComponents<MudSelectListItem<string>>()[4].Markup.Should().Contain("mud-selected-item");
         }
     }
 }

--- a/src/MudBlazor/Components/List/MudList.razor.cs
+++ b/src/MudBlazor/Components/List/MudList.razor.cs
@@ -135,8 +135,17 @@ namespace MudBlazor
 
         public void Dispose()
         {
-            ParametersChanged = null;
-            ParentList?.Unregister(this);
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                ParametersChanged = null;
+                ParentList?.Unregister(this);
+            }
         }
 
     }

--- a/src/MudBlazor/Components/SelectList/MudSelectList.razor
+++ b/src/MudBlazor/Components/SelectList/MudSelectList.razor
@@ -1,0 +1,11 @@
+﻿@namespace MudBlazor
+@inherits MudComponentBase
+@typeparam T
+
+<div @attributes="UserAttributes" class="@Classname" style="@Style">
+    <CascadingValue Value="@this" IsFixed="true">
+        <CascadingValue Value="ToStringFunc">
+            @ChildContent
+        </CascadingValue>
+    </CascadingValue>
+</div>

--- a/src/MudBlazor/Components/SelectList/MudSelectList.razor.cs
+++ b/src/MudBlazor/Components/SelectList/MudSelectList.razor.cs
@@ -45,7 +45,7 @@ namespace MudBlazor
         [Parameter] public bool DisableGutters { get; set; }
 
         /// <summary>
-        /// If true, will disable the list item if it has onclick.
+        /// If true, will disable the list
         /// </summary>
         [Parameter] public bool Disabled { get; set; }
 

--- a/src/MudBlazor/Components/SelectList/MudSelectList.razor.cs
+++ b/src/MudBlazor/Components/SelectList/MudSelectList.razor.cs
@@ -1,0 +1,222 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Components;
+using MudBlazor.Utilities;
+using static MudBlazor.Colors;
+
+namespace MudBlazor
+{
+    public partial class MudSelectList<T> : MudComponentBase, IDisposable
+    {
+        #region private fields
+        private HashSet<MudSelectListItem<T>> _items = new();
+        private HashSet<MudSelectList<T>> _childLists = new();
+        private HashSet<T> _selection = new();
+        #endregion
+
+        #region properties
+        protected string Classname =>
+        new CssBuilder("mud-list")
+           .AddClass("mud-list-padding", !DisablePadding)
+          .AddClass(Class)
+        .Build();
+
+        [CascadingParameter] protected MudSelectList<T> ParentList { get; set; }
+
+        /// <summary>
+        /// Child content of component.
+        /// </summary>
+        [Parameter] public RenderFragment ChildContent { get; set; }
+
+        /// <summary>
+        /// If true, vertical padding will be removed from the list.
+        /// </summary>
+        [Parameter] public bool DisablePadding { get; set; }
+
+        /// <summary>
+        /// If true, compact vertical padding will be applied to all list items.
+        /// </summary>
+        [Parameter] public bool Dense { get; set; }
+
+        /// <summary>
+        /// If true, the left and right padding is removed on all list items.
+        /// </summary>
+        [Parameter] public bool DisableGutters { get; set; }
+
+        /// <summary>
+        /// If true, will disable the list item if it has onclick.
+        /// </summary>
+        [Parameter] public bool Disabled { get; set; }
+
+        /// <summary>
+        /// Set to true to enable selection of multiple items. 
+        /// </summary>
+        [Parameter] public bool MultiSelection { get; set; }
+
+        /// <summary>
+        /// Set to true, the user won't be able to deselect the last item, behaving like a radio button if <see cref="MultiSelection"/> is false.
+        /// </summary>
+        [Parameter] public bool RadioBehaviour { get; set; }
+
+        /// <summary>
+        /// Callback is called when an item has been clicked and returns the latest selected item.
+        /// </summary>
+        [Parameter] public EventCallback<T> SelectionChanged { get; set; }
+
+        /// <summary>
+        /// This returns the currently selected items. You can bind this property and the initial content of the HashSet you bind it to will cause these rows to be selected initially.
+        /// </summary>
+        [Parameter]
+        public HashSet<T> SelectedItems
+        {
+            get
+            {
+                return _selection;
+            }
+            set
+            {
+                if (value == _selection)
+                    return;
+                if (value == null)
+                {
+                    if (_selection.Count == 0)
+                        return;
+                    _selection = new HashSet<T>();
+                }
+                else
+                    _selection = value;
+                SelectedItemsChanged.InvokeAsync(_selection);
+
+                InvokeAsync(StateHasChanged);
+            }
+        }
+
+        /// <summary>
+        /// Callback is called whenever items are selected or deselected in multi selection mode.
+        /// </summary>
+        [Parameter] public EventCallback<HashSet<T>> SelectedItemsChanged { get; set; }
+
+        IEqualityComparer<T> _equalityComparer = EqualityComparer<T>.Default;
+        /// <summary>
+        /// Specify a different equality comparer then the default one.
+        /// </summary>
+        [Parameter]
+        public IEqualityComparer<T> EqualityComparer
+        {
+            get => _equalityComparer;
+            set
+            {
+                _equalityComparer = value ?? EqualityComparer<T>.Default;
+            }
+        }
+
+        /// <summary>
+        /// Defines how values are displayed in the list
+        /// </summary>
+        [Parameter]
+        public Func<T, string> ToStringFunc { get; set; }
+        #endregion
+
+        protected override void OnInitialized()
+        {
+            ParentList?.Register(this);
+        }
+
+        internal event Action ParametersChanged;
+
+        protected override void OnParametersSet()
+        {
+            base.OnParametersSet();
+            ParametersChanged?.Invoke();
+        }
+
+        internal void Register(MudSelectListItem<T> item)
+        {
+            _items.Add(item);
+        }
+
+        internal void Unregister(MudSelectListItem<T> item)
+        {
+            _items.Remove(item);
+        }
+
+        internal void Register(MudSelectList<T> child)
+        {
+            _childLists.Add(child);
+        }
+
+        internal void Unregister(MudSelectList<T> child)
+        {
+            _childLists.Remove(child);
+        }
+
+        /// <summary>
+        /// Determines if the element can be removed or not, for example if it's the last element when the parent list has <see cref="RadioBehaviour"/> enabled
+        /// </summary>
+        private bool BlockRemove()
+        {
+            if (ParentList != null)
+                return ParentList.BlockRemove();
+
+            return RadioBehaviour && _selection.Count == 1;
+        }
+
+        internal void SetSelection(T item, bool selected, bool force = false)
+        {
+            if (selected)
+            {
+
+                if (_selection.Contains(item))
+                    return;
+
+                if (MultiSelection)
+                    _selection.Add(item);
+                else
+                {
+                    if (_selection.Count > 0 && !_equalityComparer.Equals(_selection.First(), item))
+                        SetSelection(_selection.First(), false, true);//remove the previous one
+
+                    _selection = new HashSet<T> { item };
+                }
+
+                SelectedItemsChanged.InvokeAsync(_selection);
+                SelectionChanged.InvokeAsync(item);
+            }
+            else
+            {
+                if (!force && BlockRemove())
+                    return;
+                //remove item and check if it has been removed, if not exit because it wasn't in the list to begin with
+                if (!_selection.Remove(item))
+                    return;
+
+                SelectedItemsChanged.InvokeAsync(_selection);
+            }
+
+            foreach (var listItem in _items.ToArray())
+            {
+                if (_equalityComparer.Equals(item, listItem.Item))
+                    listItem.SetSelected(selected);
+            }
+            foreach (var childList in _childLists.ToArray())
+                childList.SetSelection(item, selected);
+            ParentList?.SetSelection(item, selected);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                ParametersChanged = null;
+                ParentList?.Unregister(this);
+            }
+        }
+    }
+}

--- a/src/MudBlazor/Components/SelectList/MudSelectList.razor.cs
+++ b/src/MudBlazor/Components/SelectList/MudSelectList.razor.cs
@@ -86,6 +86,10 @@ namespace MudBlazor
                 }
                 else
                     _selection = value;
+
+                foreach (var item in _selection)
+                    PropagateSelection(item, true);
+
                 SelectedItemsChanged.InvokeAsync(_selection);
 
                 InvokeAsync(StateHasChanged);
@@ -194,6 +198,11 @@ namespace MudBlazor
                 SelectedItemsChanged.InvokeAsync(_selection);
             }
 
+            PropagateSelection(item, true);
+        }
+
+        private void PropagateSelection(T item, bool selected)
+        {
             foreach (var listItem in _items.ToArray())
             {
                 if (_equalityComparer.Equals(item, listItem.Item))

--- a/src/MudBlazor/Components/SelectList/MudSelectListGroup.razor
+++ b/src/MudBlazor/Components/SelectList/MudSelectListGroup.razor
@@ -1,0 +1,51 @@
+﻿@namespace MudBlazor
+@inherits MudComponentBase
+@typeparam T
+
+<div @attributes="UserAttributes" class="@Classname" @onclick="OnClickHandler" @onclick:stopPropagation="true" style="@Style">
+  @if (!String.IsNullOrEmpty(Avatar))
+  {
+    <div class="mud-list-item-avatar">
+      <MudAvatar Class="@AvatarClass">
+        <MudIcon Icon="@Avatar" Color="@IconColor"></MudIcon>
+      </MudAvatar>
+    </div>
+  }
+  else if (!String.IsNullOrEmpty(Icon))
+  {
+    <div class="mud-list-item-icon">
+      <MudIcon Icon="@Icon" Color="@IconColor"></MudIcon>
+    </div>
+  }
+  <div class="mud-list-item-text @(Inset? "mud-list-item-text-inset" : "")">
+    <MudText Typo="@_textTypo">
+      @if (ChildContent != null)
+      {
+        @ChildContent
+      }
+      else
+      {
+        @Text
+      }
+    </MudText>
+  </div>
+  @if (NestedList != null)
+  {
+    @if (_expanded)
+    {
+      <MudIcon Icon="@Icons.Material.Filled.ExpandLess" />
+    }
+    else
+    {
+      <MudIcon Icon="@Icons.Material.Filled.ExpandMore" />
+    }
+  }
+</div>
+@if (NestedList != null)
+{
+<MudCollapse Expanded="@Expanded">
+  <MudSelectList T="T" DisablePadding="true" MultiSelection="ParentList?.MultiSelection ?? false" EqualityComparer="ParentList?.EqualityComparer" RadioBehaviour="ParentList?.RadioBehaviour ?? false" Class="mud-nested-list" Disabled="@Disabled">
+    @NestedList
+  </MudSelectList>
+</MudCollapse>
+}

--- a/src/MudBlazor/Components/SelectList/MudSelectListItem.razor
+++ b/src/MudBlazor/Components/SelectList/MudSelectListItem.razor
@@ -1,0 +1,38 @@
+﻿@namespace MudBlazor
+@inherits MudComponentBase
+@typeparam T
+
+<div @attributes="UserAttributes" class="@Classname" @onclick="OnClickHandler" @onclick:stopPropagation="true" style="@Style">
+    @if (!String.IsNullOrEmpty(Avatar))
+    {
+<div class="mud-list-item-avatar">
+    <MudAvatar Class="@AvatarClass">
+        <MudIcon Icon="@Avatar" Color="@IconColor"></MudIcon>
+    </MudAvatar>
+</div> }
+else if (!String.IsNullOrEmpty(Icon))
+{
+<div class="mud-list-item-icon">
+    <MudIcon Icon="@Icon" Color="@IconColor"></MudIcon>
+</div>}
+    <div class="mud-list-item-text @(Inset? "mud-list-item-text-inset" : "")">
+        <MudText Typo="@_textTypo">
+            @if (ChildContent != null)
+            {
+                @ChildContent
+            }
+            else if (Text != null)
+            {
+                @Text
+            }
+            else if (ToStringFunc != null)
+            {
+                @ToStringFunc(Item)
+            }
+            else
+            {
+                @Item
+            }
+        </MudText>
+    </div>
+</div>

--- a/src/MudBlazor/Components/SelectList/MudSelectListItem.razor.cs
+++ b/src/MudBlazor/Components/SelectList/MudSelectListItem.razor.cs
@@ -109,7 +109,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         public EventCallback<MouseEventArgs> OnClick { get; set; }
-#endregion
+        #endregion
 
         protected void OnClickHandler(MouseEventArgs ev)
         {
@@ -184,6 +184,11 @@ namespace MudBlazor
                 return;
             _selected = selected;
             StateHasChanged();
+        }
+
+        internal void VerifySelection(HashSet<T> selected)
+        {
+            _selected = selected.Contains(Item);
         }
 
         public void Dispose()

--- a/src/MudBlazor/Components/SelectList/MudSelectListItem.razor.cs
+++ b/src/MudBlazor/Components/SelectList/MudSelectListItem.razor.cs
@@ -54,10 +54,17 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public string AvatarClass { get; set; }
 
+        private bool _disabled;
         /// <summary>
-        /// If true, will disable the list item if it has onclick.
+        /// If true, will disable the list item.
+        /// The value can be overridden by the parent list.
         /// </summary>
-        [Parameter] public bool Disabled { get; set; }
+        [Parameter]
+        public bool Disabled
+        {
+            get => _disabled || (ParentList?.Disabled ?? false);
+            set => _disabled = value;
+        }
 
         /// <summary>
         /// If true, disables ripple effect.


### PR DESCRIPTION
A twist on `MudList` allowing for multi-selection, radio-behavior and object binding.

Original issue: https://github.com/Garderoben/MudBlazor/issues/1295

At this moment, MudList components basically manages a list of MudListItem.
It should manage a list of generic objects instead.

`MudSelectList` uses the same classes and layout, the main difference on that regard is that the sublist role has been replaced by a different `MudSelectListGroup`.
It uses the same code base too (in fact is a copy-paste and then changed), with the addition of binding, multi-selection and a radio-like behaviour.