### PR TITLE
Fixes card avatar spacing in RTL

### DIFF
--- a/src/MudBlazor/Styles/components/_card.scss
+++ b/src/MudBlazor/Styles/components/_card.scss
@@ -44,3 +44,18 @@
     padding: 8px;
     align-items: center;
 }
+
+.mud-application-layout-rtl {
+    .mud-card-header {
+        & .mud-card-header-avatar {
+            margin-left: 16px;
+            margin-right: 0;
+        }
+
+        & .mud-card-header-actions {
+            align-self: flex-end;
+            margin-left: -8px;
+            margin-right: 0;
+        }
+    }
+}


### PR DESCRIPTION
Fixes `Card avatar spacing` in https://github.com/Garderoben/MudBlazor/issues/92#issuecomment-724748845

Before:
![grafik](https://user-images.githubusercontent.com/62108893/118860672-fa341d00-b8db-11eb-99e6-c54bf87b71d5.png)

After:
![grafik](https://user-images.githubusercontent.com/62108893/118860741-0a4bfc80-b8dc-11eb-9695-e25a237ca529.png)
