### PR TITLE
NumericField: restore preventDefault to true on up/down arrows

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/NumericField/Examples/DebouncedNumericFieldExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/NumericField/Examples/DebouncedNumericFieldExample.razor
@@ -30,9 +30,9 @@
 
 
 @code {
-    int _normal;
-    int _immediate;
-    int _debounced;
+    double _normal;
+    double _immediate;
+    double _debounced;
 
     void HandleIntervalElapsed(string debouncedText)
     {

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor
@@ -14,7 +14,7 @@
 					  AdornmentText="@AdornmentText" AdornmentIcon="@AdornmentIcon" AdornmentColor="@AdornmentColor" IconSize="@IconSize"
 					  OnAdornmentClick="@OnAdornmentClick" Error="@Error" Immediate="@Immediate" Margin="@Margin"
 					  OnBlur="@OnBlurred" OnKeyDown="@InterceptArrowKey" OnKeyPress="@InvokeKeyPress" OnKeyUp="@InvokeKeyUp"
-					  KeyDownPreventDefault="_keyDownPreventDefault" KeyPressPreventDefault="KeyPressPreventDefault" KeyUpPreventDefault="KeyUpPreventDefault"
+					  KeyDownPreventDefault="@(_keyDownPreventDefault || KeyDownPreventDefault)" KeyPressPreventDefault="KeyPressPreventDefault" KeyUpPreventDefault="KeyUpPreventDefault"
 					  OnIncrement="Increment" OnDecrement="Decrement" HideSpinButtons="@HideSpinButtons" Validation="_validateInstance"
 					  min="@(_minHasValue ? FormatParam(_min) : null)"
 					  max="@(_maxHasValue ? FormatParam(_max): null)"
@@ -35,5 +35,4 @@
 		else
 			return null;
 	}
-
 }

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor
@@ -13,9 +13,9 @@
 					  Disabled=@Disabled DisableUnderLine="@DisableUnderLine" ReadOnly="@ReadOnly" Adornment="@Adornment"
 					  AdornmentText="@AdornmentText" AdornmentIcon="@AdornmentIcon" AdornmentColor="@AdornmentColor" IconSize="@IconSize"
 					  OnAdornmentClick="@OnAdornmentClick" Error="@Error" Immediate="@Immediate" Margin="@Margin"
-					  OnBlur="@OnBlurred" OnKeyDown="@InterceptArrowKey" OnKeyPress="@InvokeKeyPress" OnKeyUp="@InvokeKeyUp"
+					  OnBlur="@OnBlurred" OnKeyDown="@InterceptArrowKey" OnKeyPress="@InvokeKeyPress" OnKeyUp="@InterceptKeyUp"
 					  KeyDownPreventDefault="@(_keyDownPreventDefault || KeyDownPreventDefault)" KeyPressPreventDefault="KeyPressPreventDefault" KeyUpPreventDefault="KeyUpPreventDefault"
-					  OnIncrement="Increment" OnDecrement="Decrement" HideSpinButtons="@HideSpinButtons" Validation="_validateInstance"
+                      OnIncrement="Increment" OnDecrement="Decrement" HideSpinButtons="@HideSpinButtons" Validation="_validateInstance"
 					  min="@(_minHasValue ? FormatParam(_min) : null)"
 					  max="@(_maxHasValue ? FormatParam(_max): null)"
 					  step="@(_stepHasValue ? FormatParam(_step) : null)" />

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -316,12 +316,24 @@ namespace MudBlazor
                 if (obj.Key == "ArrowUp")
                 {
                     _keyDownPreventDefault = true;
+                    if (RuntimeLocation.IsServerSide)
+                    {
+                        var value = Value;
+                        await Task.Delay(1);
+                        Value = value;
+                    }
                     await Increment();
                     return;
                 }
                 else if (obj.Key == "ArrowDown")
                 {
                     _keyDownPreventDefault = true;
+                    if (RuntimeLocation.IsServerSide)
+                    {
+                        var value = Value;
+                        await Task.Delay(1);
+                        Value = value;
+                    }
                     await Decrement();
                     return;
                 }

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -311,7 +311,7 @@ namespace MudBlazor
             if (Disabled || ReadOnly)
                 return;
 
-            if (obj.Type == "keydown")//KeyDown or repeat, blazor never fire InvokeKeyPress
+            if (obj.Type == "keydown")//KeyDown or repeat, blazor never fires InvokeKeyPress
             {
                 if (obj.Key == "ArrowUp")
                 {
@@ -326,8 +326,8 @@ namespace MudBlazor
                     return;
                 }
             }
-            _keyDownPreventDefault = KeyDownPreventDefault;
-            OnKeyPress.InvokeAsync(obj).AndForget();
+                _keyDownPreventDefault = KeyDownPreventDefault;
+            OnKeyDown.InvokeAsync(obj).AndForget();
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -326,8 +326,25 @@ namespace MudBlazor
                     return;
                 }
             }
-                _keyDownPreventDefault = KeyDownPreventDefault;
+
+            _keyDownPreventDefault = KeyDownPreventDefault;
             OnKeyDown.InvokeAsync(obj).AndForget();
+        }
+
+        /// <summary>
+        /// Overrides KeyUp event, if needed reset <see cref="_keyDownPreventDefault"/> set by <see cref="InterceptArrowKey(KeyboardEventArgs)"/>.
+        /// </summary>
+        protected void InterceptKeyUp(KeyboardEventArgs obj)
+        {
+            if (Disabled || ReadOnly)
+                return;
+
+            if (_keyDownPreventDefault != KeyDownPreventDefault)
+            {
+                _keyDownPreventDefault = KeyDownPreventDefault;
+                StateHasChanged();
+            }
+            OnKeyUp.InvokeAsync(obj).AndForget();
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
@@ -316,11 +315,13 @@ namespace MudBlazor
             {
                 if (obj.Key == "ArrowUp")
                 {
+                    _keyDownPreventDefault = true;
                     await Increment();
                     return;
                 }
                 else if (obj.Key == "ArrowDown")
                 {
+                    _keyDownPreventDefault = true;
                     await Decrement();
                     return;
                 }

--- a/src/MudBlazor/Utilities/RuntimeLocation.cs
+++ b/src/MudBlazor/Utilities/RuntimeLocation.cs
@@ -1,0 +1,11 @@
+﻿using System.Runtime.InteropServices;
+
+namespace MudBlazor.Utilities
+{
+    public class RuntimeLocation
+    {
+        public static bool IsClientSide => RuntimeInformation.OSDescription == "Browser"; // WASM
+        public static bool IsServerSide => RuntimeInformation.OSDescription != "Browser";
+    }
+
+}


### PR DESCRIPTION
Fix issue #1543, onkeydown:preventDefault on the input tag wasn't set to true when pressing up/down arrows, causing double increment: the code and the browser.

This PR is draft because I noticed that there are some quirks on the restore of "preventDefault" on other inputs.