### PR TITLE
Autocomplete: added CoerceValue parameter

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Autocomplete/AutocompletePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Autocomplete/AutocompletePage.razor
@@ -16,7 +16,9 @@
                 <Title>Usage</Title>
                 <Description>
                     How you write the search function determines whether or not the Autocomplete shows a full list initially. By setting <CodeInline>ResetValueOnEmptyText="true"</CodeInline>
-                    the value will be reset when the user clears the input text. Otherwise, the value is kept and the text coerced to the current value.
+                    the <CodeInline>Value</CodeInline> will be reset when the user clears the input text. With <CodeInline>CoerceText="true"</CodeInline> upon selection of an entry from the list, 
+                    the <CodeInline>Text</CodeInline> is always updated. When the user types something that is not on the list and <CodeInline>CoerceValue</CodeInline> is true,
+                    the <CodeInline>Value</CodeInline> will be overwritten with the user input which allows it to be passed to the validation function.
                 </Description>
             </SectionHeader>
             <SectionContent Outlined="true" DisplayFlex="true">

--- a/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompleteUsageExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompleteUsageExample.razor
@@ -3,26 +3,30 @@
 <MudGrid>
     <MudItem xs="12" sm="6" md="4">
         <MudAutocomplete T="string" Label="US States" @bind-Value="value1" SearchFunc="@Search1" 
-                         ResetValueOnEmptyText="@resetValueOnEmptyText" CoerceText="@coerceText" />
+                         ResetValueOnEmptyText="@resetValueOnEmptyText" 
+                         CoerceText="@coerceText" CoerceValue="@coerceValue"/>
     </MudItem>
     <MudItem xs="12" sm="6" md="4">
         <MudAutocomplete T="string" Label="US States" @bind-Value="value2" SearchFunc="@Search2" 
-                         ResetValueOnEmptyText="@resetValueOnEmptyText" CoerceText="@coerceText" />
+                         ResetValueOnEmptyText="@resetValueOnEmptyText" 
+                         CoerceText="@coerceText"  CoerceValue="@coerceValue"/>
     </MudItem>
     <MudItem xs="12" md="12">
         <MudText Class="mb-n3" Typo="Typo.body2">
             <MudChip>@(value1 ?? "Not selected")</MudChip><MudChip>@(value2 ?? "Not selected")</MudChip>
         </MudText>
     </MudItem>
-    <MudItem xs="12" md="12">
+    <MudItem xs="12" md="12" class="flex-column">
         <MudSwitch @bind-Checked="resetValueOnEmptyText" Color="Color.Primary">Reset Value on empty Text</MudSwitch>
         <MudSwitch @bind-Checked="coerceText" Color="Color.Secondary">Coerce Text to Value</MudSwitch>
+        <MudSwitch @bind-Checked="coerceValue" Color="Color.Tertiary">Coerce Value to Text (if not found)</MudSwitch>
     </MudItem>
 </MudGrid>
 
 @code {
     private bool resetValueOnEmptyText;
     private bool coerceText;
+    private bool coerceValue;
     private string value1, value2;
     private string[] states =
     {

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -142,7 +142,7 @@ namespace MudBlazor.UnitTests.Components
             Console.WriteLine(comp.Markup);
             var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
             var autocomplete = autocompletecomp.Instance;
-            await comp.InvokeAsync(() => autocomplete.DebounceInterval = 0);
+            autocompletecomp.SetParam(x => x.DebounceInterval, 0);
             // check initial state
             autocomplete.Value.Should().Be("Alabama");
             autocomplete.Text.Should().Be("Alabama");
@@ -154,6 +154,33 @@ namespace MudBlazor.UnitTests.Components
             autocomplete.Value.Should().Be("Alabama");
             autocomplete.Text.Should().Be("Alabama");
         }
+
+        /// <summary>
+        /// We search for a value not in list and value coercion will force the invalid value to be applied
+        /// allowing to validate the user input.
+        /// </summary>
+        /// <returns></returns>
+        [Test]
+        public async Task AutocompleteCoerceValueTest()
+        {
+            var comp = ctx.RenderComponent<AutocompleteTest1>();
+            Console.WriteLine(comp.Markup);
+            var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
+            var autocomplete = autocompletecomp.Instance;
+            autocompletecomp.SetParam(x => x.DebounceInterval, 0);
+            autocompletecomp.SetParam(x => x.CoerceValue, true); // if CoerceValue==true CoerceText will be ignored
+            // check initial state
+            autocomplete.Value.Should().Be("Alabama");
+            autocomplete.Text.Should().Be("Alabama");
+            // set a value the search won't find
+            autocompletecomp.SetParam(p=> p.Text, "Austria"); // not part of the U.S.
+
+            // now trigger the coercion by toggling the the menu (it won't even open for invalid values, but it will coerce)
+            await comp.InvokeAsync(() => autocomplete.ToggleMenu());
+            comp.WaitForAssertion(() => autocomplete.Value.Should().Be("Austria"));
+            autocomplete.Text.Should().Be("Austria");
+        }
+
 
         [Test]
         public async Task AutocompleteCoercionOffTest()
@@ -168,8 +195,8 @@ namespace MudBlazor.UnitTests.Components
             autocomplete.Value.Should().Be("Alabama");
             autocomplete.Text.Should().Be("Alabama");
             // set a value the search won't find
-            autocompletecomp.SetParam(a => a.Text, "Austria");
             await comp.InvokeAsync(() => autocomplete.ToggleMenu());
+            autocompletecomp.SetParam(a => a.Text, "Austria");
             // now trigger the coercion by closing the menu
             await comp.InvokeAsync(() => autocomplete.ToggleMenu());
             autocomplete.Value.Should().Be("Alabama");

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -67,7 +67,6 @@ namespace MudBlazor
                 Converter = new Converter<T>
                 {
                     SetFunc = _toStringFunc ?? (x => x?.ToString()),
-                    //GetFunc = LookupValue,
                 };
             }
         }
@@ -117,6 +116,12 @@ namespace MudBlazor
         /// which list value is currently selected and disallows incomplete values in Text.
         /// </summary>
         [Parameter] public bool CoerceText { get; set; } = true;
+
+        /// <summary>
+        /// If user input is not found by the search func and CoerceValue is set to true the user input
+        /// will be applied to the Value which allows to validate it and display an error message.
+        /// </summary>
+        [Parameter] public bool CoerceValue { get; set; }
 
         internal bool IsOpen { get; set; }
 
@@ -228,6 +233,7 @@ namespace MudBlazor
 
             if (_items?.Length == 0)
             {
+                await CoerceValueToText();
                 IsOpen = false;
                 UpdateIcon();
                 StateHasChanged();
@@ -350,6 +356,15 @@ namespace MudBlazor
             }
         }
 
+        private async Task CoerceValueToText()
+        {
+            if (CoerceValue==false)
+                return;
+            _timer?.Dispose();
+            var value = Converter.Get(Text);
+            await SetValueAsync(value, updateText: false);
+        }
+
         protected override void Dispose(bool disposing)
         {
             _timer?.Dispose();
@@ -376,7 +391,6 @@ namespace MudBlazor
             if (text == null)
                 return;
             _ = SetTextAsync(text, true);
-
         }
     }
 }


### PR DESCRIPTION
If user input is not found by the search func and `CoerceValue` is set to true, the user input
will be applied to the `Value` which allows to validate it and display an error message.

Fixes #1448