### PR TITLE
MudOverlay moved inside MudMenu component

### DIFF
--- a/src/MudBlazor/Components/Menu/MudMenu.razor
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor
@@ -40,7 +40,7 @@
             </MudList>
         </MudPopover>
     </CascadingValue>
+    <MudOverlay Visible="@(_isOpen && ActivationEvent != MouseEvent.MouseOver)" OnClick="@ToggleMenu" LockScroll="false" />
 </div>
 
-<MudOverlay Visible="@(_isOpen && ActivationEvent != MouseEvent.MouseOver)" OnClick="@ToggleMenu" LockScroll="false" />
 


### PR DESCRIPTION
The `MudOverlay` should be contained inside the `MudMenu`. Otherwise this could break css styles from components which share the same parent as `MudMenu`. For example this became a problem when I used the `:last-child` selector in the parent component in  #1484. Hard to explain but I hope you get what I mean.