### PR TITLE
#1469 Fix for MudTable MultiSelection check-all bug

### DIFF
--- a/src/MudBlazor/Styles/components/_table.scss
+++ b/src/MudBlazor/Styles/components/_table.scss
@@ -170,7 +170,7 @@
             & * .mud-table-cell {
                 background-color: var(--mud-palette-surface);
                 position: sticky;
-                z-index: 1;
+                z-index: 2;
                 top: 0;
             }
         }


### PR DESCRIPTION
Applied z-index:2 to _table.scss as suggested by porkopek.