### PR TITLE
Darktheme color adjustments

### DIFF
--- a/src/MudBlazor.Docs/Pages/Customization/Theming/Examples/OverviewThemesMultipleExample.razor
+++ b/src/MudBlazor.Docs/Pages/Customization/Theming/Examples/OverviewThemesMultipleExample.razor
@@ -49,7 +49,13 @@
             TextSecondary = "rgba(255,255,255, 0.50)",
             ActionDefault = "#adadb1",
             ActionDisabled = "rgba(255,255,255, 0.26)",
-            ActionDisabledBackground = "rgba(255,255,255, 0.12)"
+            ActionDisabledBackground = "rgba(255,255,255, 0.12)",
+            Divider = "rgba(255,255,255, 0.12)",
+            DividerLight = "rgba(255,255,255, 0.06)",
+            TableLines = "rgba(255,255,255, 0.12)",
+            LinesDefault = "rgba(255,255,255, 0.12)",
+            LinesInputs = "rgba(255,255,255, 0.3)",
+            TextDisabled = "rgba(255,255,255, 0.2)"
         }
     };
 }

--- a/src/MudBlazor.Docs/Shared/MainLayout.razor.cs
+++ b/src/MudBlazor.Docs/Shared/MainLayout.razor.cs
@@ -132,6 +132,7 @@ namespace MudBlazor.Docs.Shared
                     Surface = "#373740",
                     DrawerBackground = "#27272f",
                     DrawerText = "rgba(255,255,255, 0.50)",
+                    DrawerIcon = "rgba(255,255,255, 0.50)",
                     AppbarBackground = "#27272f",
                     AppbarText = "rgba(255,255,255, 0.70)",
                     TextPrimary = "rgba(255,255,255, 0.70)",
@@ -139,7 +140,12 @@ namespace MudBlazor.Docs.Shared
                     ActionDefault = "#adadb1",
                     ActionDisabled = "rgba(255,255,255, 0.26)",
                     ActionDisabledBackground = "rgba(255,255,255, 0.12)",
-                    DrawerIcon = "rgba(255,255,255, 0.50)"
+                    Divider = "rgba(255,255,255, 0.12)",
+                    DividerLight = "rgba(255,255,255, 0.06)",
+                    TableLines = "rgba(255,255,255, 0.12)",
+                    LinesDefault = "rgba(255,255,255, 0.12)",
+                    LinesInputs = "rgba(255,255,255, 0.3)",
+                    TextDisabled = "rgba(255,255,255, 0.2)"
                 }
             };
 


### PR DESCRIPTION
I played around with the line colors in the darktheme. In my opinion it looks much better now. What do you think?
Left=new, right=old:

Tables:
![tables](https://user-images.githubusercontent.com/62108893/114053042-de763980-988e-11eb-9aed-4c189565787e.png)

Text-fields:
![textfields](https://user-images.githubusercontent.com/62108893/114053111-f0f07300-988e-11eb-80df-9f5f47951837.png)

Divider:
![divider](https://user-images.githubusercontent.com/62108893/114053132-f5b52700-988e-11eb-8167-523b9eda88ee.png)

Closes #1264, #1265