### PR TITLE
Fix MudToolTip is not flex compatible, #1167

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/TooltipInlineTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/TooltipInlineTest.razor
@@ -1,0 +1,15 @@
+﻿<MudGrid>
+    <MudItem xs="12">
+        <MudTextField T="string" Text="Nice and flexy" Variant="Variant.Outlined"></MudTextField>
+    </MudItem>
+    <MudItem xs="12">
+        <MudTooltip Text="This kills the flex">
+            <MudTextField T="string" Text="Where's my flex?" Variant="Variant.Outlined"></MudTextField>
+        </MudTooltip>
+    </MudItem>
+    <MudItem xs="12">
+        <MudTooltip Text="This fixes the flex" Inline="false">
+            <MudTextField T="string" Text="I found my flex?" Variant="Variant.Outlined"></MudTextField>
+        </MudTooltip>
+    </MudItem>
+</MudGrid>

--- a/src/MudBlazor/Components/Tooltip/MudTooltip.razor
+++ b/src/MudBlazor/Components/Tooltip/MudTooltip.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
 
-<div class="mud-tooltip-root">
+<div class="@ContainerClass">
     @ChildContent
     @if (!String.IsNullOrEmpty(Text) || TooltipContent != null)
     {

--- a/src/MudBlazor/Components/Tooltip/MudTooltip.razor.cs
+++ b/src/MudBlazor/Components/Tooltip/MudTooltip.razor.cs
@@ -8,6 +8,9 @@ namespace MudBlazor
 {
     public partial class MudTooltip : MudComponentBase
     {
+        protected string ContainerClass => new CssBuilder("mud-tooltip-root")
+            .AddClass("mud-tooltip-inline", Inline)
+            .Build();
         protected string Classname => new CssBuilder("mud-tooltip")
             .AddClass($"mud-tooltip-placement-{Placement.ToDescriptionString()}")
             .AddClass(Class)
@@ -48,6 +51,11 @@ namespace MudBlazor
         /// Tooltip content. May contain any valid html
         /// </summary>
         [Parameter] public RenderFragment TooltipContent { get; set; }
+
+        /// <summary>
+        /// Determines if this component should be inline with it's surrounding (default) or if it should behave like a block element.
+        /// </summary>
+        [Parameter] public Boolean Inline { get; set; } = true;
 
         protected string GetTimeDelay()
         {

--- a/src/MudBlazor/Styles/components/_tooltip.scss
+++ b/src/MudBlazor/Styles/components/_tooltip.scss
@@ -1,7 +1,10 @@
 ﻿
 .mud-tooltip-root {
     position: relative;
-    display: inline-block;
+
+    &.mud-tooltip-inline {
+        display: inline-block;
+    }
 
     & .mud-tooltip {
         color: var(--mud-palette-dark-text);


### PR DESCRIPTION
This fixes issue #1167, for which a tooltip surrounds it's content with an inline-block div by default.
Added a new property called **Inline**, which defaults to true for compatibility. Setting it to false doesn't change the display attribute of the div to inline, but keeps it a block.
This has been achieved moving the following CSS rule `display:  inline-block` into a new class, added to the container only if `Inline == true`.

Although I'm not a fan of negative logic, this is the more elegant way I found to not break compatibility (and possibly the most common scenario).
Other options I evaluated a parameter name have been:
- Block (not self-explanatory)
- DisplayBlock
- ContainerBlock
- ContainerDisplay (and setting up an enumerator that could have even more values)

I also avoided to be verbose on the parameter documentation, originally I explained the behaviour more in detail.
I think it's clear enough to anyone who knows enough CSS.

Let me know if you prefer something else.