### PR TITLE
MudDateRangePicker - accepts TitleDateFormat

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DateRangePickerUsageExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DateRangePickerUsageExample.razor
@@ -7,7 +7,7 @@
         <MudDateRangePicker Label="Basic range picker (editable)" Editable="true" @bind-DateRange="_dateRange" />
     </MudItem>
     <MudItem xs="12" sm="6">
-        <MudDateRangePicker Label="Range picker format" HelperText="For custom cultures" DateFormat="dd/MM/yyyy" @bind-DateRange="_dateRange" />
+        <MudDateRangePicker Label="Range picker format" HelperText="For custom cultures" DateFormat="dd/MM/yyyy" TitleDateFormat="dddd, dd. MMMM" @bind-DateRange="_dateRange" />
     </MudItem>
     <MudItem xs="12" sm="6">
         <MudDateRangePicker Label="Custom start month" StartMonth="@DateTime.Now.AddMonths(-1)" @bind-DateRange="_dateRange" />

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -230,6 +230,11 @@ namespace MudBlazor
         }
 
         protected abstract string GetTitleDateString();
+        
+        protected string FormatTitleDate(DateTime? date)
+        {
+            return date?.ToString(TitleDateFormat ?? "ddd, dd MMM", Culture) ?? "";
+        }
 
         protected string GetFormattedYearString()
         {

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -106,9 +106,7 @@ namespace MudBlazor
 
         protected override string GetTitleDateString()
         {
-            if (_selectedDate != null)
-                return _selectedDate.Value.ToString(TitleDateFormat ?? "ddd, dd MMM", Culture) ?? "";
-            return Date?.ToString(TitleDateFormat ?? "ddd, dd MMM", Culture) ?? "";
+            return FormatTitleDate(_selectedDate ?? Date);
         }
 
         protected override DateTime GetCalendarStartOfMonth()

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -222,19 +222,14 @@ namespace MudBlazor
 
         protected override string GetTitleDateString()
         {
-            if (_firstDate != null && _secondDate != null)
-                return $"{_firstDate.Value.ToString("dd MMM", Culture)} - {_secondDate.Value.ToString("dd MMM", Culture)}";
-            else if (_firstDate != null)
-                return _firstDate.Value.ToString("dd MMM", Culture) + " - ";
-
-            if (DateRange == null || DateRange.Start == null)
-                return "";
-            if (DateRange.End == null)
-                return DateRange.Start.Value.ToString("dd MMM", Culture);
-
-            return $"{DateRange.Start.Value.ToString("dd MMM", Culture)} - {DateRange.End.Value.ToString("dd MMM", Culture)}";
+            if (_firstDate != null)
+                return $"{FormatTitleDate(_firstDate)} - {FormatTitleDate(_secondDate)}";
+            
+            return DateRange?.Start != null
+                ? $"{FormatTitleDate(DateRange.Start)} - {FormatTitleDate(DateRange.End)}"
+                : "";
         }
-
+        
         protected override DateTime GetCalendarStartOfMonth()
         {
             var date = StartMonth ?? DateRange?.Start ?? DateTime.Today;


### PR DESCRIPTION
Fixes #1530

Default format for TitleDate is now consistent with MudDatePicker (`ddd, dd MMM`) and TitleDateFormat description.
