### PR TITLE
New button group component added

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/ButtonGroup/ButtonGroupPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ButtonGroup/ButtonGroupPage.razor
@@ -1,0 +1,83 @@
+﻿@page "/components/buttongroup"
+
+<DocsPage>
+    <DocsPageHeader Title="Button Group">
+        <Description>The <CodeInline>MudButtonGroup</CodeInline> component can be used to group related <CodeInline>MudButtons</CodeInline>.</Description>
+    </DocsPageHeader>
+    <DocsPageContent>
+        <DocsPageSection>
+            <SectionHeader>
+                <Title>Basic button group</Title>
+            </SectionHeader>
+            <SectionContent Outlined="true" DisplayFlex="true">
+                <ButtonGroupBasicExample />
+            </SectionContent>
+            <SectionSource Code="ButtonGroupBasicExample" GitHubFolderName="ButtonGroup" />
+        </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader>
+                <Title>Sizes and colors</Title>
+            </SectionHeader>
+            <SectionContent Outlined="true">
+                <ButtonGroupSizesColorsExample />
+            </SectionContent>
+            <SectionSource Code="ButtonGroupSizesColorsExample" GitHubFolderName="ButtonGroup" />
+        </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader>
+                <Title>Vertical button group</Title>
+                <Description>With <CodeInline>VerticalAlign="true"</CodeInline> the buttons are displayed vertically.</Description>
+            </SectionHeader>
+            <SectionContent Outlined="true">
+                <ButtonGroupVerticalExample />
+            </SectionContent>
+            <SectionSource Code="ButtonGroupVerticalExample" GitHubFolderName="ButtonGroup" />
+        </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader>
+                <Title>Icon buttons</Title>
+                <Description><CodeInline>MudButtonGroup</CodeInline> can also make use of <CodeInline>MudIconButton</CodeInline> and <CodeInline>MudToggleIconButton</CodeInline>.</Description>
+            </SectionHeader>
+            <SectionContent Outlined="true">
+                <ButtonGroupIconButtonExample />
+            </SectionContent>
+            <SectionSource Code="ButtonGroupIconButtonExample" GitHubFolderName="ButtonGroup" />
+        </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader>
+                <Title>Split button</Title>
+                <Description>A <CodeInline>MudMenu</CodeInline> can be used to create a split button.</Description>
+            </SectionHeader>
+            <SectionContent Outlined="true">
+                <ButtonGroupSplitButtonExample />
+            </SectionContent>
+            <SectionSource ShowCode="false" Code="ButtonGroupSplitButtonExample" GitHubFolderName="ButtonGroup" />
+        </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader>
+                <Title>Disable elevation</Title>
+                <Description>With <CodeInline>DisableElevation="false"</CodeInline> the dropshadow of button groups with <CodeInline>Variant="Variant.Filled"</CodeInline> is removed.</Description>
+            </SectionHeader>
+            <SectionContent Outlined="true" DisplayFlex="true">
+                <ButtonGroupDisableElevationExample />
+            </SectionContent>
+            <SectionSource Code="ButtonGroupDisableElevationExample" GitHubFolderName="ButtonGroup" />
+        </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader>
+                <Title>Custom styles</Title>
+                <Description>With <CodeInline>OverrideStyles="false"</CodeInline> the <CodeInline>MudButtonGroup</CodeInline> no longer overrides the styles of the individual buttons.</Description>
+            </SectionHeader>
+            <SectionContent Outlined="true" DisplayFlex="true">
+                <ButtonGroupCustomStylesExample />
+            </SectionContent>
+            <SectionSource Code="ButtonGroupCustomStylesExample" GitHubFolderName="ButtonGroup" />
+        </DocsPageSection>
+    </DocsPageContent>
+</DocsPage>

--- a/src/MudBlazor.Docs/Pages/Components/ButtonGroup/Examples/ButtonGroupBasicExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ButtonGroup/Examples/ButtonGroupBasicExample.razor
@@ -1,0 +1,19 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudButtonGroup Color="Color.Primary" Variant="Variant.Outlined">
+    <MudButton>One</MudButton>
+    <MudButton>Two</MudButton>
+    <MudButton>Three</MudButton>
+</MudButtonGroup>
+
+<MudButtonGroup Color="Color.Primary" Variant="Variant.Filled">
+    <MudButton>One</MudButton>
+    <MudButton>Two</MudButton>
+    <MudButton>Three</MudButton>
+</MudButtonGroup>
+
+<MudButtonGroup Color="Color.Primary" Variant="Variant.Text">
+    <MudButton>One</MudButton>
+    <MudButton>Two</MudButton>
+    <MudButton>Three</MudButton>
+</MudButtonGroup>

--- a/src/MudBlazor.Docs/Pages/Components/ButtonGroup/Examples/ButtonGroupCustomStylesExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ButtonGroup/Examples/ButtonGroupCustomStylesExample.razor
@@ -1,0 +1,13 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudButtonGroup Color="Color.Primary" Variant="Variant.Outlined" OverrideStyles="_overrideStyles">
+    <MudButton Color="Color.Primary" Variant="Variant.Outlined">One</MudButton>
+    <MudButton Color="Color.Warning" Variant="Variant.Outlined">Two</MudButton>
+    <MudButton Color="Color.Secondary" Variant="Variant.Outlined">Three</MudButton>
+</MudButtonGroup>
+
+<MudSwitch @bind-Checked="@_overrideStyles" Label="Override styles" Color="Color.Primary" />
+
+@code {
+    private bool _overrideStyles;
+}

--- a/src/MudBlazor.Docs/Pages/Components/ButtonGroup/Examples/ButtonGroupDisableElevationExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ButtonGroup/Examples/ButtonGroupDisableElevationExample.razor
@@ -1,0 +1,13 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudButtonGroup Color="Color.Primary" Variant="Variant.Filled" DisableElevation="@_disableElevation">
+    <MudButton>One</MudButton>
+    <MudButton>Two</MudButton>
+    <MudButton>Three</MudButton>
+</MudButtonGroup>
+
+<MudSwitch @bind-Checked="@_disableElevation" Label="Disable elevation" Color="Color.Primary" />
+
+@code {
+    private bool _disableElevation = true;
+}

--- a/src/MudBlazor.Docs/Pages/Components/ButtonGroup/Examples/ButtonGroupIconButtonExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ButtonGroup/Examples/ButtonGroupIconButtonExample.razor
@@ -1,0 +1,9 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+
+<MudButtonGroup Color="Color.Primary" Variant="Variant.Outlined">
+    <MudIconButton Icon="@Icons.Material.Filled.AccessAlarm"></MudIconButton>
+    <MudToggleIconButton Icon="@Icons.Material.Filled.AlarmOff" Color="@Color.Error"
+                         ToggledIcon="@Icons.Material.Filled.AlarmOn" ToggledColor="@Color.Success" />
+    <MudButton StartIcon="@Icons.Material.Filled.AlarmAdd" IconColor="Color.Warning">Add alarm</MudButton>
+</MudButtonGroup>

--- a/src/MudBlazor.Docs/Pages/Components/ButtonGroup/Examples/ButtonGroupSizesColorsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ButtonGroup/Examples/ButtonGroupSizesColorsExample.razor
@@ -1,0 +1,19 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudButtonGroup Color="Color.Default" Size="Size.Small" Variant="Variant.Outlined">
+    <MudButton>One</MudButton>
+    <MudButton>Two</MudButton>
+    <MudButton>Three</MudButton>
+</MudButtonGroup>
+
+<MudButtonGroup Color="Color.Secondary" Size="Size.Medium" Variant="Variant.Outlined">
+    <MudButton>One</MudButton>
+    <MudButton>Two</MudButton>
+    <MudButton>Three</MudButton>
+</MudButtonGroup>
+
+<MudButtonGroup Color="Color.Primary" Size="Size.Large" Variant="Variant.Outlined">
+    <MudButton>One</MudButton>
+    <MudButton>Two</MudButton>
+    <MudButton>Three</MudButton>
+</MudButtonGroup>

--- a/src/MudBlazor.Docs/Pages/Components/ButtonGroup/Examples/ButtonGroupSplitButtonExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ButtonGroup/Examples/ButtonGroupSplitButtonExample.razor
@@ -1,0 +1,32 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudButtonGroup Color="Color.Primary" Variant="Variant.Outlined">
+    <MudButton>@_buttonText</MudButton>
+    <MudMenu Icon="@Icons.Material.Filled.ArrowDropDown" Direction="Direction.Bottom" OffsetY="true">
+        <MudMenuItem OnClick="() => SetButtonText(0)">Reply</MudMenuItem>
+        <MudMenuItem OnClick="() => SetButtonText(1)">Reply All</MudMenuItem>
+        <MudMenuItem OnClick="() => SetButtonText(2)">Forward</MudMenuItem>
+        <MudMenuItem OnClick="() => SetButtonText(3)">Reply & Delete</MudMenuItem>
+    </MudMenu>
+</MudButtonGroup>
+@code {
+    private string _buttonText = "Reply";
+
+    private void SetButtonText(int id)
+    {
+        switch (id)
+        {
+            case 0: _buttonText = "Reply";
+                break;
+            case 1:
+                _buttonText = "Reply All";
+                break;
+            case 2:
+                _buttonText = "Forward";
+                break;
+            case 3:
+                _buttonText = "Reply & Delete";
+                break;
+        }
+    }
+}

--- a/src/MudBlazor.Docs/Pages/Components/ButtonGroup/Examples/ButtonGroupVerticalExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ButtonGroup/Examples/ButtonGroupVerticalExample.razor
@@ -1,0 +1,19 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudButtonGroup Color="Color.Primary" Variant="Variant.Outlined" VerticalAlign="true">
+    <MudButton>One</MudButton>
+    <MudButton>Two</MudButton>
+    <MudButton>Three</MudButton>
+</MudButtonGroup>
+
+<MudButtonGroup Color="Color.Primary" Variant="Variant.Filled" VerticalAlign="true">
+    <MudButton>One</MudButton>
+    <MudButton>Two</MudButton>
+    <MudButton>Three</MudButton>
+</MudButtonGroup>
+
+<MudButtonGroup Color="Color.Primary" Variant="Variant.Text" VerticalAlign="true">
+    <MudButton>One</MudButton>
+    <MudButton>Two</MudButton>
+    <MudButton>Three</MudButton>
+</MudButtonGroup>

--- a/src/MudBlazor.Docs/Services/MenuService.cs
+++ b/src/MudBlazor.Docs/Services/MenuService.cs
@@ -96,6 +96,7 @@ namespace MudBlazor.Docs.Services
             //Buttons
             .AddNavGroup("Buttons", false, new DocsComponents()
                 .AddItem("Button", typeof(MudButton))
+                .AddItem("Button Group", typeof(MudButtonGroup))
                 .AddItem("IconButton", typeof(MudIconButton))
                 .AddItem("ToggleIconButton", typeof(MudToggleIconButton))
                 .AddItem("Button FAB", typeof(MudFab))

--- a/src/MudBlazor/Components/ButtonGroup/MudButtonGroup.razor
+++ b/src/MudBlazor/Components/ButtonGroup/MudButtonGroup.razor
@@ -1,0 +1,6 @@
+﻿@namespace MudBlazor
+@inherits MudComponentBase
+
+<MudElement HtmlTag="div" Class="@Classname" Style="@Style" Tag="@Tag" UserAttributes="@UserAttributes">
+    @ChildContent
+</MudElement>

--- a/src/MudBlazor/Components/ButtonGroup/MudButtonGroup.razor.cs
+++ b/src/MudBlazor/Components/ButtonGroup/MudButtonGroup.razor.cs
@@ -1,0 +1,60 @@
+﻿using Microsoft.AspNetCore.Components;
+using MudBlazor.Extensions;
+using MudBlazor.Utilities;
+
+namespace MudBlazor
+{
+    public partial class MudButtonGroup : MudComponentBase
+    {
+        protected string Classname =>
+        new CssBuilder("mud-button-group-root")
+          .AddClass($"mud-button-group-override-styles", OverrideStyles)
+          .AddClass($"mud-button-group-{Variant.ToDescriptionString()}")
+          .AddClass($"mud-button-group-{Variant.ToDescriptionString()}-{Color.ToDescriptionString()}")
+          .AddClass($"mud-button-group-{Variant.ToDescriptionString()}-size-{Size.ToDescriptionString()}")
+          .AddClass($"mud-button-group-vertical", VerticalAlign)
+          .AddClass($"mud-button-group-horizontal", !VerticalAlign)
+          .AddClass($"mud-button-group-disable-elevation", DisableElevation)
+          .AddClass($"mud-button-group-rtl", RightToLeft)
+          .AddClass(Class)
+        .Build();
+
+
+        [CascadingParameter] public bool RightToLeft { get; set; }
+
+        /// <summary>
+        /// If true, the button group will override the styles of the individual buttons.
+        /// </summary>
+        [Parameter] public bool OverrideStyles { get; set; } = true;
+
+        /// <summary>
+        /// Child content of component.
+        /// </summary>
+        [Parameter] public RenderFragment ChildContent { get; set; }
+
+        /// <summary>
+        /// If true, the button group will be displayed vertically.
+        /// </summary>
+        [Parameter] public bool VerticalAlign { get; set; } = false;
+
+        /// <summary>
+        /// If true, no drop-shadow will be used.
+        /// </summary>
+        [Parameter] public bool DisableElevation { get; set; } = false;
+
+        /// <summary>
+        /// The color of the component. It supports the theme colors.
+        /// </summary>
+        [Parameter] public Color Color { get; set; } = Color.Default;
+
+        /// <summary>
+        /// The size of the component.
+        /// </summary>
+        [Parameter] public Size Size { get; set; } = Size.Medium;
+
+        /// <summary>
+        /// The variant to use.
+        /// </summary>
+        [Parameter] public Variant Variant { get; set; } = Variant.Text;
+    }
+}

--- a/src/MudBlazor/Styles/MudBlazor.scss
+++ b/src/MudBlazor/Styles/MudBlazor.scss
@@ -22,6 +22,7 @@
 @import 'components/_avatar';
 @import 'components/_breadcrumbs';
 @import 'components/_button';
+@import 'components/_buttongroup';
 @import 'components/_iconbutton';
 @import 'components/_card';
 @import 'components/_charts';

--- a/src/MudBlazor/Styles/components/_buttongroup.scss
+++ b/src/MudBlazor/Styles/components/_buttongroup.scss
@@ -1,0 +1,303 @@
+@import '../abstracts/variables';
+
+.mud-button-group-root {
+    border-radius: var(--mud-default-borderradius);
+    display: inline-flex;
+
+    .mud-button-root {
+        border-radius: var(--mud-default-borderradius);
+    }
+
+    &.mud-button-group-override-styles {
+        .mud-button {
+            color: var(--mud-palette-text-primary);
+        }
+        .mud-button-root {
+            background-color: inherit;
+            box-shadow: none;
+            border: none;
+
+            &:hover {
+                background-color: var(--mud-palette-action-default-hover);
+            }
+        }
+    }
+}
+.mud-button-group-horizontal {
+    &:not(.mud-button-group-rtl) {
+        > .mud-button-root:not(:last-child), :not(:last-child) .mud-button-root {
+            border-top-right-radius: 0;
+            border-bottom-right-radius: 0;
+        }
+
+        > .mud-button-root:not(:first-child), :not(:first-child) .mud-button-root {
+            border-top-left-radius: 0;
+            border-bottom-left-radius: 0;
+            margin-left: -1px;
+        }
+    }
+
+    &.mud-button-group-rtl {
+        > .mud-button-root:not(:last-child), :not(:last-child) .mud-button-root {
+            border-top-left-radius: 0;
+            border-bottom-left-radius: 0;
+            margin-left: -1px;
+        }
+
+        > .mud-button-root:not(:first-child), :not(:first-child) .mud-button-root {
+            border-top-right-radius: 0;
+            border-bottom-right-radius: 0;
+        }
+    }
+}
+
+.mud-button-group-vertical {
+    flex-direction: column;
+    .mud-icon-button {
+        width: 100%;
+    }
+
+    > .mud-button-root:not(:last-child), :not(:last-child) .mud-button-root {
+        border-bottom-right-radius: 0;
+        border-bottom-left-radius: 0;
+    }
+
+    > .mud-button-root:not(:first-child), :not(:first-child) .mud-button-root {
+        border-top-right-radius: 0;
+        border-top-left-radius: 0;
+        margin-top: -1px;
+    }
+}
+
+.mud-button-group-text {
+    &.mud-button-group-override-styles {
+        .mud-button-root {
+            padding: 6px 8px;
+        }
+
+        &.mud-button-group-horizontal {
+            &:not(.mud-button-group-rtl) .mud-button-root:not(:first-child) {
+                border-left: 1px solid var(--mud-palette-text-primary);
+            }
+
+            &.mud-button-group-rtl .mud-button-root:not(:first-child) {
+                border-right: 1px solid var(--mud-palette-text-primary);
+            }
+        }
+
+        &.mud-button-group-vertical .mud-button-root:not(:last-child) {
+            border-bottom: 1px solid var(--mud-palette-text-primary);
+        }
+
+        @each $color in $mud-palette-colors {
+            &.mud-button-group-text-#{$color} {
+                .mud-button-root {
+                    color: var(--mud-palette-#{$color});
+
+                    &:hover {
+                        background-color: var(--mud-palette-#{$color}-hover);
+                    }
+                }
+
+                &.mud-button-group-horizontal {
+                    &:not(.mud-button-group-rtl) .mud-button-root:not(:first-child) {
+                        border-left: 1px solid var(--mud-palette-#{$color});
+                    }
+
+                    &.mud-button-group-rtl .mud-button-root:not(:first-child) {
+                        border-right: 1px solid var(--mud-palette-#{$color});
+                    }
+                }
+
+                &.mud-button-group-vertical .mud-button-root:not(:last-child) {
+                    border-bottom: 1px solid var(--mud-palette-#{$color});
+                }
+            }
+        }
+    }
+}
+
+.mud-button-group-outlined {
+    &.mud-button-group-override-styles {
+        .mud-button-root {
+            padding: 5px 15px;
+            border: 1px solid var(--mud-palette-text-primary);
+        }
+
+        @each $color in $mud-palette-colors {
+            &.mud-button-group-outlined-#{$color} .mud-button-root {
+                color: var(--mud-palette-#{$color});
+                border: 1px solid var(--mud-palette-#{$color});
+
+                &:hover {
+                    background-color: var(--mud-palette-#{$color}-hover);
+                }
+            }
+        }
+    }
+}
+
+.mud-button-group-filled {
+    box-shadow: var(--mud-elevation-2);
+
+    .mud-button-root {
+        box-shadow: none;
+
+        &:hover {
+            box-shadow: var(--mud-elevation-4);
+        }
+    }
+
+    &.mud-button-group-override-styles {
+        .mud-button-root {
+            background-color: var(--mud-palette-action-default-hover);
+            padding: 6px 16px;
+        }
+
+        &.mud-button-group-horizontal {
+            &:not(.mud-button-group-rtl) .mud-button-root:not(:first-child) {
+                border-left: 1px solid var(--mud-palette-divider);
+            }
+
+            &.mud-button-group-rtl .mud-button-root:not(:first-child) {
+                border-right: 1px solid var(--mud-palette-divider);
+            }
+        }
+
+        &.mud-button-group-vertical .mud-button-root:not(:first-child) {
+            border-top: 1px solid var(--mud-palette-divider);
+        }
+
+        @each $color in $mud-palette-colors {
+            &.mud-button-group-filled-#{$color} {
+                .mud-button-root {
+                    background-color: var(--mud-palette-#{$color});
+                    color: var(--mud-palette-#{$color}-text);             
+
+                    &:hover {
+                        background-color: var(--mud-palette-#{$color}-darken);
+                    }
+                }
+
+                &.mud-button-group-horizontal {
+                    &:not(.mud-button-group-rtl) .mud-button-root:not(:first-child) {
+                        border-left: 1px solid var(--mud-palette-#{$color}-lighten);
+                    }
+
+                    &.mud-button-group-rtl .mud-button-root:not(:first-child) {
+                        border-right: 1px solid var(--mud-palette-#{$color}-lighten);
+                    }
+                }
+
+                &.mud-button-group-vertical .mud-button-root:not(:first-child) {
+                    border-top: 1px solid var(--mud-palette-#{$color}-lighten);
+                }
+            }
+        }
+    }
+}
+
+.mud-button-group-disable-elevation {
+    box-shadow: none;
+}
+
+.mud-button-group-root {
+    &.mud-button-group-text-size-small .mud-button-root {
+        padding: 4px 5px;
+        font-size: 0.8125rem;
+
+        &.mud-icon-button .mud-icon-root {
+            font-size: 1.422rem;
+        }
+    }
+
+    &.mud-button-group-text-size-large .mud-button-root {
+        padding: 8px 11px;
+        font-size: 0.9375rem;
+
+        &.mud-icon-button .mud-icon-root {
+            font-size: 1.641rem;
+        }
+    }
+
+    &.mud-button-group-outlined-size-small .mud-button-root {
+        padding: 3px 9px;
+        font-size: 0.8125rem;
+
+        &.mud-icon-button {
+            padding: 3px 9px;
+
+            .mud-icon-root {
+                font-size: 1.422rem;
+            }
+        }
+    }
+
+    &.mud-button-group-outlined-size-large .mud-button-root {
+        padding: 7px 21px;
+        font-size: 0.9375rem;
+
+        &.mud-icon-button {
+            padding: 7px 15px;
+
+            .mud-icon-root {
+                font-size: 1.641rem;
+            }
+        }
+    }
+
+    &.mud-button-group-filled-size-small .mud-button-root {
+        padding: 4px 10px;
+        font-size: 0.8125rem;
+
+        &.mud-icon-button {
+            padding: 4px 10px;
+
+            .mud-icon-root {
+                font-size: 1.422rem;
+            }
+        }
+    }
+
+    &.mud-button-group-filled-size-large .mud-button-root {
+        padding: 8px 22px;
+        font-size: 0.9375rem;
+
+        &.mud-icon-button {
+            padding: 8px 16px;
+
+            .mud-icon-root {
+                font-size: 1.641rem;
+            }
+        }
+    }
+}
+
+.mud-button-group-root {
+    @each $color in $mud-palette-colors {
+        .mud-button-root.mud-icon-button.mud-icon-button-color-#{$color} {
+            color: var(--mud-palette-#{$color});
+        }
+    }
+
+    .mud-button-root.mud-icon-button {
+        padding-right: 12px;
+        padding-left: 12px;
+
+        .mud-icon-root {
+            font-size: 1.516rem;
+        }
+
+        &.mud-ripple-icon {
+            &:after {
+                transform: scale(10,10);
+            }
+
+            &:active:after {
+                transform: scale(0,0);
+                opacity: 0.1;
+                transition: 0s;
+            }
+        }
+    }
+}


### PR DESCRIPTION
A new button group component that groups related buttons together. As described in #1249
Tell me what you think :)

Edit:
- [x] RTL support added
- [x] Split button support added
- [x] Support for `MudIconButton` and `MudToggleIconButton` added



![picture1](https://user-images.githubusercontent.com/62108893/116826577-fa6eb180-ab94-11eb-8a7b-f992792ad008.png)


![picture2](https://user-images.githubusercontent.com/62108893/116826578-fb9fde80-ab94-11eb-9175-e05f4a54fc13.png)

![buttongroup](https://user-images.githubusercontent.com/62108893/119017402-44300800-b99b-11eb-9af5-990e88239ddf.gif)
closes #1249

