### PR TITLE
Fixes button spacing in RTL

### DIFF
--- a/src/MudBlazor/Styles/components/_button.scss
+++ b/src/MudBlazor/Styles/components/_button.scss
@@ -231,3 +231,25 @@
 .mud-button-icon-size-large > *:first-child {
     font-size: 22px;
 }
+
+.mud-application-layout-rtl .mud-button-label {
+    .mud-button-icon-start {
+        margin-right: -4px;
+        margin-left: 8px;
+
+        &.mud-button-icon-size-small {
+            margin-right: -2px;
+            margin-left: 0;
+        }
+    }
+
+    .mud-button-icon-end {
+        margin-right: 8px;
+        margin-left: -4px;
+
+        &.mud-button-icon-size-small {
+            margin-left: -2px;
+            margin-right: 0;
+        }
+    }
+}


### PR DESCRIPTION
Fixes `Button icon position and spacing` in https://github.com/Garderoben/MudBlazor/issues/92#issuecomment-724748845
Before:
![grafik](https://user-images.githubusercontent.com/62108893/118849615-32cdf980-b8d0-11eb-8205-c87f53e4db1b.png)

After:
![grafik](https://user-images.githubusercontent.com/62108893/118849684-437e6f80-b8d0-11eb-8f6f-b355c32e7b46.png)

