### PR TITLE
NumericInput: add right padding when overlapping with spinner buttons

### DIFF
--- a/src/MudBlazor/Styles/components/_inputcontrol.scss
+++ b/src/MudBlazor/Styles/components/_inputcontrol.scss
@@ -82,6 +82,10 @@
             -moz-appearance: textfield;
         }
 
+        &.mud-input-showspin .mud-input:not(.mud-input-adorned-end) input {
+            padding-right: 24px;
+        }
+        
         & .mud-input-numeric-spin {
             display: inline-flex;
             flex-direction: column;
@@ -96,9 +100,7 @@
                 min-width: unset;
                 min-height: unset;
             }
-        }
-
-        & .mud-input-underline .mud-input-numeric-spin button {
+        } & .mud-input-underline .mud-input-numeric-spin button {
             padding: 2px 0;
         }
     }

--- a/src/MudBlazor/Styles/components/_inputcontrol.scss
+++ b/src/MudBlazor/Styles/components/_inputcontrol.scss
@@ -83,7 +83,7 @@
         }
 
         &.mud-input-showspin .mud-input:not(.mud-input-adorned-end) input {
-            padding-right: 24px;
+            padding-right: 24px; //This must be the same width of the spinners
         }
         
         & .mud-input-numeric-spin {
@@ -100,7 +100,9 @@
                 min-width: unset;
                 min-height: unset;
             }
-        } & .mud-input-underline .mud-input-numeric-spin button {
+        }
+        
+        & .mud-input-underline .mud-input-numeric-spin button {
             padding: 2px 0;
         }
     }


### PR DESCRIPTION
Fix for #1550

Add new CSS rule that adds a padding equal to the spinner buttons width (24px) to prevent overlap with them.
It mainly shows for right aligned text, but also for long numbers.