### PR TITLE
Fixed InvalidCastException in MudNumericField<T>

### DIFF
--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -304,6 +304,37 @@ namespace MudBlazor.UnitTests
             numericField.HasErrors.Should().Be(false);
         }
 
-    }
+        /// <summary>
+        /// NumericField with any numeric type parameter should render.
+        /// Test for decimal type moved to another method because it cannot be parameter for TastCaseAttribute.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        [Test]
+        [TestCase((byte)5)]
+        [TestCase((sbyte)5)]
+        [TestCase((short)5)]
+        [TestCase((ushort)5)]
+        [TestCase((int)5)]
+        [TestCase((uint)5)]
+        [TestCase((long)5)]
+        [TestCase((ulong)5)]
+        [TestCase((float)1.0f)]
+        [TestCase((double)5.0)]
+        public async Task NumericField_OfAnyType_Should_Render<T>(T value)
+        {
+            Assert.DoesNotThrow(() => ctx.RenderComponent<MudNumericField<T>>(), $"NunericField<{typeof(T)}> render failed.");
+        }
 
+        /// <summary>
+        /// NumericField with decimal type parameter should render.
+        /// </summary>
+        /// <returns></returns>
+        [Test]
+        public async Task NumericField_OfDecimal_Should_Render()
+        {
+            Assert.DoesNotThrow(() => ctx.RenderComponent<MudNumericField<decimal>>(), $"NumericField<{typeof(decimal)}> render failed.");
+        }
+    }
 }

--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -306,7 +306,7 @@ namespace MudBlazor.UnitTests
 
         /// <summary>
         /// NumericField with any numeric type parameter should render.
-        /// Test for decimal type moved to another method because it cannot be parameter for TastCaseAttribute.
+        /// Test for decimal type moved to another method because it cannot be parameter for TestCaseAttribute.
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="value"></param>
@@ -320,11 +320,11 @@ namespace MudBlazor.UnitTests
         [TestCase((uint)5)]
         [TestCase((long)5)]
         [TestCase((ulong)5)]
-        [TestCase((float)1.0f)]
+        [TestCase((float)5.0f)]
         [TestCase((double)5.0)]
         public async Task NumericField_OfAnyType_Should_Render<T>(T value)
         {
-            Assert.DoesNotThrow(() => ctx.RenderComponent<MudNumericField<T>>(), $"NunericField<{typeof(T)}> render failed.");
+            Assert.DoesNotThrow(() => ctx.RenderComponent<MudNumericField<T>>(), $"{typeof(MudNumericField<>)}<{typeof(T)}> render failed.");
         }
 
         /// <summary>
@@ -334,7 +334,7 @@ namespace MudBlazor.UnitTests
         [Test]
         public async Task NumericField_OfDecimal_Should_Render()
         {
-            Assert.DoesNotThrow(() => ctx.RenderComponent<MudNumericField<decimal>>(), $"NumericField<{typeof(decimal)}> render failed.");
+            Assert.DoesNotThrow(() => ctx.RenderComponent<MudNumericField<decimal>>(), $"{typeof(MudNumericField<>)}<{typeof(decimal)}> render failed.");
         }
     }
 }

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -24,28 +24,28 @@ namespace MudBlazor
             {
                 _minDefault = (T)(object)sbyte.MinValue;
                 _maxDefault = (T)(object)sbyte.MaxValue;
-                _stepDefault = (T)(object)1;
+                _stepDefault = (T)(object)(sbyte)1;
             }
             // byte
             else if (typeof(T) == typeof(byte) || typeof(T) == typeof(byte?))
             {
                 _minDefault = (T)(object)byte.MinValue;
                 _maxDefault = (T)(object)byte.MaxValue;
-                _stepDefault = (T)(object)1;
+                _stepDefault = (T)(object)(byte)1;
             }
             // short
             else if (typeof(T) == typeof(short) || typeof(T) == typeof(short?))
             {
                 _minDefault = (T)(object)short.MinValue;
                 _maxDefault = (T)(object)short.MaxValue;
-                _stepDefault = (T)(object)1;
+                _stepDefault = (T)(object)(short)1;
             }
             // ushort
             else if (typeof(T) == typeof(ushort) || typeof(T) == typeof(ushort?))
             {
                 _minDefault = (T)(object)ushort.MinValue;
                 _maxDefault = (T)(object)ushort.MaxValue;
-                _stepDefault = (T)(object)1;
+                _stepDefault = (T)(object)(ushort)1;
             }
             // int
             else if (typeof(T) == typeof(int) || typeof(T) == typeof(int?))
@@ -59,21 +59,21 @@ namespace MudBlazor
             {
                 _minDefault = (T)(object)uint.MinValue;
                 _maxDefault = (T)(object)uint.MaxValue;
-                _stepDefault = (T)(object)1;
+                _stepDefault = (T)(object)1u;
             }
             // long
             else if (typeof(T) == typeof(long) || typeof(T) == typeof(long?))
             {
                 _minDefault = (T)(object)long.MinValue;
                 _maxDefault = (T)(object)long.MaxValue;
-                _stepDefault = (T)(object)1;
+                _stepDefault = (T)(object)1L;
             }
             // ulong
             else if (typeof(T) == typeof(ulong) || typeof(T) == typeof(ulong?))
             {
                 _minDefault = (T)(object)ulong.MinValue;
                 _maxDefault = (T)(object)ulong.MaxValue;
-                _stepDefault = (T)(object)1;
+                _stepDefault = (T)(object)1ul;
             }
             // float
             else if (typeof(T) == typeof(float) || typeof(T) == typeof(float?))


### PR DESCRIPTION
Exception was thrown from constructor when `T` was not `int`. It happened because several numeric literals that were set to `_stepDefault` were recognized by compiler as `int`.