### PR TITLE
MudTablePager: Disable back/forward buttons on first/last page

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using AngleSharp.Dom;
 using Bunit;
 using FluentAssertions;
 using MudBlazor.UnitTests.TestComponents;
@@ -121,23 +122,43 @@ namespace MudBlazor.UnitTests.Components
             // after initial load
             comp.FindAll("tr.mud-table-row").Count.Should().Be(10);
             comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 59");
+            comp.FindAll("button")[0].IsDisabled().Should().Be(true);
+            comp.FindAll("button")[1].IsDisabled().Should().Be(true);
+            comp.FindAll("button")[2].IsDisabled().Should().Be(false);
+            comp.FindAll("button")[3].IsDisabled().Should().Be(false);
             var pagingButtons = comp.FindAll("button");
             // click next page
             pagingButtons[2].Click();
             comp.FindAll("tr.mud-table-row").Count.Should().Be(10);
             comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("11-20 of 59");
+            comp.FindAll("button")[0].IsDisabled().Should().Be(false);
+            comp.FindAll("button")[1].IsDisabled().Should().Be(false);
+            comp.FindAll("button")[2].IsDisabled().Should().Be(false);
+            comp.FindAll("button")[3].IsDisabled().Should().Be(false);
             // last page
             pagingButtons[3].Click();
             comp.FindAll("tr.mud-table-row").Count.Should().Be(9);
             comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("51-59 of 59");
+            comp.FindAll("button")[0].IsDisabled().Should().Be(false);
+            comp.FindAll("button")[1].IsDisabled().Should().Be(false);
+            comp.FindAll("button")[2].IsDisabled().Should().Be(true);
+            comp.FindAll("button")[3].IsDisabled().Should().Be(true);
             // previous page
             pagingButtons[1].Click();
             comp.FindAll("tr.mud-table-row").Count.Should().Be(10);
             comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("41-50 of 59");
+            comp.FindAll("button")[0].IsDisabled().Should().Be(false);
+            comp.FindAll("button")[1].IsDisabled().Should().Be(false);
+            comp.FindAll("button")[2].IsDisabled().Should().Be(false);
+            comp.FindAll("button")[3].IsDisabled().Should().Be(false);
             // first page
             pagingButtons[0].Click();
             comp.FindAll("tr.mud-table-row").Count.Should().Be(10);
             comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 59");
+            comp.FindAll("button")[0].IsDisabled().Should().Be(true);
+            comp.FindAll("button")[1].IsDisabled().Should().Be(true);
+            comp.FindAll("button")[2].IsDisabled().Should().Be(false);
+            comp.FindAll("button")[3].IsDisabled().Should().Be(false);
         }
 
         /// <summary>
@@ -152,23 +173,43 @@ namespace MudBlazor.UnitTests.Components
             // after initial load
             comp.FindAll("tr.mud-table-row").Count.Should().Be(10);
             comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 59");
+            comp.FindAll("button")[2].IsDisabled().Should().Be(true);
+            comp.FindAll("button")[3].IsDisabled().Should().Be(true);
+            comp.FindAll("button")[0].IsDisabled().Should().Be(false);
+            comp.FindAll("button")[1].IsDisabled().Should().Be(false);
             var pagingButtons = comp.FindAll("button");
             // click next page
             pagingButtons[1].Click();
             comp.FindAll("tr.mud-table-row").Count.Should().Be(10);
             comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("11-20 of 59");
+            comp.FindAll("button")[2].IsDisabled().Should().Be(false);
+            comp.FindAll("button")[3].IsDisabled().Should().Be(false);
+            comp.FindAll("button")[0].IsDisabled().Should().Be(false);
+            comp.FindAll("button")[1].IsDisabled().Should().Be(false);
             // last page
             pagingButtons[0].Click();
             comp.FindAll("tr.mud-table-row").Count.Should().Be(9);
             comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("51-59 of 59");
+            comp.FindAll("button")[2].IsDisabled().Should().Be(false);
+            comp.FindAll("button")[3].IsDisabled().Should().Be(false);
+            comp.FindAll("button")[0].IsDisabled().Should().Be(true);
+            comp.FindAll("button")[1].IsDisabled().Should().Be(true);
             // previous page
             pagingButtons[2].Click();
             comp.FindAll("tr.mud-table-row").Count.Should().Be(10);
             comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("41-50 of 59");
+            comp.FindAll("button")[2].IsDisabled().Should().Be(false);
+            comp.FindAll("button")[3].IsDisabled().Should().Be(false);
+            comp.FindAll("button")[0].IsDisabled().Should().Be(false);
+            comp.FindAll("button")[1].IsDisabled().Should().Be(false);
             // first page
             pagingButtons[3].Click();
             comp.FindAll("tr.mud-table-row").Count.Should().Be(10);
             comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 59");
+            comp.FindAll("button")[2].IsDisabled().Should().Be(true);
+            comp.FindAll("button")[3].IsDisabled().Should().Be(true);
+            comp.FindAll("button")[0].IsDisabled().Should().Be(false);
+            comp.FindAll("button")[1].IsDisabled().Should().Be(false);
         }
 
 
@@ -189,16 +230,28 @@ namespace MudBlazor.UnitTests.Components
             pager.Value.Should().Be("20");
             comp.FindAll("tr.mud-table-row").Count.Should().Be(20);
             comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-20 of 59");
+            comp.FindAll("button")[0].IsDisabled().Should().Be(true);
+            comp.FindAll("button")[1].IsDisabled().Should().Be(true);
+            comp.FindAll("button")[2].IsDisabled().Should().Be(false);
+            comp.FindAll("button")[3].IsDisabled().Should().Be(false);
             // change page size
             await table.InvokeAsync(() => table.Instance.SetRowsPerPage(60));
             pager.Value.Should().Be("60");
             comp.FindAll("tr.mud-table-row").Count.Should().Be(59);
             comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-59 of 59");
+            comp.FindAll("button")[0].IsDisabled().Should().Be(true);
+            comp.FindAll("button")[1].IsDisabled().Should().Be(true);
+            comp.FindAll("button")[2].IsDisabled().Should().Be(true);
+            comp.FindAll("button")[3].IsDisabled().Should().Be(true);
             // change page size
             await table.InvokeAsync(() => table.Instance.SetRowsPerPage(10));
             pager.Value.Should().Be("10");
             comp.FindAll("tr.mud-table-row").Count.Should().Be(10);
             comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 59");
+            comp.FindAll("button")[0].IsDisabled().Should().Be(true);
+            comp.FindAll("button")[1].IsDisabled().Should().Be(true);
+            comp.FindAll("button")[2].IsDisabled().Should().Be(false);
+            comp.FindAll("button")[3].IsDisabled().Should().Be(false);
         }
 
         /// <summary>
@@ -219,16 +272,28 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("td")[1].TextContent.Trim().Should().Be("2");
             comp.FindAll("td")[2].TextContent.Trim().Should().Be("3");
             comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 99");
+            comp.FindAll("button")[0].IsDisabled().Should().Be(true);
+            comp.FindAll("button")[1].IsDisabled().Should().Be(true);
+            comp.FindAll("button")[2].IsDisabled().Should().Be(false);
+            comp.FindAll("button")[3].IsDisabled().Should().Be(false);
             // last page
             comp.FindAll("div.mud-table-pagination-actions button")[3].Click(); // last >
             comp.FindAll("td")[0].TextContent.Trim().Should().Be("28");
             comp.FindAll("td")[1].TextContent.Trim().Should().Be("29");
             comp.FindAll("td")[2].TextContent.Trim().Should().Be("30");
             comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("91-99 of 99");
+            comp.FindAll("button")[0].IsDisabled().Should().Be(false);
+            comp.FindAll("button")[1].IsDisabled().Should().Be(false);
+            comp.FindAll("button")[2].IsDisabled().Should().Be(true);
+            comp.FindAll("button")[3].IsDisabled().Should().Be(true);
             // change page size
             await table.InvokeAsync(() => table.Instance.SetRowsPerPage(100));
             pager.Value.Should().Be("100");
             comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-99 of 99");
+            comp.FindAll("button")[0].IsDisabled().Should().Be(true);
+            comp.FindAll("button")[1].IsDisabled().Should().Be(true);
+            comp.FindAll("button")[2].IsDisabled().Should().Be(true);
+            comp.FindAll("button")[3].IsDisabled().Should().Be(true);
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/Table/MudTablePager.razor
+++ b/src/MudBlazor/Components/Table/MudTablePager.razor
@@ -21,17 +21,17 @@
     <div class="mud-table-pagination-actions">
         @if (RightToLeft)
         {
-            <MudIconButton Icon="@Icons.Material.Filled.LastPage" @onclick="@(() => Table.NavigateTo(Page.Last))" />
-            <MudIconButton Icon="@Icons.Material.Filled.NavigateNext" @onclick="@(() => Table.NavigateTo(Page.Next))" />
-            <MudIconButton Icon="@Icons.Material.Filled.NavigateBefore" @onclick="@(() => Table.NavigateTo(Page.Previous))" />
-            <MudIconButton Icon="@Icons.Material.Filled.FirstPage" @onclick="@(() => Table.NavigateTo(Page.First))" />
+            <MudIconButton Icon="@Icons.Material.Filled.LastPage" Disabled="@ForwardButtonsDisabled" @onclick="@(() => Table.NavigateTo(Page.Last))" />
+            <MudIconButton Icon="@Icons.Material.Filled.NavigateNext" Disabled="@ForwardButtonsDisabled" @onclick="@(() => Table.NavigateTo(Page.Next))" />
+            <MudIconButton Icon="@Icons.Material.Filled.NavigateBefore" Disabled="@BackButtonsDisabled" @onclick="@(() => Table.NavigateTo(Page.Previous))" />
+            <MudIconButton Icon="@Icons.Material.Filled.FirstPage" Disabled="@BackButtonsDisabled" @onclick="@(() => Table.NavigateTo(Page.First))" />
         }
         else
         {
-            <MudIconButton Icon="@Icons.Material.Filled.FirstPage" @onclick="@(() => Table.NavigateTo(Page.First))" />
-            <MudIconButton Icon="@Icons.Material.Filled.NavigateBefore" @onclick="@(() => Table.NavigateTo(Page.Previous))" />
-            <MudIconButton Icon="@Icons.Material.Filled.NavigateNext" @onclick="@(() => Table.NavigateTo(Page.Next))" />
-            <MudIconButton Icon="@Icons.Material.Filled.LastPage" @onclick="@(() => Table.NavigateTo(Page.Last))" />
+            <MudIconButton Icon="@Icons.Material.Filled.FirstPage" Disabled="@BackButtonsDisabled" @onclick="@(() => Table.NavigateTo(Page.First))" />
+            <MudIconButton Icon="@Icons.Material.Filled.NavigateBefore" Disabled="@BackButtonsDisabled" @onclick="@(() => Table.NavigateTo(Page.Previous))" />
+            <MudIconButton Icon="@Icons.Material.Filled.NavigateNext" Disabled="@ForwardButtonsDisabled" @onclick="@(() => Table.NavigateTo(Page.Next))" />
+            <MudIconButton Icon="@Icons.Material.Filled.LastPage" Disabled="@ForwardButtonsDisabled" @onclick="@(() => Table.NavigateTo(Page.Last))" />
         }
     </div>
 </MudToolBar>

--- a/src/MudBlazor/Components/Table/MudTablePager.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTablePager.razor.cs
@@ -47,6 +47,10 @@ namespace MudBlazor
             Table?.SetRowsPerPage(int.Parse(size));
         }
 
+        private bool BackButtonsDisabled => Table == null ? false : Table.CurrentPage == 0;
+
+        private bool ForwardButtonsDisabled => Table == null ? false : (Table.CurrentPage + 1) * Table.RowsPerPage >= Table.GetFilteredItemsCount();
+
         public MudTableBase Table => Context?.Table;
 
         protected override void OnInitialized()


### PR DESCRIPTION
Back/forward navigation buttons in MudTablePager should be disabled on first/last table page