### PR TITLE
Later added chips should be initially selected if they are default

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/ChipSet/ChipSetLateDefaultTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/ChipSet/ChipSetLateDefaultTest.razor
@@ -1,0 +1,19 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudChipSet @bind-SelectedChips="SelectedChipArray" MultiSelection="true" Filter="true">
+    @if (_extraItem)
+    {
+        <MudChip Text="Extra Chip" Default="true"></MudChip>
+
+    }
+    <MudChip Text="Primary" Default="true"></MudChip>
+</MudChipSet>
+Add chips <MudIconButton Icon="@Icons.Material.Filled.Add" OnClick="Enable">Enable</MudIconButton>
+
+
+@code
+{ 
+    bool _extraItem = false;
+    public void Enable() => _extraItem = !_extraItem;
+    MudChip[] SelectedChipArray;
+}

--- a/src/MudBlazor.UnitTests/Components/ChipSetTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ChipSetTests.cs
@@ -179,6 +179,25 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("p")[0].TrimmedText().Should().Be("Corn flakes, Salad");
             string.Join(", ", chipset.Instance.SelectedChips.Select(x => x.Text).OrderBy(x => x)).Should().Be("Corn flakes, Salad");
         }
+
+
+        [Test]
+        public async Task ChipSet_MultiSelection_LateDefaultChipsShouldBeInitiallySelected()
+        {
+            var comp = ctx.RenderComponent<ChipSetLateDefaultTest>();
+            // print the generated html
+            Console.WriteLine(comp.Markup);
+            // check that only one item is present
+            var chipset = comp.FindComponent<MudChipSet>();
+            comp.FindAll("div.mud-chip").Count.Should().Be(1);
+            chipset.Instance.SelectedChips.Length.Should().Be(1);
+            string.Join(", ", chipset.Instance.SelectedChips.Select(x => x.Text).OrderBy(x => x)).Should().Be("Primary");
+            // select extra item
+            comp.FindAll("button")[0].Click();
+            // check that extra item is selected
+            comp.FindAll("div.mud-chip").Count.Should().Be(2);
+            string.Join(", ", chipset.Instance.SelectedChips.Select(x => x.Text).OrderBy(x => x)).Should().Be("Extra Chip, Primary");
+        }
     }
 
 }

--- a/src/MudBlazor/Components/Chip/MudChip.razor.cs
+++ b/src/MudBlazor/Components/Chip/MudChip.razor.cs
@@ -145,6 +145,11 @@ namespace MudBlazor
         }
 
         /// <summary>
+        /// If false, this chip has not been seen before
+        /// </summary>
+        public bool DefaultProcessed { get; set; }
+
+        /// <summary>
         /// Set by MudChipSet
         /// </summary>
         public bool IsSelected

--- a/src/MudBlazor/Components/ChipSet/MudChipSet.razor.cs
+++ b/src/MudBlazor/Components/ChipSet/MudChipSet.razor.cs
@@ -129,14 +129,29 @@ namespace MudBlazor
         [Parameter]
         public EventCallback<MudChip> OnClose { get; set; }
 
-        internal void Add(MudChip chip)
+        internal async Task Add(MudChip chip)
         {
             _chips.Add(chip);
+            await CheckDefault(chip);
         }
 
         internal void Remove(MudChip chip)
         {
             _chips.Remove(chip);
+        }
+
+
+        private async Task CheckDefault(MudChip chip)
+        {
+            if (MultiSelection)
+            {
+                if (chip.DefaultProcessed)
+                    return;
+                chip.IsSelected = chip.Default;
+                chip.DefaultProcessed = true;
+                if (chip.IsSelected)
+                    await NotifySelection();
+            }
         }
 
         private HashSet<MudChip> _chips = new HashSet<MudChip>();
@@ -183,28 +198,18 @@ namespace MudBlazor
 
         private async Task SelectDefaultChips()
         {
-            var anySelected = false;
-            if (MultiSelection)
+            if (!MultiSelection)
             {
-                foreach (var chip in _chips)
-                {
-                    if (!chip.Default)
-                        continue;
-                    chip.IsSelected = chip.Default;
-                    anySelected = true;
-                }
-            }
-            else
-            {
+                var anySelected = false;
                 var defaultChip = _chips.LastOrDefault(chip => chip.Default);
                 if (defaultChip != null)
                 {
                     defaultChip.IsSelected = true;
                     anySelected = true;
                 }
+                if (anySelected)
+                    await NotifySelection();
             }
-            if (anySelected)
-                await NotifySelection();
         }
     }
 }


### PR DESCRIPTION
A fix for issue #1369 with a simple addition of a per-chip "seen" property. Leaves the existing single selection operation as it was.