### PR TITLE
Validation example for MudAutocomplete

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Autocomplete/AutocompletePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Autocomplete/AutocompletePage.razor
@@ -16,7 +16,9 @@
                 <Title>Usage</Title>
                 <Description>
                     How you write the search function determines whether or not the Autocomplete shows a full list initially. By setting <CodeInline>ResetValueOnEmptyText="true"</CodeInline>
-                    the value will be reset when the user clears the input text. Otherwise, the value is kept and the text coerced to the current value.
+                    the <CodeInline>Value</CodeInline> will be reset when the user clears the input text. With <CodeInline>CoerceText="true"</CodeInline> upon selection of an entry from the list, 
+                    the <CodeInline>Text</CodeInline> is always updated. When the user types something that is not on the list and <CodeInline>CoerceValue</CodeInline> is true,
+                    the <CodeInline>Value</CodeInline> will be overwritten with the user input which allows it to be passed to the validation function.
                 </Description>
             </SectionHeader>
             <SectionContent Outlined="true" DisplayFlex="true">
@@ -39,6 +41,20 @@
                 <AutocompleteClrObjectsExample />
             </SectionContent>
             <SectionSource ShowCode="false" Code="AutocompleteClrObjectsExample" GitHubFolderName="Autocomplete" />
+        </DocsPageSection>
+
+		<DocsPageSection>
+            <SectionHeader>
+                <Title>Validation</Title>
+                <Description>
+                    Below there are different examples of validation with the MudAutocomplete control. The validation uses an EditForm or a MudForm. The result and display will vary if the 
+                    <CodeInline Tag="true">CoerceValue</CodeInline> option is set to <CodeInline Tag="true">true</CodeInline>. But also if characters are typed into the control instead of a selection from the dropdown list.
+                </Description>
+            </SectionHeader>
+            <SectionContent Outlined="true" DisplayFlex="true">
+                <AutocompleteValidationExample />
+            </SectionContent>
+            <SectionSource ShowCode="false" Code="AutocompleteValidationExample" GitHubFolderName="Autocomplete" />
         </DocsPageSection>
 
     </DocsPageContent>

--- a/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompleteValidationExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompleteValidationExample.razor
@@ -1,0 +1,171 @@
+﻿@namespace MudBlazor.Docs.Examples
+@using System.ComponentModel.DataAnnotations
+
+<MudGrid>
+    <MudItem xs="12" sm="6" md="4">
+        <EditForm EditContext="editContext1">
+        <DataAnnotationsValidator />
+            <MudAutocomplete Label="US States" @bind-Value="choice1.State" 
+             SearchFunc="@SearchAsync" Immediate="true" CoerceValue="@coerceValue"
+             For="@(() => choice1.State)"/>
+            <MudButton ButtonType="ButtonType.Button" Variant="Variant.Filled" Color="Color.Primary" 
+             Class="ml-auto mt-3 mb-3" OnClick="@(()=>success1=editContext1.Validate())">Validate</MudButton>
+            <MudExpansionPanels>
+                <MudExpansionPanel Text="@($"Show Errors or Success")">
+                   @if (success1)
+                   {
+                       <MudText Color="Color.Success">Success</MudText>
+                   }
+                   else
+                   {
+                       <MudText Color="@Color.Error">
+                           <ValidationSummary />
+                       </MudText>
+                   }
+                </MudExpansionPanel>
+            </MudExpansionPanels>
+       </EditForm>
+    </MudItem>
+    <MudItem xs="12" sm="6" md="4">
+        <EditForm EditContext="editContext2">
+        <DataAnnotationsValidator />
+            <MudAutocomplete Label="US States" @bind-Value="choice2.State" 
+             SearchFunc="@SearchAsync" Immediate="true" CoerceValue="@coerceValue"
+             Validation="@(new Func<string, IEnumerable<string>>(Validate))" />
+            <MudButton ButtonType="ButtonType.Button" Variant="Variant.Filled" Color="Color.Primary" 
+             Class="ml-auto mt-3 mb-3" OnClick="@(()=>success2=editContext2.Validate())">Validate</MudButton>
+            <MudExpansionPanels>
+                <MudExpansionPanel Text="@($"Show Errors or Success")">
+                   @if (success2)
+                   {
+                       <MudText Color="Color.Success">Success</MudText>
+                   }
+                   else
+                   {
+                       <MudText Color="@Color.Error">
+                           <ValidationSummary />
+                       </MudText>
+                   }
+                </MudExpansionPanel>
+            </MudExpansionPanels>
+       </EditForm>
+    </MudItem>
+    <MudItem xs="12" sm="6" md="4">
+        <MudForm @ref="form" @bind-Errors="@errors">
+            <MudAutocomplete T="string" Label="US States" @bind-Value="choice3.State" 
+             SearchFunc="@SearchAsync" Immediate="true" CoerceValue="@coerceValue"
+             Validation="@(new Func<string, IEnumerable<string>>(Validate))" />
+            <MudButton Variant="Variant.Filled" Color="Color.Primary" Class="ml-auto mt-3 mb-3" 
+             OnClick="@(()=>form.Validate())">Validate</MudButton>
+            <MudExpansionPanels>
+                <MudExpansionPanel Text="@($"Show Errors or Success")">
+                    @if (errors.Length == 0)
+                    {
+                        <MudText Color="Color.Success">Success</MudText>
+                    }
+                    else
+                    {
+                        @foreach (var error in errors)
+                        {
+                            <MudText Color="@Color.Error">@error</MudText>
+                        }
+                    }
+                </MudExpansionPanel>
+            </MudExpansionPanels>
+        </MudForm>
+	</MudItem>
+    <MudItem xs="12" md="12">
+        <MudText Class="mb-n3" Typo="Typo.body2">
+            <MudChip>@(choice1.State ?? "Not selected")</MudChip><MudChip>@(choice2.State ?? "Not selected")</MudChip><MudChip>@(choice3.State ?? "Not selected")</MudChip>
+        </MudText>
+    </MudItem>
+    <MudItem xs="12" md="12" class="flex-column">
+        <MudSwitch @bind-Checked="coerceValue" Color="Color.Tertiary">Coerce Value to Text (if not found)</MudSwitch>
+    </MudItem>
+</MudGrid>
+
+@code {
+    private string[] errors = { };
+    private MudForm form;
+    private bool coerceValue;
+    private bool success1;
+    private bool success2;
+    private Choice choice1 = new();
+    private Choice choice2 = new();
+    private Choice choice3 = new();
+    private EditContext editContext1;
+    private EditContext editContext2;
+
+    protected override void OnInitialized()
+    {
+        editContext1 = new EditContext(choice1);
+        editContext2 = new EditContext(choice2);
+    } 
+
+    private static string[] states =
+    {
+        "Alabama", "Alaska", "American Samoa", "Arizona",
+        "Arkansas", "California", "Colorado", "Connecticut",
+        "Delaware", "District of Columbia", "Federated States of Micronesia",
+        "Florida", "Georgia", "Guam", "Hawaii", "Idaho",
+        "Illinois", "Indiana", "Iowa", "Kansas", "Kentucky",
+        "Louisiana", "Maine", "Marshall Islands", "Maryland",
+        "Massachusetts", "Michigan", "Minnesota", "Mississippi",
+        "Missouri", "Montana", "Nebraska", "Nevada",
+        "New Hampshire", "New Jersey", "New Mexico", "New York",
+        "North Carolina", "North Dakota", "Northern Mariana Islands", "Ohio",
+        "Oklahoma", "Oregon", "Palau", "Pennsylvania", "Puerto Rico",
+        "Rhode Island", "South Carolina", "South Dakota", "Tennessee",
+        "Texas", "Utah", "Vermont", "Virgin Island", "Virginia",
+        "Washington", "West Virginia", "Wisconsin", "Wyoming",
+    };
+
+    private async Task<IEnumerable<string>> SearchAsync(string value)
+    {
+        // In real life use an asynchronous function for fetching data from an api.
+        await Task.Delay(5);
+
+        // if text is null or empty, show complete list
+        if (string.IsNullOrEmpty(value))
+        {
+            return states;
+        }
+
+        return states.Where(x => x.Contains(value, StringComparison.InvariantCultureIgnoreCase));
+    }
+
+    private IEnumerable<string> Validate(string value)
+    {        
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            yield return "The State field is required";
+            yield break;
+        }
+
+        if (!states.Contains(value))
+        {
+            yield return "This is an incorrect value";
+        }
+    }
+
+    public class Choice
+    {
+        [Required]
+        [State]
+        public string State { get; set;}
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter)]
+    public sealed class StateAttribute : ValidationAttribute
+    {
+        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+        {
+            if (!states.Contains(value))
+            {
+                return new ValidationResult("This is an incorrect value", new[] { validationContext.MemberName });
+            }
+
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Validation example in the official documentation for the [MudAutocomplete - Validation](https://github.com/Garderoben/MudBlazor/issues/1448).
PS : The _AutocompletePage.razor_ file is an update from the same file in the _Autocomplete: added CoerceValue parameter_ PR.
