### PR TITLE
adding tab activation for disabled tabs

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/ActivateDisabledTabsTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/ActivateDisabledTabsTest.razor
@@ -1,0 +1,134 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudTabs Elevation="1" @ref="_tabElement" PanelClass="test-active-panel" TabPanelClass="test-panel-selector" Position="Position.Top">
+    @for (int i = 0; i < Tabs.Count; i++)
+    {
+        int tempIndex = i;
+
+        <MudTabPanel @key="@Tabs[tempIndex].Name" @ref="Tabs[tempIndex].Panel" Text="@Tabs[tempIndex].Name" ID="@Tabs[tempIndex].Tag" @bind-Disabled="@Tabs[tempIndex].IsDisabled">
+            <MudText>@Tabs[tempIndex].Content</MudText>
+        </MudTabPanel>
+    }
+
+</MudTabs>
+
+@code
+{
+    public class TabBindingHelper
+    {
+        public string Name { get; set; }
+        public bool IsDisabled { get; set; }
+        public DummyPlaceHolder Tag { get; set; }
+        public MudTabPanel Panel { get; set; }
+        public int Index { get; set; }
+        public String Content { get; set; }
+    }
+
+    public class DummyPlaceHolder
+    {
+        public Guid Id { get; set; }
+    }
+
+    [Parameter] public Int32 InitialStartIndex { get; set; } = 0;
+
+    private MudTabs _tabElement;
+
+    public static string __description__ = "activating tabs should work";
+
+    public List<TabBindingHelper> Tabs { get; private set; }
+
+    public ActivateDisabledTabsTest()
+    {
+        Tabs = new();
+        for (int i = 0; i < 5; i++)
+        {
+            Tabs.Add(new TabBindingHelper { Name = (i + 1).ToString(), IsDisabled = true, Tag = new DummyPlaceHolder { Id = Guid.NewGuid() }, Index = i, Content = $"Tab Content {i + 1}" });
+        }
+    }
+
+    public void ActivateAll()
+    {
+        InvokeAsync(() =>
+        {
+            foreach (var item in Tabs)
+            {
+                item.IsDisabled = false;
+            }
+
+            StateHasChanged();
+        });
+    }
+
+    protected override void OnParametersSet()
+    {
+        base.OnParametersSet();
+
+        Tabs[InitialStartIndex].IsDisabled = false;
+    }
+
+    public void EnableTab(int index)
+    {
+        InvokeAsync(() =>
+        {
+            Tabs[index].IsDisabled = false;
+            StateHasChanged();
+        });
+    }
+
+    public void ActivateTab(int index, bool ignoreState)
+    {
+        InvokeAsync(() =>
+        {
+            _tabElement.ActivatePanel(index, ignoreState);
+        });
+    }
+
+    public void ActivateTab(int index)
+    {
+        InvokeAsync(() =>
+        {
+            _tabElement.ActivatePanel(index);
+        });
+    }
+
+    public void DisableTab(int index)
+    {
+        InvokeAsync(() =>
+        {
+            Tabs[index].IsDisabled = true;
+            StateHasChanged();
+        });
+    }
+
+    public void ActivateTab(MudTabPanel panel, bool ignoreState)
+    {
+        InvokeAsync(() =>
+        {
+            _tabElement.ActivatePanel(panel, ignoreState);
+        });
+    }
+
+    public void ActivateTab(MudTabPanel panel)
+    {
+        InvokeAsync(() =>
+        {
+            _tabElement.ActivatePanel(panel);
+        });
+    }
+
+    public void ActivateTab(DummyPlaceHolder id, bool ignoreState)
+    {
+        InvokeAsync(() =>
+        {
+            _tabElement.ActivatePanel(id, ignoreState);
+        });
+    }
+
+    public void ActivateTab(DummyPlaceHolder id)
+    {
+        InvokeAsync(() =>
+        {
+            _tabElement.ActivatePanel(id);
+        });
+    }
+}

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -268,27 +268,27 @@ namespace MudBlazor
             StateHasChanged();
         }
 
-        public void ActivatePanel(MudTabPanel panel)
+        public void ActivatePanel(MudTabPanel panel, bool ignoreDisabledState = false)
         {
-            ActivatePanel(panel, null, _showScrollButtons);
+            ActivatePanel(panel, null, ignoreDisabledState);
         }
 
-        public void ActivatePanel(int index)
+        public void ActivatePanel(int index, bool ignoreDisabledState = false)
         {
             var panel = _panels[index];
-            ActivatePanel(panel, null, _showScrollButtons);
+            ActivatePanel(panel, null, ignoreDisabledState);
         }
 
-        public void ActivatePanel(object id)
+        public void ActivatePanel(object id, bool ignoreDisabledState = false)
         {
             var panel = _panels.Where((p) => p.ID == id).FirstOrDefault();
             if (panel != null)
-                ActivatePanel(panel, null, _showScrollButtons);
+                ActivatePanel(panel, null, ignoreDisabledState);
         }
 
-        private void ActivatePanel(MudTabPanel panel, MouseEventArgs ev, bool scrollToActivePanel)
+        private void ActivatePanel(MudTabPanel panel, MouseEventArgs ev, bool ignoreDisabledState = false)
         {
-            if (!panel.Disabled)
+            if (!panel.Disabled || ignoreDisabledState)
             {
                 ActivePanelIndex = _panels.IndexOf(panel);
 


### PR DESCRIPTION
Based on the discussion in #1429, I've changed the signature of the existing method**s**, to select a tab, to enable the developer to active a disabled tab.

**Before:** 

```C#
 public void ActivatePanel(int index)
```

**Now:**

```C#
 public void ActivatePanel(int index, bool ignoreDisabledState = false)
```

There is **no breaking change** because the new parameter is initialized with a default value, which doesn't change the existing behavior. 

The "main activation" method is changed just a bit 

```C#
if (!panel.Disabled || ignoreDisabledState)
{
....
}
```

Besides, there are two new unit tests around the activation of tabs. 

