### PR TITLE
Cancel button addition in inline editing for MudTable

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableInlineEditExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableInlineEditExample.razor
@@ -5,7 +5,7 @@
 @inject ISnackbar Snackbar
 
 <MudTable Items="@Elements" Dense="@dense" Hover="@hover" ReadOnly="@ronly" CanCancelEdit="@canCancelEdit" Filter="new Func<Element,bool>(FilterFunc)" @bind-SelectedItem="selectedItem" SortLabel="Sort By" 
- CommitEditTooltip="Commit Edit" OnCommitEditClick="@(() => Snackbar.Add("Commit Edit Handler Invoked"))" BeforeInlineEdit="BackupItem" CancelInlineEdit="ResetItemToOriginalValues">
+ CommitEditTooltip="Commit Edit" OnCommitEditClick="@(() => Snackbar.Add("Commit Edit Handler Invoked"))" RowEditPreview="BackupItem" RowEditCancel="ResetItemToOriginalValues" RowEditCommit="ItemHasBeenCommitted">
     <ToolBarContent>
         <MudText Typo="Typo.h6">Periodic Elements</MudText>
         <MudToolBarSpacer />
@@ -57,8 +57,22 @@
 <MudSwitch @bind-Checked="@ronly" Color="Color.Tertiary">Read Only</MudSwitch>
 <MudSwitch @bind-Checked="@canCancelEdit" Color="Color.Info">Can Cancel Edit</MudSwitch>
 <MudText Inline="true">Selected: @selectedItem?.Name</MudText>
+<div style="display: flex;">
+    <div style="width: 15em;">
+        <MudButton ButtonType="ButtonType.Button" Variant="Variant.Filled" OnClick="ClearEditionEvents">Clear Edition events</MudButton>
+    </div>
+    <MudExpansionPanels Style="flex: 1;">
+        <MudExpansionPanel Text="Show Edition events">
+            @foreach (var editionEvent in editionEvents)
+            {
+                <MudText>@editionEvent</MudText>
+            }
+        </MudExpansionPanel>
+    </MudExpansionPanels>
+</div>
 
 @code {
+    private List<string> editionEvents = new();
     private bool dense = false;
     private bool hover = true;
     private bool ronly = false;
@@ -75,6 +89,17 @@
         Elements = await httpClient.GetFromJsonAsync<List<Element>>("webapi/periodictable");
     }
 
+    private void ClearEditionEvents()
+    {
+        editionEvents.Clear();
+    }
+
+    private void AddEditionEvent(string editionEvent)
+    {
+        editionEvents.Add(editionEvent);
+        StateHasChanged();
+    }
+
     private void BackupItem(object element)
     {
         elementBeforeEdition = new()
@@ -84,6 +109,12 @@
             Molar = ((Element)element).Molar,
             Position = ((Element)element).Position
         };
+        AddEditionEvent($"Backup of Element {((Element)element).Name} has been made (RowEditPreview event)");
+    }
+
+    private void ItemHasBeenCommitted(object element)
+    {
+        AddEditionEvent($"Edition of Element {((Element)element).Name} has been commited (RowEditCommit event)");
     }
 
     private void ResetItemToOriginalValues(object element)
@@ -92,6 +123,7 @@
         ((Element)element).Name = elementBeforeEdition.Name;
         ((Element)element).Molar = elementBeforeEdition.Molar;
         ((Element)element).Position = elementBeforeEdition.Position;
+        AddEditionEvent($"Edition of Element {((Element)element).Name} has been cancelled (RowEditCancel event)");
     }
 
     private bool FilterFunc(Element element)

--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableInlineEditExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableInlineEditExample.razor
@@ -4,7 +4,8 @@
 @inject HttpClient httpClient
 @inject ISnackbar Snackbar
 
-<MudTable Items="@Elements" Dense="@dense" Hover="@hover" ReadOnly="@ronly" Filter="new Func<Element,bool>(FilterFunc)" @bind-SelectedItem="selectedItem" SortLabel="Sort By" CommitEditTooltip="Commit Edit" OnCommitEditClick="@(() => Snackbar.Add("Commit Edit Handler Invoked"))">
+<MudTable Items="@Elements" Dense="@dense" Hover="@hover" ReadOnly="@ronly" CanCancelEdit="@canCancelEdit" Filter="new Func<Element,bool>(FilterFunc)" @bind-SelectedItem="selectedItem" SortLabel="Sort By" 
+ CommitEditTooltip="Commit Edit" OnCommitEditClick="@(() => Snackbar.Add("Commit Edit Handler Invoked"))" BeforeInlineEdit="BackupItem" CancelInlineEdit="ResetItemToOriginalValues">
     <ToolBarContent>
         <MudText Typo="Typo.h6">Periodic Elements</MudText>
         <MudToolBarSpacer />
@@ -54,14 +55,17 @@
 <MudSwitch @bind-Checked="@hover" Color="Color.Primary">Hover</MudSwitch>
 <MudSwitch @bind-Checked="@dense" Color="Color.Secondary">Dense</MudSwitch>
 <MudSwitch @bind-Checked="@ronly" Color="Color.Tertiary">Read Only</MudSwitch>
+<MudSwitch @bind-Checked="@canCancelEdit" Color="Color.Info">Can Cancel Edit</MudSwitch>
 <MudText Inline="true">Selected: @selectedItem?.Name</MudText>
 
 @code {
     private bool dense = false;
     private bool hover = true;
     private bool ronly = false;
+    private bool canCancelEdit = false;
     private string searchString = "";
     private Element selectedItem = null;
+    private Element elementBeforeEdition;
     private HashSet<Element> selectedItems = new HashSet<Element>();
 
     private IEnumerable<Element> Elements = new List<Element>();
@@ -69,7 +73,26 @@
     protected override async Task OnInitializedAsync()
     {
         Elements = await httpClient.GetFromJsonAsync<List<Element>>("webapi/periodictable");
-    } 
+    }
+
+    private void BackupItem(object element)
+    {
+        elementBeforeEdition = new()
+        {            
+            Sign = ((Element)element).Sign,
+            Name = ((Element)element).Name,
+            Molar = ((Element)element).Molar,
+            Position = ((Element)element).Position
+        };
+    }
+
+    private void ResetItemToOriginalValues(object element)
+    {
+        ((Element)element).Sign = elementBeforeEdition.Sign;
+        ((Element)element).Name = elementBeforeEdition.Name;
+        ((Element)element).Molar = elementBeforeEdition.Molar;
+        ((Element)element).Position = elementBeforeEdition.Position;
+    }
 
     private bool FilterFunc(Element element)
     {

--- a/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
@@ -93,7 +93,7 @@
                 <Title>Inline Edit Mode</Title>
                 <Description>
                     Provides input elements for Selected Row. A click on a row makes the row editable.
-                    A Cancel button appears and can be used if <CodeInline>CanCancelEdit="true"</CodeInline>. In this case, the <CodeInline>BeforeInlineEdit</CodeInline> and <CodeInline>CancelInlineEdit</CodeInline> methods must be defined to save and retrieve the initial values of the edited item.
+                    A Cancel button appears and can be used if <CodeInline>CanCancelEdit="true"</CodeInline>. In this case, the <CodeInline>RowEditPreview</CodeInline> and <CodeInline>RowEditCancel</CodeInline> methods must be defined to save and retrieve the initial values of the edited item. <CodeInline>RowEditCommit</CodeInline> method can be used to handle the commit of the item.
                 </Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" FullWidth="true">

--- a/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
@@ -92,7 +92,8 @@
             <SectionHeader>
                 <Title>Inline Edit Mode</Title>
                 <Description>
-                    Provides input elements for Selected Row.
+                    Provides input elements for Selected Row. A click on a row makes the row editable.
+                    A Cancel button appears and can be used if <CodeInline>CanCancelEdit="true"</CodeInline>. In this case, the <CodeInline>BeforeInlineEdit</CodeInline> and <CodeInline>CancelInlineEdit</CodeInline> methods must be defined to save and retrieve the initial values of the edited item.
                 </Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" FullWidth="true">

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableInlineEditCancelTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableInlineEditCancelTest.razor
@@ -1,0 +1,46 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudTable @ref="_table" T="Element" Items="items" @bind-SelectedItem="selectedItem" 
+ RowEditPreview="BackupItem" RowEditCancel="ResetItemToOriginalValues" CanCancelEdit="true">
+    <HeaderContent>
+        <MudTh>Value</MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd>@context.Value</MudTd>
+    </RowTemplate>
+    <RowEditingTemplate>
+        <MudTd>
+            <MudTextField id="@context.Id" @bind-Value="@context.Value"></MudTextField>
+        </MudTd>
+    </RowEditingTemplate>
+</MudTable>
+
+@code {
+    private Element elementBeforeEdition = new();
+    MudTable<Element> _table;
+    private Element selectedItem = null;
+    List<Element> items = new List<Element> 
+    { 
+        new Element { Value = "A", Id = "Id1" }, 
+        new Element { Value = "B", Id = "Id2" }, 
+        new Element { Value = "C", Id = "Id3" }, 
+    };
+
+    public MudTable<Element> Table => _table;
+
+    private void BackupItem(object element)
+    {
+        elementBeforeEdition.Value = ((Element)element).Value;
+    }
+
+    private void ResetItemToOriginalValues(object element)
+    {
+        ((Element)element).Value = elementBeforeEdition.Value;
+    }
+
+    public class Element
+    {
+        public string Id { get; set; }
+        public string Value { get; set; }
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -676,5 +676,44 @@ namespace MudBlazor.UnitTests.Components
             }
             validator.ControlCount.Should().Be(2);
         }
+
+        /// <summary>
+        /// This test validates the processing of the Commit and Cancel buttons for an inline editing table.
+        /// </summary>
+        [Test]
+        public async Task TableInlineEditCancelTest()
+        {
+            var comp = ctx.RenderComponent<TableInlineEditCancelTest>();
+            
+            // Check that the value in the second row is equal to 'B'
+            comp.FindAll("td")[2].TextContent.Trim().Should().Be("B");
+
+            // Click on the second row
+            var trs = comp.FindAll("tr");
+            trs[2].Click();
+
+            // Find the textfield and change the value to 'C'
+            comp.Find("#Id2").Change("C");
+
+            // Click the commit button
+            var commitButton = comp.Find("button");
+            commitButton.Click();
+
+            // Value in the second row should be now equal to 'C'
+            comp.FindAll("td")[2].TextContent.Trim().Should().Be("C");
+
+            // Click on the second row
+            trs[2].Click();
+
+            // Find the textfield and change the value to 'D'
+            comp.Find("#Id2").Change("D");
+
+            // Click the cancel button
+            var cancelButton = comp.FindAll("button")[1];
+            cancelButton.Click();
+
+            // Value in the second row should still be equal to 'C'
+            comp.FindAll("td")[2].TextContent.Trim().Should().Be("C");
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -684,7 +684,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task TableInlineEditCancelTest()
         {
             var comp = ctx.RenderComponent<TableInlineEditCancelTest>();
-            
+
             // Check that the value in the second row is equal to 'B'
             comp.FindAll("td")[2].TextContent.Trim().Should().Be("B");
 

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -200,9 +200,14 @@ namespace MudBlazor
         [Parameter] public bool ReadOnly { get; set; } = false;
 
         /// <summary>
-        /// Button click event.
+        /// Button commit edit click event.
         /// </summary>
         [Parameter] public EventCallback<MouseEventArgs> OnCommitEditClick { get; set; }
+
+        /// <summary>
+        /// Button cancel edit click event.
+        /// </summary>
+        [Parameter] public EventCallback<MouseEventArgs> OnCancelEditClick { get; set; }
 
         /// <summary>
         /// Command executed when the user clicks on the CommitEdit Button.
@@ -218,6 +223,11 @@ namespace MudBlazor
         /// Tooltip for the CommitEdit Button.
         /// </summary>
         [Parameter] public string CommitEditTooltip { get; set; }
+
+        /// <summary>
+        /// Tooltip for the CancelEdit Button.
+        /// </summary>
+        [Parameter] public string CancelEditTooltip { get; set; }
 
         /// <summary>
         /// Number of items. Used only with ServerData="true"
@@ -300,6 +310,11 @@ namespace MudBlazor
                     parameter = item;
                 CommitEditCommand.Execute(parameter);
             }
+        }
+
+        internal async Task OnCancelEditHandler(MouseEventArgs ev)
+        {
+            await OnCancelEditClick.InvokeAsync(ev);
         }
 
         protected string TableStyle

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -247,12 +247,17 @@ namespace MudBlazor
         /// <summary>
         /// The method is called before the item is modified in inline editing.
         /// </summary>
-        [Parameter] public Action<object> BeforeInlineEdit { get; set; }
+        [Parameter] public Action<object> RowEditPreview { get; set; }
+
+        /// <summary>
+        /// The method is called when the edition of the item has been commited in inline editing.
+        /// </summary>
+        [Parameter] public Action<object> RowEditCommit { get; set; }
 
         /// <summary>
         /// The method is called when the edition of the item has been canceled in inline editing.
         /// </summary>
-        [Parameter] public Action<object> CancelInlineEdit { get; set; }
+        [Parameter] public Action<object> RowEditCancel { get; set; }
 
         /// <summary>
         /// Number of items. Used only with ServerData="true"

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -230,6 +230,16 @@ namespace MudBlazor
         [Parameter] public string CancelEditTooltip { get; set; }
 
         /// <summary>
+        /// Sets the Icon of the CommitEdit Button.
+        /// </summary>
+        [Parameter] public string CommitEditIcon { get; set; } = Icons.Material.Filled.Done;
+
+        /// <summary>
+        /// Sets the Icon of the CancelEdit Button.
+        /// </summary>
+        [Parameter] public string CancelEditIcon { get; set; } = Icons.Material.Filled.Cancel;
+
+        /// <summary>
         /// Number of items. Used only with ServerData="true"
         /// </summary>
         [Parameter] public int TotalItems { get; set; }

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -240,6 +240,21 @@ namespace MudBlazor
         [Parameter] public string CancelEditIcon { get; set; } = Icons.Material.Filled.Cancel;
 
         /// <summary>
+        /// Define if Cancel button is present or not for inline editing.
+        /// </summary>
+        [Parameter] public bool CanCancelEdit { get; set; }
+
+        /// <summary>
+        /// The method is called before the item is modified in inline editing.
+        /// </summary>
+        [Parameter] public Action<object> BeforeInlineEdit { get; set; }
+
+        /// <summary>
+        /// The method is called when the edition of the item has been canceled in inline editing.
+        /// </summary>
+        [Parameter] public Action<object> CancelInlineEdit { get; set; }
+
+        /// <summary>
         /// Number of items. Used only with ServerData="true"
         /// </summary>
         [Parameter] public int TotalItems { get; set; }

--- a/src/MudBlazor/Components/Table/MudTr.razor
+++ b/src/MudBlazor/Components/Table/MudTr.razor
@@ -36,7 +36,10 @@
                 @if (object.ReferenceEquals(Context?.Table._editingItem, Item) && (!Context?.Table.ReadOnly ?? false))
                 {
                     <MudTooltip Text="@Context.Table.CommitEditTooltip">
-                        <MudIconButton Class="pa-0" Icon="@Icons.Material.Filled.Done" OnClick="FinishEdit" Size="@Size.Small" Disabled="@(!Context?.Table.Validator?.IsValid ?? false)" />
+                        <MudIconButton Class="pa-0" Icon="@CommitEditIcon" OnClick="FinishEdit" Size="@Size.Small" Disabled="@(!Context?.Table.Validator?.IsValid ?? false)" />
+                    </MudTooltip>
+					<MudTooltip Text="@Context.Table.CancelEditTooltip">
+                        <MudIconButton Class="pa-0" Icon="@CancelEditIcon" OnClick="CancelEdit" Size="@Size.Small" />
                     </MudTooltip>
                 }
             </MudTd>

--- a/src/MudBlazor/Components/Table/MudTr.razor
+++ b/src/MudBlazor/Components/Table/MudTr.razor
@@ -39,9 +39,12 @@
                         <MudTooltip Text="@Context.Table.CommitEditTooltip">
                             <MudIconButton Class="pa-0" Icon="@Context.Table.CommitEditIcon" OnClick="FinishEdit" Size="@Size.Small" Disabled="@(!Context?.Table.Validator?.IsValid ?? false)" />
                         </MudTooltip>
-                        <MudTooltip Text="@Context.Table.CancelEditTooltip">
-                            <MudIconButton Class="pa-0 ml-4" Icon="@Context.Table.CancelEditIcon" OnClick="CancelEdit" Size="@Size.Small" />
-                        </MudTooltip>
+                        @if (Context.Table.CanCancelEdit)
+                        {
+                            <MudTooltip Text="@Context.Table.CancelEditTooltip">
+                                <MudIconButton Class="pa-0 ml-4" Icon="@Context.Table.CancelEditIcon" OnClick="CancelEdit" Size="@Size.Small" />
+                            </MudTooltip>
+                        }
                     </div>
                 }
             </MudTd>

--- a/src/MudBlazor/Components/Table/MudTr.razor
+++ b/src/MudBlazor/Components/Table/MudTr.razor
@@ -35,14 +35,14 @@
             <MudTd DataLabel="&nbsp;">
                 @if (object.ReferenceEquals(Context?.Table._editingItem, Item) && (!Context?.Table.ReadOnly ?? false))
                 {
-					<div style="display: flex;">
+                    <div style="display: flex;">
                         <MudTooltip Text="@Context.Table.CommitEditTooltip">
                             <MudIconButton Class="pa-0" Icon="@Context.Table.CommitEditIcon" OnClick="FinishEdit" Size="@Size.Small" Disabled="@(!Context?.Table.Validator?.IsValid ?? false)" />
                         </MudTooltip>
-					    <MudTooltip Text="@Context.Table.CancelEditTooltip">
+                        <MudTooltip Text="@Context.Table.CancelEditTooltip">
                             <MudIconButton Class="pa-0 ml-4" Icon="@Context.Table.CancelEditIcon" OnClick="CancelEdit" Size="@Size.Small" />
                         </MudTooltip>
-					</div>
+                    </div>
                 }
             </MudTd>
         }

--- a/src/MudBlazor/Components/Table/MudTr.razor
+++ b/src/MudBlazor/Components/Table/MudTr.razor
@@ -35,12 +35,14 @@
             <MudTd DataLabel="&nbsp;">
                 @if (object.ReferenceEquals(Context?.Table._editingItem, Item) && (!Context?.Table.ReadOnly ?? false))
                 {
-                    <MudTooltip Text="@Context.Table.CommitEditTooltip">
-                        <MudIconButton Class="pa-0" Icon="@Context.Table.CommitEditIcon" OnClick="FinishEdit" Size="@Size.Small" Disabled="@(!Context?.Table.Validator?.IsValid ?? false)" />
-                    </MudTooltip>
-					<MudTooltip Text="@Context.Table.CancelEditTooltip">
-                        <MudIconButton Class="pa-0" Icon="@Context.Table.CancelEditIcon" OnClick="CancelEdit" Size="@Size.Small" />
-                    </MudTooltip>
+					<div style="display: flex;">
+                        <MudTooltip Text="@Context.Table.CommitEditTooltip">
+                            <MudIconButton Class="pa-0" Icon="@Context.Table.CommitEditIcon" OnClick="FinishEdit" Size="@Size.Small" Disabled="@(!Context?.Table.Validator?.IsValid ?? false)" />
+                        </MudTooltip>
+					    <MudTooltip Text="@Context.Table.CancelEditTooltip">
+                            <MudIconButton Class="pa-0 ml-4" Icon="@Context.Table.CancelEditIcon" OnClick="CancelEdit" Size="@Size.Small" />
+                        </MudTooltip>
+					</div>
                 }
             </MudTd>
         }

--- a/src/MudBlazor/Components/Table/MudTr.razor
+++ b/src/MudBlazor/Components/Table/MudTr.razor
@@ -36,10 +36,10 @@
                 @if (object.ReferenceEquals(Context?.Table._editingItem, Item) && (!Context?.Table.ReadOnly ?? false))
                 {
                     <MudTooltip Text="@Context.Table.CommitEditTooltip">
-                        <MudIconButton Class="pa-0" Icon="@CommitEditIcon" OnClick="FinishEdit" Size="@Size.Small" Disabled="@(!Context?.Table.Validator?.IsValid ?? false)" />
+                        <MudIconButton Class="pa-0" Icon="@Context.Table.CommitEditIcon" OnClick="FinishEdit" Size="@Size.Small" Disabled="@(!Context?.Table.Validator?.IsValid ?? false)" />
                     </MudTooltip>
 					<MudTooltip Text="@Context.Table.CancelEditTooltip">
-                        <MudIconButton Class="pa-0" Icon="@CancelEditIcon" OnClick="CancelEdit" Size="@Size.Small" />
+                        <MudIconButton Class="pa-0" Icon="@Context.Table.CancelEditIcon" OnClick="CancelEdit" Size="@Size.Small" />
                     </MudTooltip>
                 }
             </MudTd>

--- a/src/MudBlazor/Components/Table/MudTr.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTr.razor.cs
@@ -92,20 +92,23 @@ namespace MudBlazor
 
         private void FinishEdit(MouseEventArgs ev)
         {
-            _clickRowFirstTime = false;
             if (!Context?.Table.Validator.IsValid ?? true) return;
             Context?.Table.SetEditingItem(null);
             Context?.Table.OnCommitEditHandler(ev, Item);
+
+            // The item object has been edited
+            Context.Table.RowEditCommit?.Invoke(Item);
+            _clickRowFirstTime = false;
         }
 
         private void CancelEdit(MouseEventArgs ev)
         {
-            // The Item object is reset to its initial value from the Item Copy
-            CopyOriginalValues();
-
             // The edit mode is canceled
             Context?.Table.SetEditingItem(null);
             Context?.Table.OnCancelEditHandler(ev);
+
+            // The Item object is reset to its initial value from the Item Copy
+            CopyOriginalValues();
         }
 
         private void CopyOriginalValues()
@@ -114,12 +117,12 @@ namespace MudBlazor
             {
                 if (!_clickRowFirstTime)
                 {
-                    Context.Table.BeforeInlineEdit?.Invoke(Item);
+                    Context.Table.RowEditPreview?.Invoke(Item);
                     _clickRowFirstTime = true;
                 }
                 else
                 {
-                    Context.Table.CancelInlineEdit?.Invoke(Item);
+                    Context.Table.RowEditCancel?.Invoke(Item);
                     _clickRowFirstTime = false;
                 }
             }

--- a/src/MudBlazor/Components/Table/MudTr.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTr.razor.cs
@@ -12,16 +12,6 @@ namespace MudBlazor
 
         [CascadingParameter] public TableContext Context { get; set; }
 
-        /// <summary>
-        /// Sets the icon of the commit edit when editing
-        /// </summary>
-        [Parameter] public string CommitEditIcon { get; set; } = Icons.Material.Filled.Done;
-
-        /// <summary>
-        /// Sets the icon of the cancel button when editing
-        /// </summary>
-        [Parameter] public string CancelEditIcon { get; set; } = Icons.Material.Filled.Cancel;
-
         [Parameter] public RenderFragment ChildContent { get; set; }
 
         [Parameter] public object Item { get; set; }
@@ -31,7 +21,6 @@ namespace MudBlazor
         [Parameter] public bool IsEditable { get; set; }
 
         [Parameter] public bool IsHeader { get; set; }
-
         [Parameter] public bool IsFooter { get; set; }
 
         [Parameter]

--- a/src/MudBlazor/Components/Table/MudTr.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTr.razor.cs
@@ -12,6 +12,16 @@ namespace MudBlazor
 
         [CascadingParameter] public TableContext Context { get; set; }
 
+        /// <summary>
+        /// Sets the icon of the commit edit when editing
+        /// </summary>
+        [Parameter] public string CommitEditIcon { get; set; } = Icons.Material.Filled.Done;
+
+        /// <summary>
+        /// Sets the icon of the cancel button when editing
+        /// </summary>
+        [Parameter] public string CancelEditIcon { get; set; } = Icons.Material.Filled.Cancel;
+
         [Parameter] public RenderFragment ChildContent { get; set; }
 
         [Parameter] public object Item { get; set; }
@@ -21,6 +31,7 @@ namespace MudBlazor
         [Parameter] public bool IsEditable { get; set; }
 
         [Parameter] public bool IsHeader { get; set; }
+
         [Parameter] public bool IsFooter { get; set; }
 
         [Parameter]
@@ -83,6 +94,12 @@ namespace MudBlazor
             if (!Context?.Table.Validator.IsValid ?? true) return;
             Context?.Table.SetEditingItem(null);
             Context?.Table.OnCommitEditHandler(ev, Item);
+        }
+
+        private void CancelEdit(MouseEventArgs ev)
+        {
+            Context?.Table.SetEditingItem(null);
+            Context?.Table.OnCancelEditHandler(ev);
         }
     }
 }


### PR DESCRIPTION
Addition of a cancel button when the row is edited in a MudTable.
It is also possible to set the icon for the Cancel Edit button and for the Commit Edit button.
This should help for the [Table: Location of Cancel button in inline editing](https://github.com/Garderoben/MudBlazor/issues/679) issue.