### PR TITLE
MudIconButton and MudToggleIconButton: Add the icon title

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/ToggleIconButton/Examples/ToggleIconButtonEventCallbackExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ToggleIconButton/Examples/ToggleIconButtonEventCallbackExample.razor
@@ -1,8 +1,8 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudToggleIconButton Toggled="@AlarmOn" ToggledChanged="OnToggledChanged"
-                     Icon="@Icons.Material.Filled.AlarmOff" Color="@Color.Error" 
-                     ToggledIcon="@Icons.Material.Filled.AlarmOn" ToggledColor="@Color.Success" />
+                     Icon="@Icons.Material.Filled.AlarmOff" Color="@Color.Error" Title="Off" 
+                     ToggledIcon="@Icons.Material.Filled.AlarmOn" ToggledColor="@Color.Success" ToggledTitle="On" />
 
 <span>Alarm is @(AlarmOn ? "On" : "Off")</span>
 <span>@($"I have been switched on {SwitchedOnCount} times (Remaining: {MaxCount - SwitchedOnCount})")</span>

--- a/src/MudBlazor.Docs/Pages/Components/ToggleIconButton/Examples/ToggleIconButtonTwoWayBindingExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ToggleIconButton/Examples/ToggleIconButtonTwoWayBindingExample.razor
@@ -1,8 +1,8 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudToggleIconButton @bind-Toggled="@AlarmOn"
-                     Icon="@Icons.Material.Filled.AlarmOff" Color="@Color.Error"
-                     ToggledIcon="@Icons.Material.Filled.AlarmOn" ToggledColor="@Color.Success"/>
+                     Icon="@Icons.Material.Filled.AlarmOff" Color="@Color.Error" Title="Off"
+                     ToggledIcon="@Icons.Material.Filled.AlarmOn" ToggledColor="@Color.Success" ToggledTitle="On"/>
 
 <span>Alarm is @(AlarmOn ? "On" : "Off")</span>
 

--- a/src/MudBlazor.UnitTests/Components/ButtonsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ButtonsTests.cs
@@ -1,6 +1,7 @@
 ﻿#pragma warning disable CS1998 // async without await
 #pragma warning disable IDE1006 // leading underscore
 
+using Bunit;
 using FluentAssertions;
 using NUnit.Framework;
 using static Bunit.ComponentParameterFactory;
@@ -174,6 +175,25 @@ namespace MudBlazor.UnitTests.Components
             comp.Markup
                 .Should()
                 .NotContainAny("mud-icon-root");
+        }
+
+        /// <summary>
+        /// MudIconButton should have a title tag/attribute if specified
+        /// </summary>
+        [Test]
+        public void ShouldRenderTitle()
+        {
+            var title = "Title and tooltip";
+            var icon = Parameter(nameof(MudIconButton.Icon), Icons.Filled.Add);
+            var titleParam = Parameter(nameof(MudIconButton.Title), title);
+            var comp = ctx.RenderComponent<MudIconButton>(icon, titleParam);
+            comp.Find("svg Title").TextContent.Should().Be(title);
+
+            icon = Parameter(nameof(MudIconButton.Icon), "customicon");
+            comp.SetParametersAndRender(icon, titleParam);
+            comp.Find("button span.mud-icon-button-label").InnerHtml.Trim().Should().StartWith("<span")
+                .And.Contain("customicon")
+                .And.Contain($"title=\"{title}\"");
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/IconTests.cs
+++ b/src/MudBlazor.UnitTests/Components/IconTests.cs
@@ -42,5 +42,26 @@ namespace MudBlazor.UnitTests.Components
                 .And.Contain("customicon")
                 .And.Contain($"style=\"{colorStyle}\"");
         }
+
+        /// <summary>
+        /// MudIcon should have a Title tag/attribute if specified
+        /// </summary>
+        [Test]
+        public void ShouldRenderTitle()
+        {
+            var title = "Title and tooltip";
+            //svg
+            var icon = Parameter(nameof(MudIcon.Icon), Icons.Filled.Add);
+            var titleParam = Parameter(nameof(MudIcon.Title), title);
+            var comp = ctx.RenderComponent<MudIcon>(icon, titleParam);
+            comp.Find("svg Title").TextContent.Should().Be(title);
+
+            //class
+            icon = Parameter(nameof(MudIcon.Icon), "customicon");
+            comp.SetParametersAndRender(icon, titleParam);
+            comp.Markup.Trim().Should().StartWith("<span")
+                .And.Contain("customicon")
+                .And.Contain($"title=\"{title}\"");
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/ToggleIconButtonTest.cs
+++ b/src/MudBlazor.UnitTests/Components/ToggleIconButtonTest.cs
@@ -6,6 +6,7 @@ using Bunit;
 using FluentAssertions;
 using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
+using static Bunit.ComponentParameterFactory;
 
 namespace MudBlazor.UnitTests.Components
 {
@@ -63,6 +64,26 @@ namespace MudBlazor.UnitTests.Components
             // make sure both buttons state changed
             comp1.Instance.Toggled.Should().BeTrue();
             comp2.Instance.Toggled.Should().BeTrue();
+        }
+
+        /// <summary>
+        /// MudToggledIconButton should change title if specified
+        /// </summary>
+        [Test]
+        public void ShouldRenderToggledTitle()
+        {
+            var title = "Title and tooltip";
+            var toggledTitle = "toggled!";
+            var icon = Parameter(nameof(MudToggleIconButton.Icon), Icons.Filled.Add);
+            var toggledIcon = Parameter(nameof(MudToggleIconButton.ToggledIcon), Icons.Filled.Remove);
+            var titleParam = Parameter(nameof(MudToggleIconButton.Title), title);
+            var toggledTitleParam = Parameter(nameof(MudToggleIconButton.ToggledTitle), toggledTitle);
+            var comp = ctx.RenderComponent<MudToggleIconButton>(icon, toggledIcon, titleParam, toggledTitleParam);
+            comp.Find("svg Title").TextContent.Should().Be(title);
+            comp.Find("button").Click();
+            comp.Find("svg Title").TextContent.Should().Be(toggledTitle);
+            comp.Find("button").Click();
+            comp.Find("svg Title").TextContent.Should().Be(title);
         }
     }
 }

--- a/src/MudBlazor/Components/Button/MudIconButton.razor
+++ b/src/MudBlazor/Components/Button/MudIconButton.razor
@@ -16,7 +16,7 @@
     @if (!String.IsNullOrEmpty(Icon))
     {
         <span class="mud-icon-button-label">
-            <MudIcon Icon="@Icon" Size="@Size" />
+            <MudIcon Icon="@Icon" Size="@Size" Title="@Title" />
         </span>
     }
     else

--- a/src/MudBlazor/Components/Button/MudIconButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudIconButton.razor.cs
@@ -21,6 +21,11 @@ namespace MudBlazor
         [Parameter] public string Icon { get; set; }
 
         /// <summary>
+        /// Title of the icon used for accessibility.
+        /// </summary>
+        [Parameter] public string Title { get; set; }
+
+        /// <summary>
         /// The color of the component. It supports the theme colors.
         /// </summary>
         [Parameter] public Color Color { get; set; } = Color.Default;

--- a/src/MudBlazor/Components/Button/MudToggleIconButton.razor
+++ b/src/MudBlazor/Components/Button/MudToggleIconButton.razor
@@ -4,6 +4,7 @@
 <MudIconButton Icon="@(Toggled ? ToggledIcon : Icon)"
                Size="@(Toggled ? ToggledSize : Size)"
                Color="@(Toggled ? ToggledColor : Color)"
+               Title="@(Toggled && ToggledTitle != null ? ToggledTitle : Title)"
                Disabled="@Disabled"
                Edge="@Edge"
                DisableRipple="@DisableRipple"

--- a/src/MudBlazor/Components/Button/MudToggleIconButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudToggleIconButton.razor.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 
 namespace MudBlazor
@@ -25,6 +24,16 @@ namespace MudBlazor
         /// The Icon that will be used in the toggled state.
         /// </summary>
         [Parameter] public string ToggledIcon { get; set; }
+
+        /// <summary>
+        /// Title of the icon used for accessibility.
+        /// </summary>
+        [Parameter] public string Title { get; set; }
+
+        /// <summary>
+        /// Title used in toggled state, if different.
+        /// </summary>
+        [Parameter] public string ToggledTitle { get; set; }
 
         /// <summary>
         /// The color of the icon in the untoggled state. It supports the theme colors.


### PR DESCRIPTION
The icon supports a "Title" parameter, used mainly for accessibility for screen reader and show a popup.
The icon buttons should implement that.
MudToggleIconButton allow to change the title based on its toggled state, the value is optional (it keeps the same if not specified)