### PR TITLE
Fix right margin on MudInput clear button

### DIFF
--- a/src/MudBlazor/Components/Input/MudInput.razor
+++ b/src/MudBlazor/Components/Input/MudInput.razor
@@ -33,7 +33,7 @@
 
 	@if (_showClearable && !Disabled)
 	{
-	 <MudIconButton Color="@Color.Default" Icon="@Icons.Material.Filled.Clear" Size="@Size.Small" OnClick="@ClearButtonClickHandlerAsync" Class="my-n3" />
+	 <MudIconButton Color="@Color.Default" Icon="@Icons.Material.Filled.Clear" Size="@Size.Small" OnClick="@ClearButtonClickHandlerAsync" Class="mud-icon-button-edge-end" />
 	}
 
 	@if (Adornment == Adornment.End)

--- a/src/MudBlazor/Components/Input/MudInput.razor
+++ b/src/MudBlazor/Components/Input/MudInput.razor
@@ -32,8 +32,8 @@
 	}
 
 	@if (_showClearable && !Disabled)
-    {
-	 <MudIconButton Color="@Color.Default" Icon="@Icons.Material.Filled.Clear" Size="@Size.Small" OnClick="@ClearButtonClickHandlerAsync" Class="my-n3 mr-2" />
+	{
+	 <MudIconButton Color="@Color.Default" Icon="@Icons.Material.Filled.Clear" Size="@Size.Small" OnClick="@ClearButtonClickHandlerAsync" Class="@GetClearButtonCssClass()" />
 	}
 
 	@if (Adornment == Adornment.End)
@@ -57,4 +57,6 @@
 
 @code {
 	private Size GetButtonSize() => Margin == Margin.Dense ? Size.Small : Size.Medium;
+
+	private string GetClearButtonCssClass() => Variant == Variant.Text ? "my-n3 mr-n1" : "my-n3 mr-2";
 }

--- a/src/MudBlazor/Components/Input/MudInput.razor
+++ b/src/MudBlazor/Components/Input/MudInput.razor
@@ -33,7 +33,7 @@
 
 	@if (_showClearable && !Disabled)
     {
-	 <MudIconButton Color="@Color.Default" Icon="@Icons.Material.Filled.Clear" Size="@Size.Small" OnClick="@ClearButtonClickHandlerAsync" Class="my-n3 mr-n1" />
+	 <MudIconButton Color="@Color.Default" Icon="@Icons.Material.Filled.Clear" Size="@Size.Small" OnClick="@ClearButtonClickHandlerAsync" Class="my-n3 mr-2" />
 	}
 
 	@if (Adornment == Adornment.End)

--- a/src/MudBlazor/Components/Input/MudInput.razor
+++ b/src/MudBlazor/Components/Input/MudInput.razor
@@ -33,7 +33,7 @@
 
 	@if (_showClearable && !Disabled)
 	{
-	 <MudIconButton Color="@Color.Default" Icon="@Icons.Material.Filled.Clear" Size="@Size.Small" OnClick="@ClearButtonClickHandlerAsync" Class="@GetClearButtonCssClass()" />
+	 <MudIconButton Color="@Color.Default" Icon="@Icons.Material.Filled.Clear" Size="@Size.Small" OnClick="@ClearButtonClickHandlerAsync" Class="my-n3" />
 	}
 
 	@if (Adornment == Adornment.End)
@@ -57,6 +57,4 @@
 
 @code {
 	private Size GetButtonSize() => Margin == Margin.Dense ? Size.Small : Size.Medium;
-
-	private string GetClearButtonCssClass() => Variant == Variant.Text ? "my-n3 mr-n1" : "my-n3 mr-2";
 }


### PR DESCRIPTION
The right padding on clear buttons is too little for filled and outlined inputs.

I added a method that returns the class string based on the variant being rendered.

![image](https://user-images.githubusercontent.com/26885142/119913274-1c085200-bf23-11eb-8bdd-94196c275afc.png)

