### PR TITLE
Added IconDense option to ButtonGroup

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/ButtonGroup/ButtonGroupPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ButtonGroup/ButtonGroupPage.razor
@@ -39,7 +39,9 @@
         <DocsPageSection>
             <SectionHeader>
                 <Title>Icon buttons</Title>
-                <Description><CodeInline>MudButtonGroup</CodeInline> can also make use of <CodeInline>MudIconButton</CodeInline> and <CodeInline>MudToggleIconButton</CodeInline>.</Description>
+                <Description><CodeInline>MudButtonGroup</CodeInline> can also make use of <CodeInline>MudIconButton</CodeInline> and <CodeInline>MudToggleIconButton</CodeInline>.<br/>
+                If you want, you can reduce the margin inside the buttons using <CodeInline>IconDense="true"</CodeInline>
+                </Description>
             </SectionHeader>
             <SectionContent Outlined="true">
                 <ButtonGroupIconButtonExample />

--- a/src/MudBlazor.Docs/Pages/Components/ButtonGroup/Examples/ButtonGroupIconButtonExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ButtonGroup/Examples/ButtonGroupIconButtonExample.razor
@@ -1,9 +1,19 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-
+<MudContainer>
 <MudButtonGroup Color="Color.Primary" Variant="Variant.Outlined">
     <MudIconButton Icon="@Icons.Material.Filled.AccessAlarm"></MudIconButton>
     <MudToggleIconButton Icon="@Icons.Material.Filled.AlarmOff" Color="@Color.Error"
                          ToggledIcon="@Icons.Material.Filled.AlarmOn" ToggledColor="@Color.Success" />
     <MudButton StartIcon="@Icons.Material.Filled.AlarmAdd" IconColor="Color.Warning">Add alarm</MudButton>
 </MudButtonGroup>
+</MudContainer>
+
+<MudContainer>
+<MudButtonGroup Color="Color.Primary" Variant="Variant.Outlined" IconDense="true">
+    <MudIconButton Icon="@Icons.Material.Filled.AccessAlarm"></MudIconButton>
+    <MudToggleIconButton Icon="@Icons.Material.Filled.AlarmOff" Color="@Color.Error"
+                         ToggledIcon="@Icons.Material.Filled.AlarmOn" ToggledColor="@Color.Success" />
+    <MudButton StartIcon="@Icons.Material.Filled.AlarmAdd" IconColor="Color.Warning">Add alarm</MudButton>
+</MudButtonGroup>
+</MudContainer>

--- a/src/MudBlazor.Docs/Pages/Components/ButtonGroup/Examples/ButtonGroupSplitButtonExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ButtonGroup/Examples/ButtonGroupSplitButtonExample.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudButtonGroup Color="Color.Primary" Variant="Variant.Outlined">
+<MudButtonGroup Color="Color.Primary" Variant="Variant.Outlined" IconDense="true">
     <MudButton>@_buttonText</MudButton>
     <MudMenu Icon="@Icons.Material.Filled.ArrowDropDown" Direction="Direction.Bottom" OffsetY="true">
         <MudMenuItem OnClick="() => SetButtonText(0)">Reply</MudMenuItem>

--- a/src/MudBlazor/Components/ButtonGroup/MudButtonGroup.razor.cs
+++ b/src/MudBlazor/Components/ButtonGroup/MudButtonGroup.razor.cs
@@ -16,6 +16,7 @@ namespace MudBlazor
           .AddClass($"mud-button-group-horizontal", !VerticalAlign)
           .AddClass($"mud-button-group-disable-elevation", DisableElevation)
           .AddClass($"mud-button-group-rtl", RightToLeft)
+          .AddClass($"mud-button-group-icon-dense", IconDense)
           .AddClass(Class)
         .Build();
 
@@ -56,5 +57,10 @@ namespace MudBlazor
         /// The variant to use.
         /// </summary>
         [Parameter] public Variant Variant { get; set; } = Variant.Text;
+
+        /// <summary>
+        /// Reduces MudIconButton and MudToggleIconButton horizontal padding.
+        /// </summary>
+        [Parameter] public bool IconDense { get; set; }
     }
 }

--- a/src/MudBlazor/Styles/components/_buttongroup.scss
+++ b/src/MudBlazor/Styles/components/_buttongroup.scss
@@ -12,6 +12,7 @@
         .mud-button {
             color: var(--mud-palette-text-primary);
         }
+
         .mud-button-root {
             background-color: inherit;
             box-shadow: none;
@@ -23,6 +24,7 @@
         }
     }
 }
+
 .mud-button-group-horizontal {
     &:not(.mud-button-group-rtl) {
         > .mud-button-root:not(:last-child), :not(:last-child) .mud-button-root {
@@ -53,6 +55,7 @@
 
 .mud-button-group-vertical {
     flex-direction: column;
+
     .mud-icon-button {
         width: 100%;
     }
@@ -172,7 +175,7 @@
             &.mud-button-group-filled-#{$color} {
                 .mud-button-root {
                     background-color: var(--mud-palette-#{$color});
-                    color: var(--mud-palette-#{$color}-text);             
+                    color: var(--mud-palette-#{$color}-text);
 
                     &:hover {
                         background-color: var(--mud-palette-#{$color}-darken);
@@ -299,5 +302,35 @@
                 transition: 0s;
             }
         }
+    }
+}
+
+.mud-button-group-root.mud-button-group-icon-dense {
+    & .mud-icon-button {
+        padding: 5px;
+    }
+
+    &.mud-button-group-text-size-small .mud-icon-button {
+        padding: 4px;
+    }
+
+    &.mud-button-group-filled-size-small .mud-icon-button {
+        padding: 4px;
+    }
+
+    &.mud-button-group-text-size-large .mud-icon-button {
+        padding: 8px;
+    }
+
+    &.mud-button-group-filled-size-large .mud-icon-button {
+        padding: 8px;
+    }
+
+    &.mud-button-group-outlined-size-small .mud-icon-button {
+        padding: 3px;
+    }
+
+    &.mud-button-group-outlined-size-large .mud-icon-button {
+        padding: 7px;
     }
 }


### PR DESCRIPTION
As described in #1645 MudButtonGroup can have too much undesired white space.
Added `IconDense` that would apply the same padding on height and width for IconButton (and ToggleIconButton).

![image](https://user-images.githubusercontent.com/14835013/119744574-9afe7b80-be8c-11eb-9cb0-7777962a1621.png)

It's best use is for a Split Button: 
![image](https://user-images.githubusercontent.com/14835013/119744356-1e6b9d00-be8c-11eb-9f3c-a089be72ee33.png)


Waiting for confirm to add a similar option to a standalone IconButton, active only for `Variant.Text`.