### PR TITLE
LineChart: Added MaxNumYAxisTicks to limit the Nr of horizontal grid lines

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Charts/LineChartWithBigValuesTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Charts/LineChartWithBigValuesTest.razor
@@ -1,0 +1,16 @@
+﻿<div>
+    <MudChart ChartType="ChartType.Line" ChartSeries="@Series" @bind-SelectedIndex="Index" XAxisLabels="@XAxisLabels" Width="100%" Height="350px"></MudChart>
+</div>
+
+@code {
+    public static string __description__ = "Number of horizontal tick lines should be limited to sane values.";
+
+    private int Index = -1; //default value cannot be 0 -> first selectedindex is 0.
+
+    public List<ChartSeries> Series = new List<ChartSeries>()
+    {
+        new ChartSeries() { Name = "Series 1", Data = new double[] { 112368124, 114457907, 108509186, 69, 62, 62, 55, 65, 70 } }
+    };
+    public string[] XAxisLabels = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep" };
+    
+}

--- a/src/MudBlazor.UnitTests/Components/ChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ChartTests.cs
@@ -7,6 +7,7 @@ using Bunit;
 using FluentAssertions;
 using MudBlazor.Docs.Examples;
 using MudBlazor.UnitTests.TestComponents;
+using MudBlazor.UnitTests.TestComponents.Charts;
 using NUnit.Framework;
 
 namespace MudBlazor.UnitTests.Components
@@ -142,6 +143,17 @@ namespace MudBlazor.UnitTests.Components
             yaxis[0].Children[0].InnerHtml.Trim().Should().Be($"{0:n6}");
         }
 
-
+        /// <summary>
+        /// High values should not lead to millions of horizontal grid lines
+        /// this is from issue #1591 "Line chart is not able to plot big Double values"
+        /// </summary>
+        [Test]
+        [Timeout(5000)]
+        public void LineChartWithBigValues()
+        {
+            // the test should run through instantly (max 5s for a slow build server). 
+            // without the fix it took minutes on a fast computer
+            var comp = ctx.RenderComponent<LineChartWithBigValuesTest>();
+        }
     }
 }

--- a/src/MudBlazor/Components/Chart/Charts/Line.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Line.razor.cs
@@ -11,6 +11,8 @@ namespace MudBlazor.Charts
 {
     partial class Line : MudChartBase
     {
+        private const int MaxHorizontalGridLines = 100;
+
         [CascadingParameter] public MudChart MudChartParent { get; set; }
 
         private List<SvgPath> _horizontalLines = new List<SvgPath>();
@@ -59,11 +61,21 @@ namespace MudBlazor.Charts
             var boundWidth = 650.0;
 
             double gridYUnits = MudChartParent?.ChartOptions.YAxisTicks ?? 20;
+            if (gridYUnits <= 0)
+                gridYUnits = 20;
+            int maxYTicks = MudChartParent?.ChartOptions.MaxNumYAxisTicks ?? 100;
             double gridXUnits = 30;
 
             var numVerticalLines = numValues - 1;
 
             var numHorizontalLines = ((int)(maxY / gridYUnits)) + 1;
+
+            // this is a safeguard against millions of gridlines which might arise with very high values
+            while (numHorizontalLines > maxYTicks)
+            {
+                gridYUnits *= 2;
+                numHorizontalLines = ((int)(maxY / gridYUnits)) + 1;
+            }
 
             var verticalStartSpace = 25.0;
             var horizontalStartSpace = 30.0;

--- a/src/MudBlazor/Components/Chart/Models/ChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Models/ChartOptions.cs
@@ -2,7 +2,16 @@
 {
     public class ChartOptions
     {
+        /// <summary>
+        /// Spacing of Y-axis ticks.
+        /// </summary>
         public int YAxisTicks { get; set; } = 20;
+
+        /// <summary>
+        /// Maximum number of Y-axis ticks. The ticks will be thinned out if the value range is leading to too many ticks.
+        /// </summary>
+        public int MaxNumYAxisTicks { get; set; } = 20;
+
         public string YAxisFormat { get; set; }
         public bool YAxisLines { get; set; } = true;
         public bool XAxisLines { get; set; }


### PR DESCRIPTION
Fixes #1591

The problem is this: you put in numbers in a line chart that are in the millions or even billions. In chart options you have YAxisTicks which defaults to 20 meaning a tick every 20 units, leading to millions of horizontal lines resulting in extreme memory consumption and render times in the minutes. 

I added a `MaxNumYAxisTicks` to chart options (defaulting to 20) and when the number of ticks is above that the tick spacing gets doubled until the resulting number of ticks is <= MaxNumYAxisTicks.

This is how the sample provided by the OP looks like now after the fix:

![image](https://user-images.githubusercontent.com/44090/119797217-526daf00-beda-11eb-939f-d8bc66187510.png)


