### PR TITLE
Throttle breakpoint change event

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DrawerTest.cs
+++ b/src/MudBlazor.UnitTests/Components/DrawerTest.cs
@@ -259,5 +259,47 @@ namespace MudBlazor.UnitTests.Components.Components
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
             comp.FindAll("aside+.mud-drawer-overlay").Count.Should().Be(0);
         }
+
+        /// <summary>
+        /// Resize screen to small in two steps: first to SM, then to XS. After restoring the original screen size, the drawer should reopen automatically.
+        /// </summary>
+        /// <returns></returns>
+        [Test]
+        public async Task Responsive_ResizeToSmall_RestoreToLarge_CheckStates()
+        {
+            var srv = ctx.Services.GetService<IResizeListenerService>() as MockResizeListenerService;
+            srv?.ApplyScreenSize(1280, 768);
+
+            var comp = ctx.RenderComponent<DrawerResponsiveTest>(new[]
+            {
+                Parameter(nameof(DrawerResponsiveTest.PreserveOpenState), true)
+            });
+
+            Console.WriteLine(comp.Markup);
+
+            //open drawer
+            comp.Find("button").Click();
+
+            comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeTrue();
+
+            //resize to small, drawer should close
+            srv?.ApplyScreenSize(800, 768);
+
+            comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeFalse();
+
+            //resize to extra small, drawer should close
+            srv?.ApplyScreenSize(400, 768);
+
+            comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeFalse();
+
+            //resize to large, drawer should open automatically
+            srv?.ApplyScreenSize(1024, 768);
+
+            comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeTrue();
+        }
     }
 }

--- a/src/MudBlazor/TScripts/mudResizeListener.js
+++ b/src/MudBlazor/TScripts/mudResizeListener.js
@@ -25,21 +25,21 @@
         this.breakpoint = this.getBreakpoint(window.innerWidth);
     }
 
-    throttleResizeHandler () {
-        if (!this.options.notifyOnBreakpointOnly) {
-            clearTimeout(this.throttleResizeHandlerId);
-            //console.log("[MudBlazor] throttleResizeHandler ", {options:this.options});
-            this.throttleResizeHandlerId = window.setTimeout(this.resizeHandler.bind(this), ((this.options || {}).reportRate || 100));
-        } else {
-            let bp = this.getBreakpoint(window.innerWidth);
-            if (bp != this.breakpoint) {
-                this.resizeHandler();
-                this.breakpoint = bp;
-            }
-        }
+    throttleResizeHandler() {
+        clearTimeout(this.throttleResizeHandlerId);
+        //console.log("[MudBlazor] throttleResizeHandler ", {options:this.options});
+        this.throttleResizeHandlerId = window.setTimeout(this.resizeHandler.bind(this), ((this.options || {}).reportRate || 100));
     }
 
-    resizeHandler () {
+    resizeHandler() {
+        if (this.options.notifyOnBreakpointOnly) {
+            let bp = this.getBreakpoint(window.innerWidth);
+            if (bp == this.breakpoint) {
+                return;
+            }
+            this.breakpoint = bp;
+        }
+
         try {
             //console.log("[MudBlazor] RaiseOnResized invoked");
             this.dotnet.invokeMethodAsync('RaiseOnResized',


### PR DESCRIPTION
Possible fix to #1371 and #1376
The problem here is that breakpoint change event fires two times, once after reaching md size then again when reaching sm. Delaying the event on JS side could solve this problem.