### PR TITLE
a fix? for #1455

### DIFF
--- a/src/MudBlazor.UnitTests/Mocks/MockResizeObserver.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockResizeObserver.cs
@@ -10,7 +10,7 @@ using MudBlazor.Services;
 
 namespace MudBlazor.UnitTests.Mocks
 {
-    public class MockResizeObserver : IResizeObserver
+    public class MockResizeObserver : IResizeObserver, IDisposable
     {
         private Dictionary<ElementReference, BoundingClientRect> _cachedValues = new();
 
@@ -108,5 +108,10 @@ namespace MudBlazor.UnitTests.Mocks
         public double GetHeight(ElementReference reference) => GetSizeInfo(reference)?.Height ?? 0.0;
         public double GetWidth(ElementReference reference) => GetSizeInfo(reference)?.Width ?? 0.0;
         public bool IsElementObserved(ElementReference reference) => _cachedValues.ContainsKey(reference);
+
+        public void Dispose()
+        {
+           
+        }
     }
 }

--- a/src/MudBlazor/Components/Tabs/MudTabPanel.razor
+++ b/src/MudBlazor/Components/Tabs/MudTabPanel.razor
@@ -1,8 +1,6 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
 @implements IAsyncDisposable
-@implements IDisposable
-
 
 @if (Parent?.KeepPanelsAlive == true)
 {
@@ -19,6 +17,8 @@ else
 }
 
 @code {
+
+    private Boolean _disposed;
 
     [CascadingParameter] private MudTabs Parent { get; set; }
 
@@ -92,26 +92,12 @@ else
         }
     }
 
-    protected virtual void Dispose(bool disposing)
-    {
-    }
-
-    public void Dispose()
-    {
-        Dispose(true);
-        GC.SuppressFinalize(this);
-    }
-
-    protected virtual async ValueTask DisposeAsyncCore()
-    {
-        await Parent?.RemovePanel(this);
-    }
-
     public async ValueTask DisposeAsync()
     {
-        await DisposeAsyncCore();
+        if(_disposed == true) { return;  }
 
-        Dispose(false);
-        GC.SuppressFinalize(this);
+        _disposed = true;
+        await Parent?.RemovePanel(this);
+
     }
 }

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -12,7 +12,7 @@ using MudBlazor.Utilities;
 
 namespace MudBlazor
 {
-    public partial class MudTabs : MudComponentBase, IDisposable, IAsyncDisposable
+    public partial class MudTabs : MudComponentBase, IAsyncDisposable
     {
         private bool _isDisposed;
         private int _activePanelIndex = 0;
@@ -187,30 +187,14 @@ namespace MudBlazor
             }
         }
 
-        protected virtual void Dispose(bool disposing)
-        {
-            _isDisposed = true;
-            _resizeObserver.OnResized -= OnResized;
-        }
-
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        protected virtual async ValueTask DisposeAsyncCore()
-        {
-            _isDisposed = true;
-            await _resizeObserver.DisposeAsync();
-        }
 
         public async ValueTask DisposeAsync()
         {
-            await DisposeAsyncCore();
+            if (_isDisposed == true) { return; }
 
-            Dispose(false);
-            GC.SuppressFinalize(this);
+            _isDisposed = true;
+            await _resizeObserver.DisposeAsync();
+            _resizeObserver.OnResized -= OnResized;
         }
 
         #endregion

--- a/src/MudBlazor/Services/ReseizeObserver/IResizeObserver.cs
+++ b/src/MudBlazor/Services/ReseizeObserver/IResizeObserver.cs
@@ -9,7 +9,7 @@ namespace MudBlazor.Services
 
     public delegate void SizeChanged(IDictionary<ElementReference, BoundingClientRect> changes);
 
-    public interface IResizeObserver : IAsyncDisposable
+    public interface IResizeObserver : IAsyncDisposable, IDisposable
     {
         Task<BoundingClientRect> Observe(ElementReference element);
         Task<IEnumerable<BoundingClientRect>> Observe(IEnumerable<ElementReference> elements);

--- a/src/MudBlazor/TScripts/mudResizeObserver.js
+++ b/src/MudBlazor/TScripts/mudResizeObserver.js
@@ -15,12 +15,23 @@
     }
 
     disconnect(id, element) {
-        this._maps[id].disconnect(element);
+        //I can't think about a case, where this can be called, without observe has been called before
+        //however, a check is not harmful either		
+        var existingEntry = this._maps[id];
+        if (existingEntry != null) {
+            this._maps[id].disconnect(element);
+        }
     }
 
     cancelListener(id) {
-        this._maps[id].cancelListener();
-        delete this._maps[id];
+        //cancelListener is called during dispose of .net instance
+        //in rare cases it could be possible, that no object has been connect so far
+        //and no entry exists. Therefore, a little check to prevent an error in this case		
+        var existingEntry = this._maps[id];
+        if (existingEntry != null) {
+            this._maps[id].cancelListener();
+            delete this._maps[id];
+        }
     }
 }
 

--- a/src/MudBlazor/TScripts/mudResizeObserver.js
+++ b/src/MudBlazor/TScripts/mudResizeObserver.js
@@ -18,7 +18,7 @@
         //I can't think about a case, where this can be called, without observe has been called before
         //however, a check is not harmful either		
         var existingEntry = this._maps[id];
-        if (existingEntry != null) {
+        if (existingEntry) {
             existingEntry.disconnect(element);
         }
     }
@@ -28,7 +28,7 @@
         //in rare cases it could be possible, that no object has been connect so far
         //and no entry exists. Therefore, a little check to prevent an error in this case		
         var existingEntry = this._maps[id];
-        if (existingEntry != null) {
+        if (existingEntry) {
             existingEntry.cancelListener();
             delete this._maps[id];
         }

--- a/src/MudBlazor/TScripts/mudResizeObserver.js
+++ b/src/MudBlazor/TScripts/mudResizeObserver.js
@@ -19,7 +19,7 @@
         //however, a check is not harmful either		
         var existingEntry = this._maps[id];
         if (existingEntry != null) {
-            this._maps[id].disconnect(element);
+            existingEntry.disconnect(element);
         }
     }
 
@@ -29,7 +29,7 @@
         //and no entry exists. Therefore, a little check to prevent an error in this case		
         var existingEntry = this._maps[id];
         if (existingEntry != null) {
-            this._maps[id].cancelListener();
+            existingEntry.cancelListener();
             delete this._maps[id];
         }
     }


### PR DESCRIPTION
Based on discussion #1455, I tried to reproduce the error but couldn't do so. 

Instead, I clarified a bit about the disposal methods. In addition, the javascript calls for canceling a subscription, and the unobserving of an element is now surrounding by a try-catch-block.

```C#
try { await _jsRuntime.InvokeVoidAsync($"mudResizeObserver.disconnect", _id, elementId); } catch (Exception) { }

and

try { _ = _jsRuntime.InvokeVoidAsync($"mudResizeObserver.cancelListener", _id); } catch (Exception) { }
``` 

I'm not satisfied with this solution. It'd be great to get to the gist of the matter, understanding the root cause. However, as the error likely didn't cause any harm for users, this solution seems like an appropriate balance between time invested and relevance.  