### PR TITLE
Fixes fab button spacing in RTL

### DIFF
--- a/src/MudBlazor/Styles/components/_fab.scss
+++ b/src/MudBlazor/Styles/components/_fab.scss
@@ -119,6 +119,23 @@
     }
 }
 
+.mud-application-layout-rtl .mud-fab-extended {
+    &.mud-fab-size-large .mud-icon-root {
+        margin-left: 8px;
+        margin-right: 0;
+    }
+
+    &.mud-fab-size-small .mud-icon-root {
+        margin-left: 4px;
+        margin-right: 0;
+    }
+
+    &.mud-fab-size-medium .mud-icon-root {
+        margin-left: 8px;
+        margin-right: 0;
+    }
+}
+
 .mud-fab-color-inherit {
     color: inherit;
 }


### PR DESCRIPTION
Fixes `FAB icon position` in https://github.com/Garderoben/MudBlazor/issues/92#issuecomment-724748845

Before:
![grafik](https://user-images.githubusercontent.com/62108893/118852781-60687200-b8d3-11eb-9ab2-904ca5d7963a.png)

After:
![grafik](https://user-images.githubusercontent.com/62108893/118941175-bed43580-b951-11eb-8292-a5db29dc3489.png)

