### PR TITLE
(re)Adding a public accessable property for tabpanels

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/TabsAddingRemovingTabsTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/TabsAddingRemovingTabsTest.razor
@@ -3,7 +3,7 @@
 <MudButton OnClick="AddTab">Add Tab</MudButton>
 <MudButton OnClick="RemoveLast">Remove Last</MudButton>
 
-<MudTabs Elevation="1">
+<MudTabs Elevation="1" @ref="Tabs">
     @foreach (var tab in _tabs)
     {
         <MudTabPanel @key="tab" Text="@tab">
@@ -18,6 +18,8 @@
 
     private List<string> _tabs = new List<string>();
     private int i = 0;
+
+    public MudTabs Tabs { get; set; }
 
     private async Task AddTab()
     {

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -43,16 +43,27 @@ namespace MudBlazor.UnitTests.Components
             Console.WriteLine(comp.Markup);
             comp.Find("div.mud-tabs-panels").InnerHtml.Trim().Should().BeEmpty();
             comp.FindAll("div.mud-tab").Should().BeEmpty();
+            comp.Instance.Tabs.Panels.Should().NotBeNull().And.BeEmpty();
+
             // add a panel
             comp.FindAll("button")[0].Click();
             Console.WriteLine("\n" + comp.Markup);
             comp.Find("div.mud-tabs-panels").InnerHtml.Trim().Should().NotBeEmpty();
             comp.FindAll("div.mud-tab").Count.Should().Be(1);
             comp.FindAll("p.mud-typography").Count.Should().Be(1);
+
+            comp.Instance.Tabs.Panels.Should().NotBeNull().And.HaveCount(1);
+            comp.FindComponents<MudTabPanel>().First().Instance.Should().Be(comp.Instance.Tabs.Panels[0]);
+
             // add another
             comp.FindAll("button")[0].Click();
             Console.WriteLine("\n" + comp.Markup);
             comp.FindAll("div.mud-tab").Count.Should().Be(2);
+
+            comp.Instance.Tabs.Panels.Should().NotBeNull().And.HaveCount(2);
+            comp.FindComponents<MudTabPanel>().ElementAt(0).Instance.Should().Be(comp.Instance.Tabs.Panels[0]);
+            comp.FindComponents<MudTabPanel>().ElementAt(1).Instance.Should().Be(comp.Instance.Tabs.Panels[1]);
+
             comp.FindAll("p.mud-typography").Count.Should().Be(1, because: "Only the current tab panel is displayed");
             // we are now on tab 0
             comp.Find("p.mud-typography").TrimmedText().Should().Be("Tab 0");
@@ -63,12 +74,18 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("button")[1].Click();
             comp.FindAll("div.mud-tab").Count.Should().Be(1);
             comp.FindAll("p.mud-typography").Count.Should().Be(1);
+
+            comp.Instance.Tabs.Panels.Should().NotBeNull().And.HaveCount(1);
+            comp.FindComponents<MudTabPanel>().ElementAt(0).Instance.Should().Be(comp.Instance.Tabs.Panels[0]);
+
             // we should be on tab0 again
             comp.Find("p.mud-typography").TrimmedText().Should().Be("Tab 0");
             // remove another
             comp.FindAll("button")[1].Click();
             comp.Find("div.mud-tabs-panels").InnerHtml.Trim().Should().BeEmpty();
             comp.FindAll("div.mud-tab").Should().BeEmpty();
+
+            comp.Instance.Tabs.Panels.Should().NotBeNull().And.BeEmpty();
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -164,13 +164,24 @@ namespace MudBlazor
         [Parameter]
         public EventCallback<int> ActivePanelIndexChanged { get; set; }
 
-        private List<MudTabPanel> _panels = new List<MudTabPanel>();
+        /// <summary>
+        /// A readonly list of the current panels. Panels should be added or removed through the RenderTree use this collection to get informations about the current panels
+        /// </summary>
+        public IReadOnlyList<MudTabPanel> Panels { get; private set; }
+
+        private List<MudTabPanel> _panels;
 
         private string _prevIcon;
 
         private string _nextIcon;
 
         #region Life cycle management
+
+        public MudTabs()
+        {
+            _panels = new List<MudTabPanel>();
+            Panels = _panels.AsReadOnly();
+        }
 
         protected override void OnParametersSet()
         {


### PR DESCRIPTION

To make it possible that developers can access the tabs, without opening an easy way to manipulate the collection, I've added a ```ReadOnlyList<MudTabPabel>``` to the ```MudTab``` class and linked it to the private list of tabs.

It was mentioned in #1473 and #1467