### PR TITLE
Added default to Enum Typo

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Select/Examples/SelectInteractiveExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Select/Examples/SelectInteractiveExample.razor
@@ -3,7 +3,7 @@
 <MudGrid>
     <MudItem xs="12" md="3">
         <MudForm>
-            <MudSwitch T="bool" CheckedChanged="@OnPostitionChange" Color="Color.Primary" Label="Open Top" />
+            <MudSwitch T="bool" CheckedChanged="@OnPositionChange" Color="Color.Primary" Label="Open Top" />
             <MudSwitch @bind-Checked="@OffsetY" Color="Color.Secondary" Label="Offset Y" />
             <MudSwitch @bind-Checked="@Dense" Color="Color.Primary" Label="Dense" />
         </MudForm>
@@ -30,7 +30,7 @@
     public Direction _direction {get; set;}
     public Variant _variant { get; set; } = Variant.Filled;
 
-    protected void OnPostitionChange()
+    protected void OnPositionChange()
     {
         OpenTop = !OpenTop;
 

--- a/src/MudBlazor/Enums/Typo.cs
+++ b/src/MudBlazor/Enums/Typo.cs
@@ -4,6 +4,8 @@ namespace MudBlazor
 {
     public enum Typo
     {
+        [Description("default")]
+        default,
         [Description("h1")]
         h1,
         [Description("h2")]

--- a/src/MudBlazor/Enums/Typo.cs
+++ b/src/MudBlazor/Enums/Typo.cs
@@ -4,8 +4,8 @@ namespace MudBlazor
 {
     public enum Typo
     {
-        [Description("default")]
-        default,
+        [Description("inherit")]
+        inherit,
         [Description("h1")]
         h1,
         [Description("h2")]


### PR DESCRIPTION
It is not possible to switch typo to default of document, and default != body1

Using for example a mudlink next to normal html text leads to different fontsizes.

![image](https://user-images.githubusercontent.com/26269158/114723985-6e0e6300-9d3b-11eb-8544-6f8cd60ad522.png)

