### PR TITLE
Fix minor typo for method name in SelectInteractiveExample

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Select/Examples/SelectInteractiveExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Select/Examples/SelectInteractiveExample.razor
@@ -3,7 +3,7 @@
 <MudGrid>
     <MudItem xs="12" md="3">
         <MudForm>
-            <MudSwitch T="bool" CheckedChanged="@OnPostitionChange" Color="Color.Primary" Label="Open Top" />
+            <MudSwitch T="bool" CheckedChanged="@OnPositionChange" Color="Color.Primary" Label="Open Top" />
             <MudSwitch @bind-Checked="@OffsetY" Color="Color.Secondary" Label="Offset Y" />
             <MudSwitch @bind-Checked="@Dense" Color="Color.Primary" Label="Dense" />
         </MudForm>
@@ -30,7 +30,7 @@
     public Direction _direction {get; set;}
     public Variant _variant { get; set; } = Variant.Filled;
 
-    protected void OnPostitionChange()
+    protected void OnPositionChange()
     {
         OpenTop = !OpenTop;
 


### PR DESCRIPTION
SelectInteractiveExample.OnPostitionChange will become SelectInteractiveExample.OnPositionChange