### PR TITLE
Added two way binding to MudNavGroup `Expanded` property

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/NavMenu/Examples/NavMenuTwoWayBindableExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/NavMenu/Examples/NavMenuTwoWayBindableExample.razor
@@ -1,0 +1,28 @@
+﻿@namespace MudBlazor.Docs.Examples
+<MudPaper Width="250px" Class="py-3" Square="true">
+    <MudNavMenu>
+        <MudText Typo="Typo.h6" Class="px-4">My Application</MudText>
+        <MudText Typo="Typo.body2" Class="px-4 mud-text-secondary">Secondary Text</MudText>
+        <MudDivider Class="my-2" />
+        <MudNavGroup Title="Settings" @bind-Expanded=_isExpanded>
+            <MudNavLink Href="/users">Users</MudNavLink>
+            <MudNavLink Href="/security">Security</MudNavLink>
+        </MudNavGroup>
+    </MudNavMenu>
+</MudPaper>
+<br />
+<MudText>
+    The MudNavGroup is
+    @if (_isExpanded)
+    {
+        <b class="mud-theme-tertiary rounded pa-2 ml-2">expanded</b>
+    }
+    else
+    {
+        <b class="mud-theme-error rounded pa-2 ml-2">collapsed</b>
+    }
+    </MudText>
+
+    @code{
+    bool _isExpanded = true;
+}

--- a/src/MudBlazor.Docs/Pages/Components/NavMenu/NavMenuPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/NavMenu/NavMenuPage.razor
@@ -11,7 +11,17 @@
             <SectionContent DarkenBackground="true">
                 <NavMenuExample />
             </SectionContent>
-            <SectionSource Code="NavMenuExample" GitHubFolderName="NavMenu"  />
+            <SectionSource Code="NavMenuExample" GitHubFolderName="NavMenu" />
+        </DocsPageSection>
+        <DocsPageSection>
+            <SectionHeader>
+                <Title>MudNavGroup Two Way Bind </Title>
+                <Description>MudNavGroup admits two-way binding in the <CodeInline>Expanded</CodeInline> property, so you can control what happens on expanding and collapsing</Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true">
+                <NavMenuTwoWayBindableExample />
+            </SectionContent>
+            <SectionSource Code="NavMenuTwoWayBindableExample" GitHubFolderName="NavMenu" />
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/NavMenu/NavMenuOneWay.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/NavMenu/NavMenuOneWay.razor
@@ -1,0 +1,5 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+<MudNavGroup Title="Settings" Expanded=true>
+    <MudNavLink Href="/users">Users</MudNavLink>
+</MudNavGroup>
+

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/NavMenu/NavMenuTwoWay.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/NavMenu/NavMenuTwoWay.razor
@@ -1,0 +1,8 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+<MudNavGroup Title="Settings" @bind-Expanded=_isExpanded>
+    <MudNavLink Href="/users">Users</MudNavLink>
+</MudNavGroup>
+
+@code{
+   public bool _isExpanded;
+}

--- a/src/MudBlazor.UnitTests/Components/NavMenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NavMenuTests.cs
@@ -1,0 +1,66 @@
+﻿#pragma warning disable IDE1006 // leading underscore
+
+using Bunit;
+using FluentAssertions;
+using MudBlazor.UnitTests.TestComponents;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Components
+{
+    [TestFixture]
+    public class NavMenuTexts
+    {
+        private Bunit.TestContext ctx;
+
+        [SetUp]
+        public void Setup()
+        {
+            ctx = new Bunit.TestContext();
+            ctx.AddTestServices();
+        }
+
+        [TearDown]
+        public void TearDown() => ctx.Dispose();
+
+        /// <summary>
+        /// This component is initially Expanded with the property Expand set to imutable true <c>Expand=true</c>
+        /// And even so, he changes when clicked
+        /// </summary>
+        [Test]
+        public void One_Way_Bindable()
+        {
+            var comp = ctx.RenderComponent<NavMenuOneWay>();
+            comp.Markup.Should().Contain("expanded");
+
+            var navgroup = comp.Find(".mud-nav-group>button");
+            navgroup.Click();
+
+            comp.Markup.Should().NotContain("expanded");
+
+
+        }
+
+        /// <summary>
+        /// This component has a field _isExpanded two-way bound to Expanded property
+        /// Initially is set to false and after clicking the navgroup should change to true
+        /// </summary>
+
+        [Test]
+        public void Two_Way_Bindable()
+        {
+            var comp = ctx.RenderComponent<NavMenuTwoWay>();
+            comp.Markup.Should().NotContain("expanded");
+            var isExpanded = comp.Instance._isExpanded;
+            isExpanded.Should().BeFalse();
+
+            var navgroup = comp.Find(".mud-nav-group>button");
+            navgroup.Click();
+
+            isExpanded = comp.Instance._isExpanded;
+            isExpanded.Should().BeTrue();
+            comp.Markup.Should().Contain("expanded");
+
+
+        }
+    }
+}

--- a/src/MudBlazor/Components/NavMenu/MudNavGroup.razor.cs
+++ b/src/MudBlazor/Components/NavMenu/MudNavGroup.razor.cs
@@ -39,10 +39,26 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public bool DisableRipple { get; set; }
 
+        private bool _expanded;
         /// <summary>
-        /// If true, expands the nav group, otherwise collapse it. Setting this prop enables control over the panel.
+        /// If true, expands the nav group, otherwise collapse it. 
+        /// Two-way bindable
         /// </summary>
-        [Parameter] public bool Expanded { get; set; }
+        [Parameter]
+        public bool Expanded
+        {
+            get => _expanded;
+            set
+            {
+                if (_expanded == value)
+                    return;
+
+                _expanded = value;
+                ExpandedChanged.InvokeAsync(_expanded);
+            }
+        }
+
+        [Parameter] public EventCallback<bool> ExpandedChanged { get; set; }
 
         /// <summary>
         /// If true, hides expand-icon at the end of the NavGroup.
@@ -62,7 +78,8 @@ namespace MudBlazor
 
         protected void ExpandedToggle()
         {
-            Expanded = !Expanded;
+            _expanded = !Expanded;
+            ExpandedChanged.InvokeAsync(_expanded);
         }
     }
 }


### PR DESCRIPTION
This addresses #1322

MudNavGroup property `Expanded` should be two-way bondable, so you can choose what happens when the nav group collapses or expands.