### PR TITLE
Fix initial selected values that didn't show converted

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/MultiSelectWithInitialValues.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/MultiSelectWithInitialValues.razor
@@ -1,0 +1,37 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudSelect Label="Select Item" 
+    MultiSelection="true" 
+    T="@TestItem" 
+    SelectedValues="@SelectedItems" 
+    ToStringFunc="@ToString">
+
+    @foreach (TestItem item in AllItems)
+    {
+        <MudSelectItem Value="@item" />
+    }
+</MudSelect>
+
+@code {
+
+    private List<TestItem> AllItems = new();    
+    private HashSet<TestItem> SelectedItems = new();
+    protected override async Task OnInitializedAsync()
+    {
+        AllItems.Add(new TestItem { A = "FirstA" });
+        AllItems.Add(new TestItem { A = "SecondA" });
+        AllItems.Add(new TestItem { A = "ThirdA" });
+        
+        SelectedItems.Add(AllItems[0]);
+        SelectedItems.Add(AllItems[1]);
+        await base.OnInitializedAsync();
+    }
+
+    private string ToString(TestItem x)
+        => x is null ? string.Empty : $"{x.A}";
+
+    private class TestItem
+    {
+        public string A { get; set; }        
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -443,6 +443,24 @@ namespace MudBlazor.UnitTests.Components
             validatedValue.Should().Be("1");
         }
 
+        /// <summary>
+        /// We filled the multiselect with initial selected values, that must
+        /// show in the value of the input as a comma separated list of strings
+        /// </summary>
+        /// <returns></returns>
+        [Test]
+        public async Task MultiSelect_Initial_Values()
+        {
+            var comp = ctx.RenderComponent<MultiSelectWithInitialValues>();
+            // print the generated html
+            Console.WriteLine(comp.Markup);
+
+            // select the input of the select
+            var input = comp.Find("input");
+            //the value of the input
+            var value = input.Attributes.Where(a => a.LocalName == "value").First().Value;
+            value.Should().Be("FirstA, SecondA");     
+        }
 
         #region DataAttribute validation
         [Test]

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
-using Microsoft.JSInterop;
 using MudBlazor.Utilities;
 using MudBlazor.Utilities.Exceptions;
 
@@ -71,6 +70,7 @@ namespace MudBlazor
                 if (!MultiSelection)
                     SetValueAsync(_selectedValues.FirstOrDefault()).AndForget();
                 else
+                    //Warning. Here the Converter was not set yet
                     SetTextAsync(string.Join(", ", SelectedValues.Select(x => Converter.Set(x)))).AndForget();
                 SelectedValuesChanged.InvokeAsync(new HashSet<T>(SelectedValues));
             }
@@ -155,9 +155,11 @@ namespace MudBlazor
 
         protected override Task UpdateTextPropertyAsync(bool updateValue)
         {
-            // when multiselection is true, we don't update the text when the value changes. 
-            // instead the Text will be set with a comma separated list of selected values
-            return MultiSelection ? Task.CompletedTask : base.UpdateTextPropertyAsync(updateValue);
+            // when multiselection is true, we return
+            // a comma separated list of selected values
+            return MultiSelection
+                ? SetTextAsync(string.Join(", ", SelectedValues.Select(x => Converter.Set(x))))
+                : base.UpdateTextPropertyAsync(updateValue);
         }
 
         internal event Action<HashSet<T>> SelectionChangedFromOutside;


### PR DESCRIPTION
The initial selected values didn't get converted in the input initially, because when the Select called the Converter, in the Text setter, the Converter was still the DefaultConverter, not the user Converter.

This fixes it