### PR TITLE
MudSelect: Do not fire changed event when the same item is selected again.

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/ReselectValueTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/ReselectValueTest.razor
@@ -1,0 +1,22 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<div>
+    <MudSelect Variant="Variant.Text"
+               @bind-Value="fruit"
+               Direction="Direction.Bottom" Dense="true" OffsetY="true"
+               SelectedValuesChanged="@((HashSet<string> f) => FruitChanged(f))">
+
+        <MudSelectItem Value="@("Apple")">Apple</MudSelectItem>
+        <MudSelectItem Value="@("Orange")">Orange</MudSelectItem>
+    </MudSelect>
+</div>
+
+@code{
+    string fruit = "Apple";
+    public int ChangeCount { get; private set; }
+
+    void FruitChanged(HashSet<string> fruits)
+    {
+        ChangeCount++;
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -482,6 +482,39 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.ClearButtonClicked.Should().BeTrue();
         }
 
+        /// <summary>
+        /// Reselect an already selected value should not call SelectedValuesChanged event.
+        /// </summary>
+        [Test]
+        public void SelectReselectTest()
+        {
+            var comp = ctx.RenderComponent<ReselectValueTest>();
+            // print the generated html
+            Console.WriteLine(comp.Markup);
+            // select elements needed for the test
+            var select = comp.FindComponent<MudSelect<string>>();
+            var menu = comp.Find("div.mud-popover");
+            var input = comp.Find("div.mud-input-control");
+
+            input.Click();
+            select.Instance.Value.Should().Be("Apple");
+
+            // now click an item and see the value change
+            var items = comp.FindAll("div.mud-list-item").ToArray();
+            items[1].Click();
+
+            // menu should be closed now
+            menu.ClassList.Should().NotContain("mud-popover-open");
+            select.Instance.Value.Should().Be("Orange");
+            comp.Instance.ChangeCount.Should().Be(1);
+
+            // now click an item and see the value change
+            items = comp.FindAll("div.mud-list-item").ToArray();
+            select.Instance.Value.Should().Be("Orange");
+            comp.Instance.ChangeCount.Should().Be(1);
+            items[1].Click();
+        }
+
         #region DataAttribute validation
         [Test]
         public async Task TextField_Should_Validate_Data_Attribute_Fail()

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -240,17 +240,25 @@ namespace MudBlazor
                 else
                     SelectedValues.Remove(value);
                 await SetTextAsync(string.Join(", ", SelectedValues.Select(x => Converter.Set(x))));
+                BeginValidate();
             }
             else
             {
                 // single selection
-                await SetValueAsync(value);
                 _isOpen = false;
                 UpdateIcon();
+
+                if (EqualityComparer<T>.Default.Equals(Value, value))
+                {
+                    StateHasChanged();
+                    return;
+                }
+
+                await SetValueAsync(value);
                 SelectedValues.Clear();
                 SelectedValues.Add(value);
             }
-            BeginValidate();
+
             StateHasChanged();
             await SelectedValuesChanged.InvokeAsync(SelectedValues);
         }


### PR DESCRIPTION
Fix for #1521