### PR TITLE
MudTable - Hold shift to check/uncheck multiple rows

### DIFF
--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -55,10 +55,11 @@
                         {
                             var rowClass = new CssBuilder(RowClass).AddClass(RowClassFunc?.Invoke(item, rowIndex)).Build();
                             var rowStyle = new StyleBuilder().AddStyle(RowStyle).AddStyle(RowStyleFunc?.Invoke(item, rowIndex)).Build();
-                            <MudTr Class="@rowClass" Style="@rowStyle" Item="item" @key="item" IsCheckable="MultiSelection" IsEditable="RowEditingTemplate != null" 
+                            <MudTr Class="@rowClass" Style="@rowStyle" Item="item" @key="item" IsCheckable="MultiSelection" IsEditable="RowEditingTemplate != null"
+                                   @onkeydown="e => KeyDownHandler(e)" @onkeyup="e => KeyUpHandler(e)" tabindex="@rowIndex"
                                    IsCheckedChanged="@((value) => { var x = item; OnRowCheckboxChanged(value, x); })">
                                 @if ((!ReadOnly) && RowEditingTemplate != null && object.Equals(_editingItem, item))
-                                { 
+                                {
                                     <CascadingValue Value="@Validator" IsFixed="true">
                                         @RowEditingTemplate(item)
                                     </CascadingValue>


### PR DESCRIPTION
This allows the user to hold shift to do a multiple selection of items in a table.

![MudTable](https://user-images.githubusercontent.com/81972128/117876247-c49e8c80-b268-11eb-8bdd-19e319d30e91.gif)
