### PR TITLE
Fixes RTL margin, padding and alignment issues

### DIFF
--- a/src/MudBlazor/Styles/components/_alert.scss
+++ b/src/MudBlazor/Styles/components/_alert.scss
@@ -74,11 +74,8 @@
     padding: 7px 0;
     font-size: 22px;
     margin-right: 12px;
-}
-
-.mud-application-layout-rtl .mud-alert-icon {
-    margin-right: 0;
-    margin-left: 12px;
+    margin-inline-end: 12px;
+    margin-inline-start: unset;
 }
 
 .mud-alert-message {
@@ -91,11 +88,7 @@
     margin-left: auto;
     margin-right: -8px;
     padding-left: 16px;
-}
-
-.mud-application-layout-rtl .mud-alert-action {
-    margin-right: -8px;
-    margin-left: 0;
-    padding-right: 16px;
-    padding-right: 0;
+    margin-inline-start: auto;
+    margin-inline-end: -8px;
+    padding-inline-start: 16px;
 }

--- a/src/MudBlazor/Styles/components/_badge.scss
+++ b/src/MudBlazor/Styles/components/_badge.scss
@@ -41,6 +41,8 @@
 
                     & .mud-icon-badge {
                         margin-left: -4px;
+                        margin-inline-start: -4px;
+                        margin-inline-end: unset;
                         margin-top: -4px;
                     }
                 }
@@ -54,6 +56,8 @@
                     color: inherit;
                     font-size: 12px;
                     margin-left: -2px;
+                    margin-inline-start: -2px;
+                    margin-inline-end: unset;
                 }
             }
 

--- a/src/MudBlazor/Styles/components/_breadcrumbs.scss
+++ b/src/MudBlazor/Styles/components/_breadcrumbs.scss
@@ -23,6 +23,8 @@
 
 .mud-breadcrumb-item > a > svg.mud-svg-icon-root {
     margin-right: 4px;
+    margin-inline-end: 4px;
+    margin-inline-start: unset;
 }
 
 .mud-breadcrumb-item.mud-disabled > a {

--- a/src/MudBlazor/Styles/components/_button.scss
+++ b/src/MudBlazor/Styles/components/_button.scss
@@ -199,9 +199,13 @@
         display: inherit;
         margin-left: -4px;
         margin-right: 8px;
+        margin-inline-start: -4px;
+        margin-inline-end: 8px;
 
         &.mud-button-icon-size-small {
             margin-left: -2px;
+            margin-inline-start: -2px;
+            margin-inline-end: 8px;
         }
     }
 
@@ -209,9 +213,13 @@
         display: inherit;
         margin-left: 8px;
         margin-right: -4px;
+        margin-inline-start: 8px;
+        margin-inline-end: -4px;
 
         &.mud-button-icon-size-small {
             margin-right: -2px;
+            margin-inline-end: -2px;
+            margin-inline-start: 8px;
         }
     }
 }
@@ -230,26 +238,4 @@
 
 .mud-button-icon-size-large > *:first-child {
     font-size: 22px;
-}
-
-.mud-application-layout-rtl .mud-button-label {
-    .mud-button-icon-start {
-        margin-right: -4px;
-        margin-left: 8px;
-
-        &.mud-button-icon-size-small {
-            margin-right: -2px;
-            margin-left: 0;
-        }
-    }
-
-    .mud-button-icon-end {
-        margin-right: 8px;
-        margin-left: -4px;
-
-        &.mud-button-icon-size-small {
-            margin-left: -2px;
-            margin-right: 0;
-        }
-    }
 }

--- a/src/MudBlazor/Styles/components/_card.scss
+++ b/src/MudBlazor/Styles/components/_card.scss
@@ -10,6 +10,8 @@
     & .mud-card-header-avatar {
         flex: 0 0 auto;
         margin-right: 16px;
+        margin-inline-end: 16px;
+        margin-inline-start: unset;
     }
 
     & .mud-card-header-content {
@@ -25,6 +27,8 @@
         align-self: flex-start;
         margin-top: -8px;
         margin-right: -8px;
+        margin-inline-end: -8px;
+        margin-inline-start: unset;
     }
 }
 
@@ -43,19 +47,4 @@
     display: flex;
     padding: 8px;
     align-items: center;
-}
-
-.mud-application-layout-rtl {
-    .mud-card-header {
-        & .mud-card-header-avatar {
-            margin-left: 16px;
-            margin-right: 0;
-        }
-
-        & .mud-card-header-actions {
-            align-self: flex-end;
-            margin-left: -8px;
-            margin-right: 0;
-        }
-    }
 }

--- a/src/MudBlazor/Styles/components/_chip.scss
+++ b/src/MudBlazor/Styles/components/_chip.scss
@@ -52,6 +52,8 @@
     .mud-chip-icon {
         margin-left: -4px;
         margin-right: 4px;
+        margin-inline-start: -4px;
+        margin-inline-end: 4px;
         color: inherit;
     }
 
@@ -59,6 +61,8 @@
         padding: 1px;
         margin-right: -4px;
         margin-left: 6px;
+        margin-inline-end: -4px;
+        margin-inline-start: 6px;
         height: 18px;
         width: 18px;
         color: inherit;
@@ -81,20 +85,6 @@
         user-select: none;
     }
 }
-
-.mud-application-layout-rtl .mud-chip {
-    .mud-chip-icon {
-        margin-right: -4px;
-        margin-left: 4px;
-    }
-
-    .mud-chip-close-button {
-        margin-left: -4px;
-        margin-right: 6px;
-    }
-}
-
-
 
 .mud-chip-filled {
     color: var(--mud-palette-text-primary);

--- a/src/MudBlazor/Styles/components/_dialog.scss
+++ b/src/MudBlazor/Styles/components/_dialog.scss
@@ -1,4 +1,4 @@
-﻿.mud-dialog-container {
+.mud-dialog-container {
     display: flex;
     position: fixed;
     top: 0;
@@ -89,6 +89,8 @@
 
         & > :not(:first-child) {
             margin-left: 8px;
+            margin-inline-start: 8px;
+            margin-inline-end: unset;
         }
     }
 }

--- a/src/MudBlazor/Styles/components/_divider.scss
+++ b/src/MudBlazor/Styles/components/_divider.scss
@@ -15,6 +15,8 @@
 
 .mud-divider-inset {
     margin-left: 72px;
+    margin-inline-start: 72px;
+    margin-inline-end: unset;
 }
 
 .mud-divider-light {

--- a/src/MudBlazor/Styles/components/_fab.scss
+++ b/src/MudBlazor/Styles/components/_fab.scss
@@ -91,6 +91,8 @@
 
         .mud-icon-root {
             margin-right: 8px;
+            margin-inline-end: 8px;
+            margin-inline-start: unset;
         }
     }
 
@@ -103,6 +105,8 @@
 
         .mud-icon-root {
             margin-right: 4px;
+            margin-inline-end: 4px;
+            margin-inline-start: unset;
         }
     }
 
@@ -115,24 +119,9 @@
 
         .mud-icon-root {
             margin-right: 8px;
+            margin-inline-end: 8px;
+            margin-inline-start: unset;
         }
-    }
-}
-
-.mud-application-layout-rtl .mud-fab-extended {
-    &.mud-fab-size-large .mud-icon-root {
-        margin-left: 8px;
-        margin-right: 0;
-    }
-
-    &.mud-fab-size-small .mud-icon-root {
-        margin-left: 4px;
-        margin-right: 0;
-    }
-
-    &.mud-fab-size-medium .mud-icon-root {
-        margin-left: 8px;
-        margin-right: 0;
     }
 }
 

--- a/src/MudBlazor/Styles/components/_iconbutton.scss
+++ b/src/MudBlazor/Styles/components/_iconbutton.scss
@@ -48,10 +48,14 @@
 
 .mud-icon-button-edge-start {
     margin-left: -12px;
+    margin-inline-start: -12px;
+    margin-inline-end: unset;
 }
 
 .mud-icon-button-edge-end {
     margin-right: -12px;
+    margin-inline-end: -12px;
+    margin-inline-start: unset;
 }
 
 .mud-icon-button-size-small {
@@ -60,9 +64,13 @@
 
     &.mud-icon-button-edge-start {
         margin-left: -3px;
+        margin-inline-start: -3px;
+        margin-inline-end: unset;
     }
 
     &.mud-icon-button-edge-end {
         margin-right: -3px;
+        margin-inline-end: -3px;
+        margin-inline-start: unset;
     }
 }

--- a/src/MudBlazor/Styles/components/_input.scss
+++ b/src/MudBlazor/Styles/components/_input.scss
@@ -83,10 +83,14 @@
 
         &.mud-input-adorned-start {
             padding-left: 12px;
+            padding-inline-start: 12px;
+            padding-inline-end: unset;
         }
 
         &.mud-input-adorned-end {
             padding-right: 12px;
+            padding-inline-end: 12px;
+            padding-inline-start: unset;
         }
 
         &.mud-input-underline {
@@ -142,7 +146,7 @@
             width: 100%;
             max-width: 100%;
             height: 100%;
-            text-align: left;
+            text-align: start;
             pointer-events: none;
             border-radius: var(--mud-default-borderradius);
             border-color: var(--mud-palette-lines-inputs);
@@ -166,10 +170,14 @@
 
         &.mud-input-adorned-start {
             padding-left: 14px;
+            padding-inline-start: 14px;
+            padding-inline-end: unset;
         }
 
         &.mud-input-adorned-end {
             padding-right: 14px;
+            padding-inline-end: 14px;
+            padding-inline-start: unset;
         }
     }
 }
@@ -261,10 +269,14 @@
 
             &.mud-input-root-adorned-start {
                 padding-left: 0;
+                padding-inline-start: 0;
+                padding-inline-end: 12px;
             }
 
             &.mud-input-root-adorned-end {
                 padding-right: 0;
+                padding-inline-end: 0;
+                padding-inline-start: 12px;
             }
         }
     }
@@ -284,10 +296,14 @@
 
         &.mud-input-root-adorned-start {
             padding-left: 0;
+            padding-inline-start: 0;
+            padding-inline-end: 14px;
         }
 
         &.mud-input-root-adorned-end {
             padding-right: 0;
+            padding-inline-end: 0;
+            padding-inline-start: 14px;
         }
     }
 
@@ -368,10 +384,15 @@
 
       &.mud-input-root-adorned-start {
         margin-left: 0;
+        margin-inline-start: 0;
+        margin-inline-end: 12px;
+
       }
 
       &.mud-input-root-adorned-end {
         margin-right: 0;
+        margin-inline-end: unset;
+        margin-inline-start: 12px;
       }
     }
 
@@ -407,10 +428,14 @@
 
     &.mud-input-root-adorned-start {
       margin-left: 0;
+      margin-inline-start: 0;
+      margin-inline-end: 14px;
     }
 
     &.mud-input-root-adorned-end {
       margin-right: 0;
+      margin-inline-end: 0;
+      margin-inline-start: 14px;
     }
   }
 }
@@ -432,6 +457,8 @@
 .mud-input-adornment-start {
   &.mud-text {
     margin-right: 8px;
+    margin-inline-end: 8px;
+    margin-inline-start: unset;
   }
 
   &.mud-icon {
@@ -440,14 +467,20 @@
 
 .mud-input-adornment-end {
   margin-left: 8px;
+  margin-inline-start: 8px;
+  margin-inline-end: unset;
 }
 
 .mud-input-number-control.mud-input-showspin .mud-input-adornment-end {
     margin-right: 12px;
+    margin-inline-end: 12px;
+    margin-inline-start: unset;
 }
 
 .mud-input-number-control.mud-input-showspin .mud-input-underline:not(.mud-input-filled) .mud-input-adornment-end {
     margin-right: 24px;
+    margin-inline-end: 24px;
+    margin-inline-start: unset;
 }
 
 .mud-input-adornment-disable-pointerevents {

--- a/src/MudBlazor/Styles/components/_inputcontrol.scss
+++ b/src/MudBlazor/Styles/components/_inputcontrol.scss
@@ -1,4 +1,4 @@
-﻿.mud-input-control {
+.mud-input-control {
     border: 0;
     margin: 0;
     padding: 0;
@@ -82,11 +82,38 @@
             -moz-appearance: textfield;
         }
 
-        &.mud-input-showspin .mud-input:not(.mud-input-adorned-end) input {
-            padding-right: 24px; //This must be the same width of the spinners
+        &.mud-input-showspin .mud-input:not(.mud-input-adorned-end) {
+            input {
+                padding-right: 24px; //This must be the same width of the spinners
+                padding-inline-end: 24px;
 
-            &.mud-input-root-margin-dense {
-                padding-right: 17px; //This must be the same width of the spinners
+                &.mud-input-root-margin-dense {
+                    padding-right: 17px; //This must be the same width of the spinners
+                    padding-inline-end: 17px;
+                }
+            }
+            &.mud-input-text input {
+                padding-inline-start: 0;
+
+                &.mud-input-root-margin-dense {
+                    padding-inline-start: 0;
+                }
+            }
+
+            &.mud-input-filled input {
+                padding-inline-start: 12px;
+
+                &.mud-input-root-margin-dense {
+                    padding-inline-start: 12px;
+                }
+            }
+
+            &.mud-input-outlined input {
+                padding-inline-start: 14px;
+
+                &.mud-input-root-margin-dense {
+                    padding-inline-start: 14px;
+                }
             }
         }
 
@@ -117,7 +144,7 @@
     margin: 0;
     font-size: 0.75rem;
     margin-top: 3px;
-    text-align: left;
+    text-align: start;
     font-weight: 400;
     line-height: 1.66;
     letter-spacing: 0.03333em;

--- a/src/MudBlazor/Styles/components/_list.scss
+++ b/src/MudBlazor/Styles/components/_list.scss
@@ -15,7 +15,7 @@
     display: flex;
     position: relative;
     box-sizing: border-box;
-    text-align: left;
+    text-align: start;
     align-items: center;
     padding-top: 8px;
     padding-bottom: 8px;
@@ -77,6 +77,8 @@
 
 .mud-list-item-text-inset {
     padding-left: 56px;
+    padding-inline-start: 56px;
+    padding-inline-end: unset;
 }
 
 .mud-list-item-icon {
@@ -104,6 +106,8 @@
 
 .mud-list-subheader-inset {
     padding-left: 72px;
+    padding-inline-start: 72px;
+    padding-inline-end: unset;
 }
 
 .mud-list-subheader-sticky {
@@ -122,5 +126,7 @@
 .mud-nested-list {
     & > .mud-list-item {
         padding-left: 32px;
+        padding-inline-start: 32px;
+        padding-inline-end: unset;
     }
 }

--- a/src/MudBlazor/Styles/components/_navmenu.scss
+++ b/src/MudBlazor/Styles/components/_navmenu.scss
@@ -28,6 +28,8 @@
 
     & * .mud-navmenu .mud-nav-item .mud-nav-link {
         padding-left: 36px;
+        padding-inline-start: 36px;
+        padding-inline-end: unset;
     }
 }
 
@@ -93,8 +95,10 @@
 
     & .mud-nav-link-text {
         width: 100%;
-        text-align: left;
+        text-align: start;
         margin-left: 12px;
+        margin-inline-start: 12px;
+        margin-inline-end: unset;
         letter-spacing: 0;
     }
 }
@@ -106,17 +110,11 @@
 .mud-nav-group * .mud-navmenu > .mud-nav-group {
     & .mud-nav-link {
         padding-left: 36px;
+        padding-inline-start: 36px;
     }
 
     & * .mud-navmenu .mud-nav-item .mud-nav-link {
         padding-left: 48px;
-    }
-}
-
-.mud-application-layout-rtl {
-    & * .mud-nav-link-text {
-        text-align: right;
-        margin-left: 0px;
-        margin-right: 12px;
+        padding-inline-start: 48px;
     }
 }

--- a/src/MudBlazor/Styles/components/_picker.scss
+++ b/src/MudBlazor/Styles/components/_picker.scss
@@ -12,6 +12,8 @@
 
         & > :not(:first-child) {
             margin-left: 8px;
+            margin-inline-start: 8px;
+            margin-inline-end: unset;
         }
     }
 }

--- a/src/MudBlazor/Styles/components/_pickerdate.scss
+++ b/src/MudBlazor/Styles/components/_pickerdate.scss
@@ -26,6 +26,8 @@
 
 .mud-picker-datepicker-date-landscape {
     margin-right: 16px;
+    margin-inline-end: 16px;
+    margin-inline-start: unset;
 }
 
 

--- a/src/MudBlazor/Styles/components/_pickertime.scss
+++ b/src/MudBlazor/Styles/components/_pickertime.scss
@@ -31,6 +31,8 @@
         display: flex;
         margin-left: 20px;
         margin-right: -20px;
+        margin-inline-start: 20px;
+        margin-inline-end: -20px;
         flex-direction: column;
 
         .mud-timepicker-button {
@@ -44,6 +46,8 @@
     .mud-timepicker-separator {
         cursor: default;
         margin: 0 4px 0 2px;
+        margin-inline-start: 2px;
+        margin-inline-end: 4px;
     }
 
     &.mud-picker-timepicker-toolbar-landscape {
@@ -64,6 +68,8 @@
             display: flex;
             margin-left: 20px;
             margin-right: -20px;
+            margin-inline-start: 20px;
+            margin-inline-end: -20px;
             flex-direction: column;
 
             .mud-timepicker-button {

--- a/src/MudBlazor/Styles/components/_radio.scss
+++ b/src/MudBlazor/Styles/components/_radio.scss
@@ -6,6 +6,8 @@
     align-items: center;
     margin-left: -11px;
     margin-right: 16px;
+    margin-inline-start: -11px;
+    margin-inline-end: 16px;
     vertical-align: middle;
     -webkit-tap-highlight-color: transparent;
     color: var(--mud-palette-action-default);
@@ -90,16 +92,22 @@
     &start {
         margin-left: 16px;
         margin-right: -11px;
+        margin-inline-start: 16px;
+        margin-inline-end: -11px;
         flex-direction: row-reverse;
     }
 
     &top {
         margin-left: 16px;
+        margin-inline-start: 16px;
+        margin-inline-end: unset;
         flex-direction: column-reverse;
     }
 
     &bottom {
         margin-left: 16px;
+        margin-inline-start: 16px;
+        margin-inline-end: unset;
         flex-direction: column;
     }
 }

--- a/src/MudBlazor/Styles/components/_simpletable.scss
+++ b/src/MudBlazor/Styles/components/_simpletable.scss
@@ -25,7 +25,7 @@
                 display: table-cell;
                 padding: 16px;
                 font-size: 0.875rem;
-                text-align: left;
+                text-align: start;
                 font-weight: 400;
                 line-height: 1.43;
                 border-bottom: 1px solid var(--mud-palette-table-lines);
@@ -51,10 +51,13 @@
     & * tr {
         & td, th {
             padding: 6px 24px 6px 16px;
+            padding-inline-start: 16px;
+            padding-inline-end: 24px;
         }
 
         & td, th:last-child {
             padding-right: 16px;
+            padding-inline-end: 16px;
         }
     }
 }

--- a/src/MudBlazor/Styles/components/_snackbar.scss
+++ b/src/MudBlazor/Styles/components/_snackbar.scss
@@ -1,4 +1,4 @@
-﻿
+
 .mud-snackbar {
     display: flex;
     flex-wrap: wrap;
@@ -38,6 +38,9 @@
         margin-left: auto;
         margin-right: -8px;
         padding-left: 16px;
+        margin-inline-start: auto;
+        margin-inline-end: -8px;
+        padding-inline-start: 16px;
 
         & > button {
             color: inherit;

--- a/src/MudBlazor/Styles/components/_switch.scss
+++ b/src/MudBlazor/Styles/components/_switch.scss
@@ -6,6 +6,8 @@
     align-items: center;
     margin-left: -11px;
     margin-right: 16px;
+    margin-inline-start: -11px;
+    margin-inline-end: 16px;
     vertical-align: middle;
     -webkit-tap-highlight-color: transparent;
 

--- a/src/MudBlazor/Styles/components/_table.scss
+++ b/src/MudBlazor/Styles/components/_table.scss
@@ -1,4 +1,4 @@
-﻿@import '../abstracts/variables';
+@import '../abstracts/variables';
 
 .mud-table {
     color: var(--mud-palette-text-primary);
@@ -90,6 +90,8 @@
 .mud-table-toolbar {
     padding-left: 16px;
     padding-right: 8px;
+    padding-inline-start: 16px;
+    padding-inline-end: 8px;
 }
 
 
@@ -98,7 +100,7 @@
     display: table-cell;
     padding: 16px;
     font-size: 0.875rem;
-    text-align: left;
+    text-align: start;
     font-weight: 400;
     line-height: 1.43;
     border-bottom: 1px solid var(--mud-palette-table-lines);
@@ -120,10 +122,14 @@
     & * .mud-table-row {
         & .mud-table-cell {
             padding: 6px 24px 6px 16px;
+            padding-inline-start: 16px;
+            padding-inline-end: 24px;
         }
 
         & .mud-table-cell:last-child {
             padding-right: 16px;
+            padding-inline-end: 16px;
+            padding-inline-start: unset;
         }
     }
 }
@@ -286,6 +292,8 @@
     border-top: 1px solid var(--mud-palette-table-lines);
     height: 52px;
     padding-right: 2px;
+    padding-inline-end: 2px;
+    padding-inline-start: unset;
 }
 
 .mud-table-pagination-spacer {
@@ -323,6 +331,8 @@
 .mud-table-pagination-actions {
     flex-shrink: 0;
     margin-left: 20px;
+    margin-inline-start: 20px;
+    margin-inline-end: unset;
 }
 
 .mud-table-smalldevices-sortselect {
@@ -359,7 +369,7 @@
             align-items: center;
             border: none;
             padding: 14px 16px;
-            text-align: left !important;
+            text-align: start !important;
         }
 
         &.mud-table-dense {
@@ -372,6 +382,8 @@
             content: attr(data-label);
             font-weight: 500;
             padding-right: 16px;
+            padding-inline-end: 16px;
+            padding-inline-start: unset;
         }
 
         &.mud-table-small-alignright .mud-table-cell:before {
@@ -403,6 +415,7 @@
 
             .mud-select ~ .mud-table-pagination-caption {
                 margin-left: auto;
+                margin-inline-start: auto;
             }
         }
     }
@@ -415,10 +428,13 @@
             .mud-select {
                 margin-left: auto;
                 margin-right: -14px;
+                margin-inline-start: auto;
+                margin-inline-end: -14px;
             }
 
             .mud-select ~ .mud-table-pagination-caption {
                 margin-left: unset !important;
+                margin-inline-start: unset !important;
             }
         }
     }
@@ -431,11 +447,15 @@
                 flex-wrap: wrap;
                 padding-top: 16px;
                 padding-right: 16px;
+                padding-inline-end: 16px;
+                padding-inline-start: unset;
                 min-height: 100px;
 
                 .mud-table-pagination-actions {
                     margin-left: auto;
                     margin-right: -14px;
+                    margin-inline-start: auto;
+                    margin-inline-end: -14px;
                 }
             }
         }

--- a/src/MudBlazor/Styles/components/_tabs.scss
+++ b/src/MudBlazor/Styles/components/_tabs.scss
@@ -1,4 +1,4 @@
-﻿@import '../abstracts/variables';
+@import '../abstracts/variables';
 
 .mud-tabs {
     display: flex;
@@ -161,6 +161,8 @@
 
     & .mud-tab-icon-text {
         margin-right: 8px;
+        margin-inline-end: 8px;
+        margin-inline-start: unset;
     }
 }
 
@@ -194,6 +196,8 @@
 
 .mud-tab-badge{
     margin-left:8px;
+    margin-inline-start: 8px;
+    margin-inline-end: unset;
 }
 
 @each $color in $mud-palette-colors {

--- a/src/MudBlazor/Styles/components/_treeview.scss
+++ b/src/MudBlazor/Styles/components/_treeview.scss
@@ -17,6 +17,8 @@
     margin: 0px;
     padding: 0px;
     margin-left: 17px;
+    margin-inline-start: 17px;
+    margin-inline-end: unset;
     list-style: none;
 }
 
@@ -73,12 +75,16 @@
     display: flex;
     flex-shrink: 0;
     margin-right: 4px;
+    margin-inline-end: 4px;
+    margin-inline-start: unset;
     justify-content: center;
 }
 
 .mud-treeview-item-label {
     flex-grow: 1;
     padding-left: 4px;
+    padding-inline-start: 4px;
+    padding-inline-end: unset;
 }
 
 .mud-treeview-canhover .mud-treeview-item-activated .mud-treeview-item-content:hover {
@@ -118,26 +124,7 @@
 }
 
 .mud-application-layout-rtl {
-    .mud-treeview-item-icon {
-        margin-left: 4px;
-        margin-right: 0;
-    }
-
-    .mud-treeview-item-label {
-        padding-right: 4px;
-        padding-left: 0;
-    }
-
-    .mud-treeview-group {
-        margin-right: 17px;
-        margin-left: 0;
-    }
-
     .mud-treeview-item-arrow {
-        transform: rotate(180deg);
-
-        .mud-treeview-item-arrow-expand.mud-transform {
-            transform: rotate(-90deg);
-        }
+        transform: scaleX(-1);
     }
 }


### PR DESCRIPTION
I changed:
`padding-left` to `padding-inline-start`
`padding-right` to `padding-inline-end`
`margin-left` to `margin-inline-start`
`margin-right` to `margin-inline-end`
`text-align: left` to `text-align: start`
`text-align: right` to `text-align: end`
where it was necessary.

That way we can easily fix all padding, margin and alignment problems without writing custom css for rtl.
These properties are supported by all browser which are supported by blazor.
https://caniuse.com/?search=padding-inline-start
https://docs.microsoft.com/en-us/aspnet/core/blazor/supported-platforms?view=aspnetcore-5.0