### PR TITLE
MudTabs with additional header content

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/CustomDynamicTabsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/CustomDynamicTabsExample.razor
@@ -1,0 +1,87 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudTabs @bind-ActivePanelIndex="_index">
+	<ChildContent>
+		@foreach (var item in _tabs)
+		{
+			 <MudTabPanel Text="@item.Name" Tag="@item.Id">@item.Content</MudTabPanel>
+		}
+	</ChildContent>
+	<Header>
+		<MudButtonGroup>
+			<MudTooltip Text="Prepend a tab">
+				<MudIconButton Icon="@Icons.Material.Filled.ChevronLeft" OnClick="@( () => AddTabCallback(false) )" />
+			</MudTooltip>
+			<MudTooltip Text="Append a tab">
+				<MudIconButton Icon="@Icons.Material.Filled.ChevronRight" OnClick="@( () => AddTabCallback(true) )"  />
+			</MudTooltip>
+		</MudButtonGroup>
+	</Header>
+	<TabPanelHeader>
+		@if(context.Text.StartsWith("Tab") == false)
+		{
+			<MudTooltip Text="only dynamic tabs can be closed">
+				<MudIconButton Color="Color.Error" Icon="@Icons.Material.Filled.Remove" OnClick="(_) => RemoveTab(context)" />
+			</MudTooltip>
+		}
+  </TabPanelHeader>
+</MudTabs>
+
+@code {
+
+	private class TabView
+	{
+		public String Name { get; set; }
+		public String Content { get; set; }
+		public Guid Id { get; set; }
+	}
+
+	private List<TabView> _tabs = new();
+	private int _index = 0;
+	private int? _nextIndex = null;
+
+	private void RemoveTab(MudTabPanel tabPanel)
+	{
+		var tab = _tabs.FirstOrDefault(x => x.Id == (Guid)tabPanel.Tag);
+		if(tab != null)
+		{
+			_tabs.Remove(tab);
+		}
+	}
+
+	protected override void OnInitialized()
+	{
+		base.OnInitialized();
+
+		_tabs.Add(new TabView { Content = "first tab content", Name = "Tab A", Id = Guid.NewGuid() });
+		_tabs.Add(new TabView { Content = "second tab content", Name = "Tab B", Id = Guid.NewGuid() });
+		_tabs.Add(new TabView { Content = "third tab content", Name = "Tab C", Id = Guid.NewGuid() });
+	}
+
+	private void AddTabCallback(Boolean append)
+	{
+		var tabView = new TabView { Name = "dynamic content", Content = "a new tab", Id = Guid.NewGuid() };
+		
+		//the tab becomes availabe after it is rendered. Hence, we can't set the index here
+		if(append == true)
+		{
+			_tabs.Add(tabView);
+			_nextIndex = _tabs.Count - 1;
+		}
+		else
+		{
+			_tabs.Insert(0, tabView);
+			_nextIndex = 0;
+		}
+	}
+
+	protected override void OnAfterRender(bool firstRender)
+	{
+		if(_nextIndex.HasValue == true)
+		{
+			_index = _nextIndex.Value;
+			_nextIndex = null;
+			StateHasChanged();
+		}
+	}
+}

--- a/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/DynamicTabsSimpleExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/DynamicTabsSimpleExample.razor
@@ -1,0 +1,64 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudButton Color="Color.Primary" OnClick="Restore">Restore</MudButton>
+
+<MudDynamicTabs AddTab="AddTabCallback" CloseTab="@((panel) => CloseTabCallback(panel))" @bind-ActivePanelIndex="_index" AddIconToolTip="Click here to add a new tab" CloseIconToolTip="Close this tab. All data will be lost">
+	@foreach (var item in _tabs)
+	{
+	 <MudTabPanel Text="@item.Name" Tag="@item.Id">@item.Content</MudTabPanel>
+	}
+</MudDynamicTabs>
+
+@code {
+
+	private class TabView
+	{
+		public String Name { get; set; }
+		public String Content { get; set; }
+		public Guid Id { get; set; }
+	}
+
+	private List<TabView> _tabs = new();
+	private int _index = 0;
+	private bool _updateIndex = false;
+
+	private void Restore()
+	{
+		_tabs.Clear();
+		_tabs.Add(new TabView { Content = "first tab content", Name = "Tab A", Id = Guid.NewGuid() });
+		_tabs.Add(new TabView { Content = "second tab content", Name = "Tab B", Id = Guid.NewGuid() });
+		_tabs.Add(new TabView { Content = "third tab content", Name = "Tab C", Id = Guid.NewGuid() });
+	}
+
+	protected override void OnInitialized()
+	{
+		base.OnInitialized();
+		Restore();
+	}
+
+	private void AddTabCallback()
+	{
+		_tabs.Add(new TabView { Name = "dynamic content", Content = "a new tab", Id = Guid.NewGuid() });
+		//the tab becomes availabe after it is rendered. Hence, we can't set the index here
+		_updateIndex = true;
+	}
+
+	private void CloseTabCallback(MudTabPanel panel)
+	{
+		var tabView = _tabs.FirstOrDefault(x => x.Id == (Guid)panel.Tag);
+		if(tabView != null)
+		{
+			_tabs.Remove(tabView);
+		}
+	}
+
+	protected override void OnAfterRender(bool firstRender)
+	{
+		if(_updateIndex == true)
+		{
+			_index = _tabs.Count - 1;
+			StateHasChanged();
+			_updateIndex = false;
+		}
+	}
+}

--- a/src/MudBlazor.Docs/Pages/Components/Tabs/TabsPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/TabsPage.razor
@@ -91,7 +91,7 @@
             </SectionContent>
             <SectionSource Code="TabsSetActiveExample" ShowCode="false" GitHubFolderName="Tabs" />
         </DocsPageSection>
-                <DocsPageSection>
+        <DocsPageSection>
             <SectionHeader>
                 <Title>Binding Selected Panel</Title>
             </SectionHeader>
@@ -100,6 +100,33 @@
             </SectionContent>
             <SectionSource Code="TabsBindingExample" ShowCode="false" GitHubFolderName="Tabs" />
         </DocsPageSection>
-
+        <DocsPageSection>
+            <SectionHeader>
+                <Title>Simple Dynamic Tabs</Title>
+                <Description>A browser like tab experience, where uses can add new tabs and close existing ones. Add and Close needs to be provided as callbacks.</Description>
+            </SectionHeader>
+            <SectionContent Outlined="true" FullWidth="true" Class="demo-tabs">
+                <DynamicTabsSimpleExample />
+            </SectionContent>
+            <SectionSource Code="DynamicTabsSimpleExample" GitHubFolderName="Tabs" ShowCode="false" />
+        </DocsPageSection>
+		 <DocsPageSection>
+            <SectionHeader>
+                <Title>Advanced Dynamic Tabs</Title>
+                <Description>
+					<MudText Typo="Typo.body2">
+						Allthough MudDynamicTabs allows a basic browser like tab experience, the way the style can be influenced is limited 
+					</MudText>
+					<MudText Typo="Typo.body2">
+						 The Property Header and TabPanelHeader allows you to add any RenderFragement to the tab (Header) 
+						 and to each tab panel (TabPanelHeader). The placement can be influenced by setting values to HeaderPosition or TabPanelHeaderPosition
+					</MudText>
+				</Description>
+            </SectionHeader>
+            <SectionContent Outlined="true" FullWidth="true" Class="demo-tabs">
+                <CustomDynamicTabsExample />
+            </SectionContent>
+            <SectionSource Code="CustomDynamicTabsExample" GitHubFolderName="Tabs" ShowCode="false" />
+        </DocsPageSection>
     </DocsPageContent>
 </DocsPage>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/SimpleDynamicTabsInteractionTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/SimpleDynamicTabsInteractionTest.razor
@@ -1,0 +1,31 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudDynamicTabs 
+		CloseIconClass="my-close-icon-class" CloseTab="OnCloseClicked"
+		AddIconClass="my-add-icon-class" AddTab="OnAddClicked"  >
+	<MudTabPanel Text="Tab A">
+		Content A
+	</MudTabPanel>
+	<MudTabPanel Text="Tab B">
+		Content B
+	</MudTabPanel>
+	<MudTabPanel Text="Tab C">
+		Content C
+	</MudTabPanel>
+</MudDynamicTabs>
+
+@code {
+
+	public Int32 AddClickCounter { get; private set; }
+	public HashSet<MudTabPanel> CloseClicked { get; private set; } = new();
+
+	private void OnAddClicked()
+	{
+		AddClickCounter++;
+	}
+
+	private void OnCloseClicked(MudTabPanel panel)
+	{
+		CloseClicked.Add(panel);
+	}
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/SimpleDynamicTabsTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/SimpleDynamicTabsTest.razor
@@ -1,0 +1,19 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudDynamicTabs 
+		CloseIconClass="my-close-icon-class" CloseIconStyle="propertyA: 4px" CloseTabIcon="@Icons.Material.Filled.RestoreFromTrash"
+		AddIconClass="my-add-icon-class" AddIconStyle="propertyB: 6px"  AddTabIcon="@Icons.Material.Filled.AddAlarm" >
+	<MudTabPanel Text="Tab A">
+		Content A
+	</MudTabPanel>
+	<MudTabPanel Text="Tab B">
+		Content A
+	</MudTabPanel>
+	<MudTabPanel Text="Tab C">
+		Content A
+	</MudTabPanel>
+</MudDynamicTabs>
+
+@code {
+
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/SimpleDynamicTabsTestWithToolTips.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/SimpleDynamicTabsTestWithToolTips.razor
@@ -1,0 +1,19 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudDynamicTabs 
+		CloseIconClass="my-close-icon-class" CloseIconStyle="propertyA: 4px" CloseTabIcon="@Icons.Material.Filled.RestoreFromTrash" CloseIconToolTip="close here"
+		AddIconClass="my-add-icon-class" AddIconStyle="propertyB: 6px"  AddTabIcon="@Icons.Material.Filled.AddAlarm" AddIconToolTip="add here" >
+	<MudTabPanel Text="Tab A">
+		Content A
+	</MudTabPanel>
+	<MudTabPanel Text="Tab B">
+		Content A
+	</MudTabPanel>
+	<MudTabPanel Text="Tab C">
+		Content A
+	</MudTabPanel>
+</MudDynamicTabs>
+
+@code {
+
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/TabsWithHeaderTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/TabsWithHeaderTest.razor
@@ -1,0 +1,27 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+<MudTabs HeaderPosition="@TabHeaderPosition" TabPanelHeaderPosition="@TabPanelHeaderPosition">
+    <ChildContent>
+        <MudTabPanel Text="First Tab" Tag="0">
+            <MudText Typo="Typo.h1">  First Tab Content</MudText>
+        </MudTabPanel>
+        <MudTabPanel Text="Second Tab" Tag="1">
+            <MudText Typo="Typo.h1">Second Tab Content</MudText>
+        </MudTabPanel>
+        <MudTabPanel Text="Third Tab" Tag="2">
+            <MudText Typo="Typo.h1">Third Tab Content</MudText>
+        </MudTabPanel>
+    </ChildContent>
+    <Header>
+        <MudText Typo="Typo.caption" Class="test-header-content">Count: @context.Panels.Count</MudText>
+    </Header>
+    <TabPanelHeader>
+        <MudText Typo="Typo.caption" Class="test-panel-header-content">Index: @context.Tag</MudText>
+    </TabPanelHeader>
+</MudTabs>
+
+@code {
+
+    [Parameter] public TabHeaderPosition TabHeaderPosition { get; set; } = TabHeaderPosition.After;
+    [Parameter] public TabHeaderPosition TabPanelHeaderPosition { get; set; } = TabHeaderPosition.After;
+
+}

--- a/src/MudBlazor.UnitTests/Components/DynamicTabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DynamicTabsTests.cs
@@ -1,0 +1,191 @@
+﻿#pragma warning disable CS1998 // async without await
+#pragma warning disable IDE1006 // leading underscore
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using AngleSharp.Html.Dom;
+using Bunit;
+using FluentAssertions;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor.Interop;
+using MudBlazor.Services;
+using MudBlazor.UnitTests.Mocks;
+using MudBlazor.UnitTests.TestComponents;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Components
+{
+
+    [TestFixture]
+    public class DynamicTabsTests
+    {
+        private Bunit.TestContext ctx;
+
+        [SetUp]
+        public void Setup()
+        {
+            ctx = new Bunit.TestContext();
+            ctx.AddTestServices();
+        }
+
+        [TearDown]
+        public void TearDown() => ctx.Dispose();
+
+        [Test]
+        public async Task DefaultValues()
+        {
+            ctx.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockResizeObserver()));
+
+            var comp = ctx.RenderComponent<MudDynamicTabs>();
+            var tabs = comp.Instance;
+
+            tabs.Header.Should().NotBeNull();
+            tabs.TabPanelHeader.Should().NotBeNull();
+
+            tabs.HeaderPosition.Should().Be(TabHeaderPosition.After);
+            tabs.TabPanelHeaderPosition.Should().Be(TabHeaderPosition.After);
+
+            tabs.AddTabIcon.Should().Be(Icons.Material.Filled.Add);
+            tabs.CloseTabIcon.Should().Be(Icons.Material.Filled.Close);
+
+            tabs.AddIconClass.Should().BeNullOrEmpty();
+            tabs.AddIconStyle.Should().BeNullOrEmpty();
+            tabs.AddIconToolTip.Should().BeNullOrEmpty();
+
+            tabs.CloseIconClass.Should().BeNullOrEmpty();
+            tabs.CloseIconStyle.Should().BeNullOrEmpty();
+            tabs.CloseIconToolTip.Should().BeNullOrEmpty();
+        }
+
+        [Test]
+        public async Task BasicParameters()
+        {
+            ctx.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockResizeObserver()));
+
+            var comp = ctx.RenderComponent<SimpleDynamicTabsTest>();
+            Console.WriteLine(comp.Markup);
+
+            // three panels three close icons;
+            var closeButtons = comp.FindAll(".my-close-icon-class");
+            closeButtons.Should().HaveCount(3);
+
+            foreach (var item in closeButtons)
+            {
+                item.GetAttribute("style").Should().Be("propertyA: 4px");
+                item.ClassList.Should().StartWith(new string[] { "mud-button-root" });
+
+                XElement actual = XElement.Parse($"<test>{item.Children[0].Children[0].InnerHtml}</test>");
+                XElement expected = XElement.Parse($"<test>{Icons.Material.Filled.RestoreFromTrash}</test>");
+
+                actual.Should().BeEquivalentTo(expected);
+            }
+
+            var addButtons = comp.FindAll(".my-add-icon-class");
+
+            addButtons.Should().HaveCount(1);
+            foreach (var item in addButtons)
+            {
+                item.GetAttribute("style").Should().Be("propertyB: 6px");
+                item.ClassList.Should().StartWith(new string[] { "mud-button-root" });
+
+                XElement actual = XElement.Parse($"<test>{item.Children[0].Children[0].InnerHtml}</test>");
+                XElement expected = XElement.Parse($"<test>{Icons.Material.Filled.AddAlarm}</test>");
+
+                actual.Should().BeEquivalentTo(expected);
+
+            }
+        }
+
+        [Test]
+        public async Task BasicParameters_WithToolTips()
+        {
+            ctx.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockResizeObserver()));
+
+            var comp = ctx.RenderComponent<SimpleDynamicTabsTestWithToolTips>();
+            Console.WriteLine(comp.Markup);
+
+            // three panels three close icons;
+            var closeButtons = comp.FindAll(".my-close-icon-class");
+            closeButtons.Should().HaveCount(3);
+
+            foreach (var item in closeButtons)
+            {
+                item.GetAttribute("style").Should().Be("propertyA: 4px");
+                item.ClassList.Should().StartWith(new string[] { "mud-button-root" });
+
+                XElement actual = XElement.Parse($"<test>{item.Children[0].Children[0].InnerHtml}</test>");
+                XElement expected = XElement.Parse($"<test>{Icons.Material.Filled.RestoreFromTrash}</test>");
+
+                actual.Should().BeEquivalentTo(expected);
+
+                var parent = (IHtmlElement)item.Parent;
+                parent.Children.Should().HaveCount(2);
+
+                var toolTip = parent.Children[1];
+                toolTip.ClassList.Should().StartWith(new string[] { "mud-tooltip" });
+                toolTip.TextContent.Should().Be("close here");
+            }
+
+            var addButtons = comp.FindAll(".my-add-icon-class");
+
+            addButtons.Should().HaveCount(1);
+            foreach (var item in addButtons)
+            {
+                item.GetAttribute("style").Should().Be("propertyB: 6px");
+                item.ClassList.Should().StartWith(new string[] { "mud-button-root" });
+
+                XElement actual = XElement.Parse($"<test>{item.Children[0].Children[0].InnerHtml}</test>");
+                XElement expected = XElement.Parse($"<test>{Icons.Material.Filled.AddAlarm}</test>");
+
+                actual.Should().BeEquivalentTo(expected);
+
+                var parent = (IHtmlElement)item.Parent;
+                parent.Children.Should().HaveCount(2);
+
+                var toolTip = parent.Children[1];
+                toolTip.ClassList.Should().StartWith(new string[] { "mud-tooltip" });
+                toolTip.TextContent.Should().Be("add here");
+            }
+        }
+
+        [Test]
+        public async Task TestInteractions_AddTab()
+        {
+            ctx.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockResizeObserver()));
+            var comp = ctx.RenderComponent<SimpleDynamicTabsInteractionTest>();
+
+            Console.WriteLine(comp.Markup);
+
+            var addButton = comp.Find(".my-add-icon-class");
+            addButton.Click();
+
+            await Task.Delay(5);
+            comp.Instance.AddClickCounter.Should().Be(1);
+        }
+
+        [Test]
+        public async Task TestInteractions_RemoveTab()
+        {
+            ctx.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockResizeObserver()));
+            var comp = ctx.RenderComponent<SimpleDynamicTabsInteractionTest>();
+
+            Console.WriteLine(comp.Markup);
+
+            for (int i = 0; i < 3; i++)
+            {
+                var closeButton = comp.FindAll(".my-close-icon-class")[i];
+                closeButton.Click();
+
+                await Task.Delay(5);
+
+                comp.Instance.CloseClicked.Should().HaveCount(i + 1);
+            }
+
+        }
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -837,7 +837,6 @@ namespace MudBlazor.UnitTests.Components
         {
             ctx.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockResizeObserver()));
 
-
             //starting with index 1:
             var comp = ctx.RenderComponent<SelectedIndexTabsTest>();
             comp.Instance.Tabs.ActivePanelIndex.Should().Be(1);
@@ -864,6 +863,124 @@ namespace MudBlazor.UnitTests.Components
             activePanels.Should().HaveCount(1);
             panels[0].ClassList.Contains("mud-tab-active").Should().BeTrue();
 
+        }
+
+        [Test]
+        public void DefaultValuesForHeaders()
+        {
+            MudTabs tabs = new MudTabs();
+
+            tabs.HeaderPosition.Should().Be(TabHeaderPosition.After);
+            tabs.Header.Should().BeNull();
+
+            tabs.TabPanelHeaderPosition.Should().Be(TabHeaderPosition.After);
+            tabs.TabPanelHeader.Should().BeNull();
+
+        }
+
+        /// <summary>
+        /// The header should be rendered based on the value of header position.
+        /// </summary>
+        [Test]
+        [TestCase(TabHeaderPosition.After)]
+        [TestCase(TabHeaderPosition.Before)]
+        public async Task RenderHeaderBasedOnPosition(TabHeaderPosition position)
+        {
+            ctx.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockResizeObserver()));
+
+            var comp = ctx.RenderComponent<TabsWithHeaderTest>();
+            comp.SetParametersAndRender(x => x.Add(y => y.TabHeaderPosition, position));
+            comp.SetParametersAndRender(x => x.Add(y => y.TabPanelHeaderPosition, TabHeaderPosition.None));
+
+            var headerContent = comp.Find(".test-header-content");
+            headerContent.TextContent.Should().Be($"Count: {3}");
+
+            var headerPanel = headerContent.ParentElement;
+            String addtionalClass = position == TabHeaderPosition.After ? "mud-tabs-header-after" : "mud-tabs-header-before";
+            headerPanel.ClassList.Should().BeEquivalentTo(new string[] { "mud-tabs-header", addtionalClass });
+
+            var tabInnerHeader = comp.Find(".mud-tabs-toolbar-inner");
+
+            tabInnerHeader.Children.Should().Contain(headerPanel);
+            if(position == TabHeaderPosition.After)
+            {
+                tabInnerHeader.Children.Last().Should().Be(headerPanel);
+            }
+            else
+            {
+                tabInnerHeader.Children.First().Should().Be(headerPanel);
+            }
+        }
+
+        /// <summary>
+        /// If the header template is set, but the position is none, no header should be rendered
+        /// </summary>
+        [Test]
+        public async Task RenderHeaderBasedOnPosition_None()
+        {
+            ctx.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockResizeObserver()));
+
+            var comp = ctx.RenderComponent<TabsWithHeaderTest>();
+            comp.SetParametersAndRender(x => x.Add(y => y.TabHeaderPosition, TabHeaderPosition.None));
+            comp.SetParametersAndRender(x => x.Add(y => y.TabPanelHeaderPosition, TabHeaderPosition.None));
+
+            var headerContent = comp.FindAll(".test-header-content");
+            headerContent.Should().BeEmpty();
+        }
+
+        /// <summary>
+        /// The panel header header should be rendered based on the value of header position.
+        /// </summary>
+        [Test]
+        [TestCase(TabHeaderPosition.After)]
+        [TestCase(TabHeaderPosition.Before)]
+        public async Task RenderHeaderPanelBasedOnPosition(TabHeaderPosition position)
+        {
+            ctx.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockResizeObserver()));
+
+            var comp = ctx.RenderComponent<TabsWithHeaderTest>();
+            comp.SetParametersAndRender(x => x.Add(y => y.TabHeaderPosition, TabHeaderPosition.None));
+            comp.SetParametersAndRender(x => x.Add(y => y.TabPanelHeaderPosition, position));
+
+            var headerContent = comp.FindAll(".test-panel-header-content");
+            headerContent.Should().HaveCount(3);
+
+            headerContent.Select(x => x.TextContent).ToList().Should().BeEquivalentTo(new string[] { "Index: 0", "Index: 1", "Index: 2" });
+
+            foreach (var item in headerContent)
+            {
+                var headerPanel = item.ParentElement;
+                string addtionalClass = position == TabHeaderPosition.After ? "mud-tabs-panel-header-after" : "mud-tabs-panel-header-before";
+          
+                headerPanel.ClassList.Should().BeEquivalentTo(new string[] { "mud-tabs-panel-header", addtionalClass });
+
+                var parent = headerPanel.ParentElement;
+
+                if(position == TabHeaderPosition.After)
+                {
+                    parent.Children.Last().Should().Be(headerPanel);
+                }
+                else
+                {
+                    parent.Children.First().Should().Be(headerPanel);
+                }
+            }
+        }
+
+        /// <summary>
+        /// If the header template is set, but the position is none, no header should be rendered
+        /// </summary>
+        [Test]
+        public async Task RenderHeaderPanelBasedOnPosition_None()
+        {
+            ctx.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockResizeObserver()));
+
+            var comp = ctx.RenderComponent<TabsWithHeaderTest>();
+            comp.SetParametersAndRender(x => x.Add(y => y.TabHeaderPosition, TabHeaderPosition.None));
+            comp.SetParametersAndRender(x => x.Add(y => y.TabPanelHeaderPosition, TabHeaderPosition.None));
+
+            var headerContent = comp.FindAll(".test-panel-header-content");
+            headerContent.Should().BeEmpty();
         }
 
         [Test]

--- a/src/MudBlazor/Components/Tabs/MudDynamicTabs.razor
+++ b/src/MudBlazor/Components/Tabs/MudDynamicTabs.razor
@@ -1,0 +1,44 @@
+﻿@namespace MudBlazor
+@inherits MudTabs
+
+@{ 
+    base.BuildRenderTree(__builder);
+}
+
+@code {
+
+
+	protected override void OnInitialized()
+    {
+		base.Header = (context) => 
+	@:@{
+			if (string.IsNullOrEmpty(AddIconToolTip) == false)
+			{
+				<MudTooltip Text="@AddIconToolTip">
+					<MudIconButton Icon="@AddTabIcon" Class="@AddIconClass" Style="@AddIconStyle" OnClick="@AddTab" />
+				</MudTooltip>
+			}
+			else
+			{
+				<MudIconButton Icon="@AddTabIcon" Class="@AddIconClass" Style="@AddIconStyle" OnClick="@AddTab" />
+			}
+		}
+		;
+
+        base.TabPanelHeader = (context) =>  
+	@:@{
+			if (string.IsNullOrEmpty(CloseIconToolTip) == false)
+			{
+				<MudTooltip Text="@CloseIconToolTip">
+					<MudIconButton Icon="@CloseTabIcon" Class="@CloseIconClass" Style="@CloseIconStyle" OnClick="EventCallback.Factory.Create<MouseEventArgs>(this, () => CloseTab.InvokeAsync(context))" />
+				</MudTooltip>
+			}
+			else
+			{
+				<MudIconButton Icon="@CloseTabIcon" Class="@CloseIconClass" Style="@CloseIconStyle"  OnClick="EventCallback.Factory.Create<MouseEventArgs>(this, () => CloseTab.InvokeAsync(context))" />
+			}
+		}
+		;
+    }
+
+}

--- a/src/MudBlazor/Components/Tabs/MudDynamicTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudDynamicTabs.razor.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+
+namespace MudBlazor
+{
+    public partial class MudDynamicTabs : MudTabs
+    {
+        /// <summary>
+        /// The icon used for the add button
+        /// </summary>
+        [Parameter] public string AddTabIcon { get; set; } = Icons.Material.Filled.Add;
+
+        /// <summary>
+        /// the icon used of the close button
+        /// </summary>
+        [Parameter] public string CloseTabIcon { get; set; } = Icons.Material.Filled.Close;
+
+        /// <summary>
+        /// The callback, when the add button has been clicked
+        /// </summary>
+        [Parameter] public EventCallback AddTab { get; set; }
+
+        /// <summary>
+        /// The callback, when the a close button has been clicked
+        /// </summary>
+        [Parameter] public EventCallback<MudTabPanel> CloseTab { get; set; }
+
+        /// <summary>
+        /// Classes that are applied to the icon button of the add button
+        /// </summary>
+        [Parameter] public string AddIconClass { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Styles that are applied to the icon button of the add button
+        /// </summary>
+        [Parameter] public string AddIconStyle { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Classes that are applied to the icon button of the close button
+        /// </summary>
+        [Parameter] public string CloseIconClass { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Styles that are applied to the icon button of the close button
+        /// </summary>
+        [Parameter] public string CloseIconStyle { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Tooltip that shown when a user hovers of the add button. Empty or null, if no tooltip should be visible
+        /// </summary>
+        [Parameter] public string AddIconToolTip { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Tooltip that shown when a user hovers of the close button. Empty or null, if no tooltip should be visible
+        /// </summary>
+        [Parameter] public string CloseIconToolTip { get; set; } = string.Empty;
+    }
+}

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor
@@ -5,6 +5,12 @@
     <CascadingValue Value="this" IsFixed="true">
         <div class="@ToolbarClassnames">
             <div class="mud-tabs-toolbar-inner" style="@MaxHeightStyles">
+                @if(HeaderPosition == TabHeaderPosition.Before && Header != null)
+                {
+                    <div class="mud-tabs-header mud-tabs-header-before">
+                       @Header(this)
+                    </div>
+                }
                 @if(_showScrollButtons)
                 {
                     <div class="mud-tabs-scroll-button">
@@ -17,6 +23,12 @@
                         {
                             <MudTooltip Placement="@GetTooltipPlacement()" Text="@panel.ToolTip">
                                 <div @ref="panel.PanelRef" class="@GetTabClass(panel)" style="@GetTabStyle(panel)" @onclick=@( e => ActivatePanel(panel, e, false) )>
+                                    @if(TabPanelHeaderPosition == TabHeaderPosition.Before && TabPanelHeader != null)
+                                    {
+                                        <div class="mud-tabs-panel-header mud-tabs-panel-header-before">
+                                            @TabPanelHeader(panel)
+                                        </div>
+                                    }
                                     @if (!String.IsNullOrEmpty(panel.Text) && String.IsNullOrEmpty(panel.Icon))
                                     {
                                         @((MarkupString)panel.Text)
@@ -34,6 +46,12 @@
                                     {
                                         <MudBadge Content="@panel.BadgeData" Color="@panel.BadgeColor" Class="mud-tab-badge" />
                                     }
+                                    @if(TabPanelHeaderPosition == TabHeaderPosition.After && TabPanelHeader != null)
+                                    {
+                                        <div class="mud-tabs-panel-header mud-tabs-panel-header-after">
+                                            @TabPanelHeader(panel)
+                                        </div>
+                                    }
                                 </div>
                             </MudTooltip>
                         }
@@ -47,6 +65,12 @@
                 {
                     <div class="mud-tabs-scroll-button">
                         <MudIconButton Icon="@_nextIcon" Color="@ScrollIconColor" OnClick="@((e) => ScrollNext())" Disabled="@_nextButtonDisabled" />
+                    </div>
+                }
+                @if(HeaderPosition == TabHeaderPosition.After && Header != null)
+                {
+                    <div class="mud-tabs-header mud-tabs-header-after">
+                        @Header(this)
                     </div>
                 }
             </div>

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -171,6 +171,30 @@ namespace MudBlazor
 
         private List<MudTabPanel> _panels;
 
+        /// <summary>
+        /// A render fragement that is added before or after (based on the value of HeaderPosition) the tabs inside the header panel of the tab control
+        /// </summary>
+        [Parameter]
+        public RenderFragment<MudTabs> Header { get; set; }
+
+        /// <summary>
+        /// Addional content specified by Header is placed either before the tabs, after or not at all
+        /// </summary>
+        [Parameter]
+        public TabHeaderPosition HeaderPosition { get; set; } = TabHeaderPosition.After;
+
+        /// <summary>
+        /// A render fragement that is added before or after (based on the value of HeaderPosition) inside each tab panel
+        /// </summary>
+        [Parameter]
+        public RenderFragment<MudTabPanel> TabPanelHeader { get; set; }
+
+        /// <summary>
+        /// Addional content specified by Header is placed either before the tabs, after or not at all
+        /// </summary>
+        [Parameter]
+        public TabHeaderPosition TabPanelHeaderPosition { get; set; } = TabHeaderPosition.After;
+
         private string _prevIcon;
 
         private string _nextIcon;

--- a/src/MudBlazor/Components/Tabs/TabHeaderPosition.cs
+++ b/src/MudBlazor/Components/Tabs/TabHeaderPosition.cs
@@ -1,0 +1,25 @@
+﻿
+
+using System.ComponentModel;
+
+namespace MudBlazor
+{
+    public enum TabHeaderPosition
+    {
+        /// <summary>
+        /// Additional content is placed after the the first tab
+        /// </summary>
+        [Description("after")]
+        After,
+        /// <summary>
+        /// Addtional content is placed before the first tab
+        /// </summary>
+        [Description("before")]
+        Before,
+        /// <summary>
+        /// No additional contnet is rendered
+        /// </summary>
+        [Description("none")]
+        None,
+    }
+}

--- a/src/MudBlazor/Styles/components/_tabs.scss
+++ b/src/MudBlazor/Styles/components/_tabs.scss
@@ -249,3 +249,20 @@
         transform: translate(100%, 0);
     }
 }
+
+.mud-tabs-header {
+    &.mud-tabs-header-before {
+    }
+
+    &.mud-tabs-header-after {
+    }
+}
+
+.mud-tabs-panel-header {
+    &.mud-tabs-panel-header-before {
+    }
+
+    &.mud-tabs-panel-header-after {
+    }
+}
+

--- a/src/MudBlazor/Styles/components/_tabs.scss
+++ b/src/MudBlazor/Styles/components/_tabs.scss
@@ -259,10 +259,15 @@
 }
 
 .mud-tabs-panel-header {
+    display: flex;
+    flex: 1 1 auto;
+
     &.mud-tabs-panel-header-before {
+        justify-content: flex-start;
     }
 
     &.mud-tabs-panel-header-after {
+        justify-content: flex-end;
     }
 }
 


### PR DESCRIPTION
Inspired by request in #1568, the PR introduces two ```RenderFragements``` for MudTabs that can add additional content in the header panel and the header of each tab panel.

Besides ```MudDynamicTabs``` using this new fragment to render an add and remove button. For each operation, a Callback needs to be supplied. 

![DynamicTabs](https://user-images.githubusercontent.com/51370361/119808277-8d8dd380-bf16-11eb-847a-ed1f9e1e4e3b.gif)

Unit tests and updates of the docs are provided as well. 

Design is still missing. I guess @Garderoben and @porkopek are the experts on this matter.  