### PR TITLE
fix(autocomplete): call the `OnBlur` method when input blurred

### DIFF
--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -259,6 +259,25 @@ namespace MudBlazor.UnitTests.Components
 
         }
 
+        /// <summary>
+        /// Test for <seealso cref="https://github.com/Garderoben/MudBlazor/issues/1415"/>
+        /// </summary>
+        [Test]
+        public async Task Autocomplete_OnBlurShouldBeCalled()
+        {
+            var calls = 0;
+            Action<FocusEventArgs> fn = (args) => calls++;
+            var comp = ctx.RenderComponent<MudAutocomplete<string>>((a) =>
+            {
+                a.Add(x => x.OnBlur, fn);
+            });
+            var input = comp.Find("input");
+
+            calls.Should().Be(0);
+            input.Blur();
+            calls.Should().Be(1);
+        }
+
 
         #region DataAttribute validation
         [Test]

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -320,7 +320,7 @@ namespace MudBlazor
         private Task OnInputBlurred(FocusEventArgs args)
         {
             //return !IsOpen ? CoerceTextToValue() : Task.CompletedTask;
-            OnBlur.InvokeAsync(args); //  <== This is the missing line
+            OnBlur.InvokeAsync(args);
             return Task.CompletedTask;
             // we should not validate on blur in autocomplete, because the user needs to click out of the input to select a value, 
             // resulting in a premature validation. thus, don't call base

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -320,6 +320,7 @@ namespace MudBlazor
         private Task OnInputBlurred(FocusEventArgs args)
         {
             //return !IsOpen ? CoerceTextToValue() : Task.CompletedTask;
+            OnBlur.InvokeAsync(args); //  <== This is the missing line
             return Task.CompletedTask;
             // we should not validate on blur in autocomplete, because the user needs to click out of the input to select a value, 
             // resulting in a premature validation. thus, don't call base


### PR DESCRIPTION
Rather self explanatory.

Solution was given in https://github.com/Garderoben/MudBlazor/issues/1415#issuecomment-824960469

Tests included.

Fixes #1415