### PR TITLE
Added test to proof #1389 is fixed

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/SimplifiedScrollableTabsTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/SimplifiedScrollableTabsTest.razor
@@ -1,0 +1,44 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudTabs Elevation="1" @ref="_tabElement" AlwaysShowScrollButtons="false" Position="Position.Top">
+    @foreach (var tab in _tabs)
+    {
+<MudTabPanel @key="tab" Text="@tab">
+    <MudText>@tab</MudText>
+</MudTabPanel>}
+</MudTabs>
+
+@code
+{ 
+    private MudTabs _tabElement;
+
+    public static string __description__ = "scrolling should work";
+
+    [Parameter]
+    public Int32 StartAmount { get; set; } = 0;
+
+    protected override void OnParametersSet()
+    {
+        base.OnParametersSet();
+
+        for (int i = 0; i < StartAmount; i++)
+        {
+            _tabs.Add($"new item {i + 1}");
+        }
+    }
+
+    private List<string> _tabs = new();
+
+    public async Task AddPanel()
+    {
+        _tabs.Add($"new item {_tabs.Count+1}");
+        await InvokeAsync(StateHasChanged);
+    }
+
+    public async Task RemoveLastPanel()
+    {
+        _tabs.RemoveAt(_tabs.Count-1);
+        await InvokeAsync(StateHasChanged);
+    }
+
+}

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -639,6 +639,80 @@ namespace MudBlazor.UnitTests.Components
             }
         }
 
+        [Test]
+        public async Task PanelAdd_ScrollButtonsBecomeVisible()
+        {
+            var observer = new MockResizeObserver
+            {
+                PanelSize = 100.0,
+                PanelTotalSize = 250.0,
+            };
+
+            ctx.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), observer));
+
+            var comp = ctx.RenderComponent<SimplifiedScrollableTabsTest>();
+
+            Console.WriteLine(comp.Markup);
+
+            var buttonContainer = comp.FindAll(".mud-tabs-scroll-button");
+            buttonContainer.Should().HaveCount(0);
+
+            //add the first panel, buttons shouldn't be visible
+            await comp.Instance.AddPanel();
+
+            buttonContainer.Refresh();
+            buttonContainer.Should().HaveCount(0);
+
+            //add second panel, buttons shouldn't be visible
+            await comp.Instance.AddPanel();
+
+            buttonContainer.Refresh();
+            buttonContainer.Should().HaveCount(0);
+
+            //add third panel, buttons should be visible
+            await comp.Instance.AddPanel();
+
+            buttonContainer.Refresh();
+            buttonContainer.Should().HaveCount(2);
+        }
+
+        [Test]
+        public async Task PanelRemove_ScrollButtonsBecomeInvisible()
+        {
+            var observer = new MockResizeObserver
+            {
+                PanelSize = 100.0,
+                PanelTotalSize = 250.0,
+            };
+
+            ctx.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), observer));
+
+            var comp = ctx.RenderComponent<SimplifiedScrollableTabsTest>(p => p.Add(x => x.StartAmount,5));
+
+            Console.WriteLine(comp.Markup);
+
+            var buttonContainer = comp.FindAll(".mud-tabs-scroll-button");
+            buttonContainer.Should().HaveCount(2);
+
+            //remove 5th panel, buttons should be visible
+            await comp.Instance.RemoveLastPanel();
+
+            buttonContainer.Refresh();
+            buttonContainer.Should().HaveCount(2);
+
+            //remove 4th panel, buttons should be visible
+            await comp.Instance.RemoveLastPanel();
+
+            buttonContainer.Refresh();
+            buttonContainer.Should().HaveCount(2);
+
+            //remove 3rd panel, buttons shouldn't be visible
+            await comp.Instance.RemoveLastPanel();
+
+            buttonContainer.Refresh();
+            buttonContainer.Should().HaveCount(0);
+        }
+
         #region Helper
 
         private static double GetSliderValue(IRenderedComponent<ScrollableTabsTest> comp, string attribute = "left")

--- a/src/MudBlazor.UnitTests/Mocks/MockResizeObserver.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockResizeObserver.cs
@@ -59,6 +59,8 @@ namespace MudBlazor.UnitTests.Mocks
 
         public async Task<BoundingClientRect> Observe(ElementReference element) => (await Observe(new[] { element })).FirstOrDefault();
 
+        private Boolean _firstBatchProcessed = false;
+
         public Task<IEnumerable<BoundingClientRect>> Observe(IEnumerable<ElementReference> elements)
         {
             List<BoundingClientRect> result = new List<BoundingClientRect>();
@@ -66,7 +68,7 @@ namespace MudBlazor.UnitTests.Mocks
             {
                 var size = PanelSize;
                 // last element is alaways TabsContentSize
-                if (item.Id == elements.Last().Id && elements.Count() > 1)
+                if (item.Id == elements.Last().Id && _firstBatchProcessed == false)
                 {
                     size = PanelTotalSize;
                 }
@@ -77,6 +79,8 @@ namespace MudBlazor.UnitTests.Mocks
                 }
                 _cachedValues.Add(item, rect);
             }
+
+            _firstBatchProcessed = true;
 
             return Task.FromResult<IEnumerable<BoundingClientRect>>(result);
         }


### PR DESCRIPTION
The test that the scroll buttons are visible or enabled when tabs are added or removed is already part of the test ```Handle_Add``` and  ```Handle_Remove_BeforeSelection``` and ```Handle_Remove_AfterSelection```. However, this test covers the case in a lighter and easier-to-understand way. 

This is proof that the "new" version of the tabs (#1321) solve issue #1389  