### PR TITLE
Treeview fix ActivatedValue

### DIFF
--- a/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
@@ -65,7 +65,7 @@ namespace MudBlazor
         public string Width { get; set; }
 
         [Parameter] public HashSet<T> Items { get; set; }
-
+  
         [Parameter] public EventCallback<T> ActivatedValueChanged { get; set; }
 
         [Parameter] public EventCallback<HashSet<T>> SelectedValuesChanged { get; set; }
@@ -97,8 +97,7 @@ namespace MudBlazor
                 await UpdateSelectedItems();
             }
             await base.OnAfterRenderAsync(firstRender);
-        }
-
+        } 
         internal async Task UpdateActivatedItem(MudTreeViewItem<T> item, bool requestedValue)
         {
             if ((_activatedValue == item && requestedValue) ||
@@ -142,5 +141,7 @@ namespace MudBlazor
         }
 
         internal void AddChild(MudTreeViewItem<T> item) => _childItems.Add(item);
+
+        internal void RemoveChild(MudTreeViewItem<T> item) => _childItems.Remove(item);
     }
 }

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Threading.Tasks;
 using System.Windows.Input;
@@ -8,7 +9,7 @@ using MudBlazor.Utilities;
 
 namespace MudBlazor
 {
-    public partial class MudTreeViewItem<T> : MudComponentBase
+    public partial class MudTreeViewItem<T> : MudComponentBase, IDisposable
     {
         private string _text;
         private bool _isSelected, _isActivated, _isServerLoaded;
@@ -260,5 +261,19 @@ namespace MudBlazor
                 StateHasChanged();
             }
         }
+
+        public void Dispose()
+        {
+            if (Parent != null)
+            {
+                Parent.RemoveChild(this);
+            }
+            else
+            {
+                MudTreeRoot?.RemoveChild(this);
+            }
+        }
+
+        private void RemoveChild(MudTreeViewItem<T> item) => this._childItems.Remove(item);
     }
 }


### PR DESCRIPTION
**Current State:**  Still in process (Writing this decription)

Currently there are several problems in the TreeView, which always happen when the `Items `list changes.

Issues for example:  #1522 and #1511

### Why does this issue happen?
If `Items` changes, then the TreeView is rebuilt. So far this is correct. But Blazor doesn't make a new instance of TreeViewItem for optimization reasons. The existing TreeViewItems are set with new values. Since the status "IsActivated" depends on the TreeViewItem and not on the value, the error happens here.

### What has to be done?
- [x]  If an item is removed from Items, a TreeViewItem remains in _childItems. This can be corrected with IDisposable.


