### PR TITLE
MudTable: Fix initial sort label not being set for table when using InitialDirection for MudTableSortLabel

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableOnlySortedTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableOnlySortedTest.razor
@@ -1,8 +1,8 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
-<MudTable ServerData="@(new Func<TableState, Task<TableData<int>>>(ServerReload))">
+<MudTable ServerData="@(new Func<TableState, Task<TableData<int>>>(ServerReload))" AllowUnsorted="false">
     <HeaderContent>
-        <MudTh><MudTableSortLabel SortLabel="No." InitialDirection="SortDirection.Descending" T="int">Nr</MudTableSortLabel></MudTh>
+        <MudTh><MudTableSortLabel SortLabel="No." T="int">Nr</MudTableSortLabel></MudTh>
     </HeaderContent>
     <RowTemplate>
         <MudTd DataLabel="Nr">@context</MudTd>
@@ -14,7 +14,7 @@
 
 @code {
 #pragma warning disable CS1998 // async without await
-    public static string __description__ = "The server-side loaded table should reflect initial sort direction in its initial table state.";
+    public static string __description__ = "When AllowUnsorted is not set a table must have at least one MudTableSortLabel with InitialDirection";
 
     private int totalItems;
 

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -688,6 +688,16 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// The server-side loaded table should reflect initial sort direction in its initial table state.
+        /// In this case, the items should be sorted with descending order.
+        /// </summary>
+        [Test]
+        public async Task TableOnlySortedTest()
+        {
+            Assert.Throws<ArgumentException>(() => ctx.RenderComponent<TableOnlySortedTest>());
+        }
+
+        /// <summary>
         /// The table should render the classes and style to the tr using the RowStyleFunc and RowClassFunc parameters
         /// </summary>
         [Test]

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -105,6 +105,12 @@ namespace MudBlazor
         [Parameter] public string SortLabel { get; set; }
 
         /// <summary>
+        /// If true allows table to be in an unsorted state through column clicks (i.e. first click sorts "Ascending", second "Descending", third "None").
+        /// If false only "Ascending" and "Descending" states are allowed (i.e. there always should be a column to sort).
+        /// </summary>
+        [Parameter] public bool AllowUnsorted { get; set; } = true;
+
+        /// <summary>
         /// If the table has more items than this number, it will break the rows into pages of said size.
         /// Note: requires a MudTablePager in PagerContent.
         /// </summary>

--- a/src/MudBlazor/Components/Table/MudTableSortLabel.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTableSortLabel.razor.cs
@@ -65,15 +65,16 @@ namespace MudBlazor
 
         [Parameter] public string SortLabel { get; set; }
 
-        public Task ToggleSortDirection()
-        {
-            if (SortDirection == SortDirection.None)
-                return UpdateSortDirectionAsync(SortDirection.Ascending);
-            else if (SortDirection == SortDirection.Ascending)
-                return UpdateSortDirectionAsync(SortDirection.Descending);
-            else
-                return UpdateSortDirectionAsync(SortDirection.None);
-        }
+        public Task ToggleSortDirection() =>
+            (SortDirection, Table.AllowUnsorted) switch
+            {
+                (SortDirection.None, _) => UpdateSortDirectionAsync(SortDirection.Ascending),
+                (SortDirection.Ascending, _) => UpdateSortDirectionAsync(SortDirection.Descending),
+                (SortDirection.Descending, true) => UpdateSortDirectionAsync(SortDirection.None),
+                (SortDirection.Descending, false) => UpdateSortDirectionAsync(SortDirection.Ascending),
+
+                _ => throw new ArgumentException("Unsupported sort direction", nameof(SortDirection)),
+            };
 
         protected override void OnInitialized()
         {

--- a/src/MudBlazor/Components/Table/TableContext.cs
+++ b/src/MudBlazor/Components/Table/TableContext.cs
@@ -112,8 +112,13 @@ namespace MudBlazor
         public override void InitializeSorting()
         {
             var initial_sortlabel = SortLabels.FirstOrDefault(x => x.InitialDirection != SortDirection.None);
-            if (initial_sortlabel == null)
+
+            if (initial_sortlabel == null && !Table.AllowUnsorted)
+                throw new ArgumentException("If AllowUnsorted is not set then there has to be at least one MudTableSortLabel with InitialDirection set");
+
+            if (initial_sortlabel == null && Table.AllowUnsorted)
                 return;
+
             CurrentSortLabel = initial_sortlabel;
             UpdateSortLabels(initial_sortlabel);
             // this will trigger initial sorting of the table

--- a/src/MudBlazor/Components/Table/TableContext.cs
+++ b/src/MudBlazor/Components/Table/TableContext.cs
@@ -114,6 +114,7 @@ namespace MudBlazor
             var initial_sortlabel = SortLabels.FirstOrDefault(x => x.InitialDirection != SortDirection.None);
             if (initial_sortlabel == null)
                 return;
+            CurrentSortLabel = initial_sortlabel;
             UpdateSortLabels(initial_sortlabel);
             // this will trigger initial sorting of the table
             initial_sortlabel.SetSortDirection(initial_sortlabel.InitialDirection);


### PR DESCRIPTION
A small fix for #1702 
Seems to work.