### PR TITLE
Fixed string interpolation for elevation css

### DIFF
--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -34,7 +34,7 @@ namespace MudBlazor
            .AddClass("mud-table-square", Square)
            .AddClass("mud-table-sticky-header", FixedHeader)
            .AddClass("mud-table-sticky-footer", FixedFooter)
-           .AddClass("mud-elevation-{Elevation}", !Outlined)
+           .AddClass($"mud-elevation-{Elevation}", !Outlined)
           .AddClass(Class)
         .Build();
 


### PR DESCRIPTION
Maybe the smallest pull request ever, but there was a missing `$` in the elevation css builder for MudTable.