### PR TITLE
MudTreeView RTL support fixed

### DIFF
--- a/src/MudBlazor/Styles/components/_treeview.scss
+++ b/src/MudBlazor/Styles/components/_treeview.scss
@@ -116,3 +116,28 @@
         transform: rotate(359deg);
     }
 }
+
+.mud-application-layout-rtl {
+    .mud-treeview-item-icon {
+        margin-left: 4px;
+        margin-right: 0;
+    }
+
+    .mud-treeview-item-label {
+        padding-right: 4px;
+        padding-left: 0;
+    }
+
+    .mud-treeview-group {
+        margin-right: 17px;
+        margin-left: 0;
+    }
+
+    .mud-treeview-item-arrow {
+        transform: rotate(180deg);
+
+        .mud-treeview-item-arrow-expand.mud-transform {
+            transform: rotate(-90deg);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1596
~I changed the margin in `mud-treeview-group` from 17px to 16px because I used the class `mr-4`. Or should I add a custom css class to fix the issue?~