### PR TITLE
Moving popups outside the parent container

### DIFF
--- a/src/MudBlazor.Docs/Shared/MainLayout.razor
+++ b/src/MudBlazor.Docs/Shared/MainLayout.razor
@@ -5,6 +5,7 @@
 <MudThemeProvider Theme="_currentTheme"/>
 <MudDialogProvider FullWidth="true" MaxWidth="MaxWidth.ExtraSmall" />
 <MudSnackbarProvider />
+<MudBodyRenderProvider />
 
 <MudSwipeArea OnSwipe="@OnSwipe">
     <MudLayout RightToLeft="@_rightToLeft">

--- a/src/MudBlazor.UnitTests/Generated/ExampleDocsTests.cs
+++ b/src/MudBlazor.UnitTests/Generated/ExampleDocsTests.cs
@@ -31,6 +31,7 @@ namespace MudBlazor.UnitTests.Components
             ctx.Services.AddSingleton<IHeadElementHelper>(new MockHeadElementHelper());
             ctx.Services.AddTransient<IResizeObserver, MockResizeObserver>();
             ctx.Services.AddSingleton<IBrowserWindowSizeProvider>(new MockBrowserWindowSizeProvider());
+            ctx.Services.AddSingleton<IBodyRenderService, BodyRenderService>();
             ctx.Services.AddOptions();
             ctx.Services.AddScoped(sp =>
                 new HttpClient(new MockDocsMessageHandler()) { BaseAddress = new Uri("https://localhost/") });

--- a/src/MudBlazor.UnitTests/Mocks/MockScrollServices.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockScrollServices.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using MudBlazor.Interop;
 
 namespace MudBlazor.UnitTests.Mocks
 {
@@ -45,5 +46,7 @@ namespace MudBlazor.UnitTests.Mocks
         public ValueTask ScrollToYearAsync(string elementId) => ValueTask.CompletedTask;
 
         public ValueTask UnlockScrollAsync(string elementId, string cssClass) => ValueTask.CompletedTask;
+
+        public ValueTask<ScrollPosition> GetScrollPosition() => ValueTask.FromResult(new ScrollPosition());
     }
 }

--- a/src/MudBlazor/Components/Body/BodyRenderService.cs
+++ b/src/MudBlazor/Components/Body/BodyRenderService.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+namespace MudBlazor
+{
+    public class BodyRenderService : IBodyRenderService
+    {
+        public event Action OnRenderRequested;
+        public event Action<MudBodyRendered> OnComponentAdded;
+        public event Action<MudBodyRendered> OnComponentRemoved;
+
+        public void AddComponent(MudBodyRendered bodyRendered)
+        {
+            OnComponentAdded?.Invoke(bodyRendered);
+        }
+
+        public void RemoveComponent(MudBodyRendered bodyRendered)
+        {
+            OnComponentRemoved?.Invoke(bodyRendered);
+        }
+
+        public void Render()
+        {
+            OnRenderRequested?.Invoke();
+        }
+    }
+}

--- a/src/MudBlazor/Components/Body/IBodyRenderService.cs
+++ b/src/MudBlazor/Components/Body/IBodyRenderService.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace MudBlazor
+{
+    public interface IBodyRenderService
+    {
+        event Action OnRenderRequested;
+        event Action<MudBodyRendered> OnComponentAdded;
+        event Action<MudBodyRendered> OnComponentRemoved;
+
+        void AddComponent(MudBodyRendered bodyRendered);
+
+        void RemoveComponent(MudBodyRendered bodyRendered);
+        void Render();
+    }
+}

--- a/src/MudBlazor/Components/Body/MudBodyRenderProvider.razor
+++ b/src/MudBlazor/Components/Body/MudBodyRenderProvider.razor
@@ -1,0 +1,13 @@
+﻿@namespace MudBlazor 
+@inherits ComponentBase 
+@implements IDisposable
+
+<div>
+    @foreach (var component in components)
+    {
+        if (component.IsRendered)
+        {
+            @component.ChildContent
+        }
+    }
+</div>

--- a/src/MudBlazor/Components/Body/MudBodyRenderProvider.razor.cs
+++ b/src/MudBlazor/Components/Body/MudBodyRenderProvider.razor.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Components;
+
+namespace MudBlazor
+{
+    public partial class MudBodyRenderProvider : ComponentBase, IDisposable
+    {
+        private List<MudBodyRendered> components = new List<MudBodyRendered>();
+
+        [Inject]
+        public IBodyRenderService BodyRenderService { get; set; }
+
+        protected override void OnInitialized()
+        {
+            base.OnInitialized();
+
+            BodyRenderService.OnRenderRequested += StateHasChanged;
+            BodyRenderService.OnComponentAdded += BodyRenderService_OnComponentAdded;
+            BodyRenderService.OnComponentRemoved += BodyRenderService_OnComponentRemoved;
+        }
+
+        private void BodyRenderService_OnComponentAdded(MudBodyRendered obj)
+        {
+            components.Add(obj);
+            StateHasChanged();
+        }
+
+        private void BodyRenderService_OnComponentRemoved(MudBodyRendered obj)
+        {
+            components.Remove(obj);
+            StateHasChanged();
+        }
+
+        public void Dispose()
+        {
+            BodyRenderService.OnRenderRequested -= StateHasChanged;
+            BodyRenderService.OnComponentAdded -= BodyRenderService_OnComponentAdded;
+            BodyRenderService.OnComponentRemoved -= BodyRenderService_OnComponentRemoved;
+        }
+    }
+}

--- a/src/MudBlazor/Components/Body/MudBodyRendered.cs
+++ b/src/MudBlazor/Components/Body/MudBodyRendered.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using Microsoft.AspNetCore.Components;
+
+namespace MudBlazor
+{
+    public class MudBodyRendered : ComponentBase, IDisposable
+    {
+        [Parameter]
+        public RenderFragment ChildContent { get; set; }
+
+        [Parameter]
+        public bool IsRendered { get; set; } = true;
+
+        [Inject]
+        public IBodyRenderService BodyRenderService { get; set; }
+
+        protected override void OnInitialized()
+        {
+            base.OnInitialized();
+
+            BodyRenderService?.AddComponent(this);
+        }
+
+        protected override void OnAfterRender(bool firstRender)
+        {
+            base.OnAfterRender(firstRender);
+            BodyRenderService?.Render();
+        }
+
+        public void Dispose()
+        {
+
+            BodyRenderService?.RemoveComponent(this);
+        }
+    }
+}

--- a/src/MudBlazor/Components/Menu/MudMenu.razor
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor
@@ -4,7 +4,7 @@
 
 
 
-<div class="@Classname" style="@Style" oncontextmenu="@(ActivationEvent == MouseEvent.RightClick ? "return false;" : "")">
+<div @ref="_container" class="@Classname" style="@Style" oncontextmenu="@(ActivationEvent == MouseEvent.RightClick ? "return false;" : "")">
     @if (ActivatorContent != null)
     {
         <CascadingValue Value="@((IActivatable) this)" IsFixed="true">
@@ -33,7 +33,7 @@
         <MudIconButton Icon="@Icon" Color="@Color" Size="@Size" Disabled="@Disabled" DisableRipple="@DisableRipple" @onclick="@ToggleMenu" />
     }
     <CascadingValue Value="@this">
-        <MudPopover Open="@_isOpen" Class="@MenuClassname" MaxHeight="@MaxHeight" Style="@PopoverStyle" Direction="@Direction" OffsetX="@OffsetX" OffsetY="@OffsetY">
+        <MudPopover ContainerRef="@_container" FullWidth="@FullWidth" Open="@_isOpen" Class="@MenuClassname" MaxHeight="@MaxHeight" Style="@PopoverStyle" Direction="@Direction" OffsetX="@OffsetX" OffsetY="@OffsetY">
             <MudList Clickable="true" Dense="@Dense">
                 @ChildContent
             </MudList>

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -20,6 +20,7 @@ namespace MudBlazor
        .Build();
 
         private bool _isOpen;
+        private ElementReference _container;
 
         [Parameter] public string Label { get; set; }
 
@@ -111,6 +112,8 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public RenderFragment ChildContent { get; set; }
 
+        [Inject] private IScrollManager ScrollManager { get; set; }
+
         public string PopoverStyle { get; set; }
 
         public void CloseMenu()
@@ -120,11 +123,13 @@ namespace MudBlazor
             StateHasChanged();
         }
 
-        public void OpenMenu(MouseEventArgs args)
+        public async void OpenMenu(MouseEventArgs args)
         {
             if (Disabled)
                 return;
-            PopoverStyle = PositionAtCurser ? $"position:fixed; left:{args?.ClientX}px; top:{args?.ClientY}px;" : null;
+
+            var scrollPosition = await ScrollManager.GetScrollPosition();
+            PopoverStyle = PositionAtCurser ? $"transform: translate({args?.ClientX + scrollPosition.Left}px, {args?.ClientY + scrollPosition.Top}px);" : null;
             _isOpen = true;
             StateHasChanged();
         }

--- a/src/MudBlazor/Components/Popover/MudPopover.razor
+++ b/src/MudBlazor/Components/Popover/MudPopover.razor
@@ -1,6 +1,8 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
 
-<div @attributes="UserAttributes" class="@PopoverClass" style="@PopoverStyles">
-    @ChildContent
-</div>
+<MudBodyRendered IsRendered="Open">
+    <div @ref="_popoverRef" @attributes="UserAttributes" class="@PopoverClass" style="@PopoverStyles">
+        @ChildContent
+    </div>
+</MudBodyRendered>

--- a/src/MudBlazor/Components/Popover/MudPopover.razor.cs
+++ b/src/MudBlazor/Components/Popover/MudPopover.razor.cs
@@ -1,5 +1,9 @@
-﻿using Microsoft.AspNetCore.Components;
+﻿using System;
+using System.Globalization;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
 using MudBlazor.Extensions;
+using MudBlazor.Interop;
 using MudBlazor.Utilities;
 
 
@@ -7,12 +11,14 @@ namespace MudBlazor
 {
     public partial class MudPopover : MudComponentBase
     {
+        private ElementReference _popoverRef;
+
         protected string PopoverClass =>
            new CssBuilder("mud-popover")
             .AddClass("mud-popover-open", Open)
-            .AddClass($"mud-popover-{Direction.ToDescriptionString()}")
-            .AddClass("mud-popover-offset-y", OffsetY)
-            .AddClass("mud-popover-offset-x", OffsetX)
+            //.AddClass($"mud-popover-{Direction.ToDescriptionString()}")
+            //.AddClass("mud-popover-offset-y", OffsetY)
+            //.AddClass("mud-popover-offset-x", OffsetX)
             .AddClass("mud-paper")
             .AddClass("mud-paper-square", Square)
             .AddClass($"mud-elevation-{Elevation}")
@@ -24,6 +30,14 @@ namespace MudBlazor
             .AddStyle("max-height", $"{MaxHeight}px", MaxHeight != null)
             .AddStyle(Style)
             .Build();
+
+        [Parameter]
+        public ElementReference ContainerRef { get; set; }
+
+        /// <summary>
+        /// If true, the popover will be same width as the <see cref="ContainerRef"/>.
+        /// </summary>
+        [Parameter] public bool FullWidth { get; set; }
 
         /// <summary>
         /// The higher the number, the heavier the drop-shadow. 0 for no shadow set to 8 by default.
@@ -64,5 +78,15 @@ namespace MudBlazor
         /// Child content of the component.
         /// </summary>
         [Parameter] public RenderFragment ChildContent { get; set; }
+
+        protected override async Task OnAfterRenderAsync(bool firstRender)
+        {
+            await _popoverRef.MudSetPositionRelativeToAsync(ContainerRef, new MudPositionOptions()
+            {
+                Direction = Direction,
+                ApplyReferenceWidth = FullWidth
+            });
+            await base.OnAfterRenderAsync(firstRender);
+        }
     }
 }

--- a/src/MudBlazor/Components/Tooltip/MudTooltip.razor
+++ b/src/MudBlazor/Components/Tooltip/MudTooltip.razor
@@ -1,19 +1,23 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
 
-<div class="@ContainerClass">
+<div @ref="_containerRef" class="@ContainerClass" 
+     onmouseenter="document.getElementById('@_tooltipId').classList.add('mud-tooltip-hover')"
+     onmouseleave="document.getElementById('@_tooltipId').classList.remove('mud-tooltip-hover')">
     @ChildContent
     @if (!String.IsNullOrEmpty(Text) || TooltipContent != null)
     {
-        <div class="@Classname" style="@GetTimeDelay()">
-            @if (TooltipContent != null)
-            {
-                @TooltipContent
-            }
-            else
-            {
-                @Text
-            }
-        </div>
+        <MudBodyRendered>
+            <div id="@_tooltipId" @ref="_tooltipRef" class="@Classname" style="@GetTimeDelay()">
+                @if (TooltipContent != null)
+                {
+                    @TooltipContent
+                }
+                else
+                {
+                    @Text
+                }
+            </div>
+        </MudBodyRendered>
     }
 </div>

--- a/src/MudBlazor/Components/Tooltip/MudTooltip.razor.cs
+++ b/src/MudBlazor/Components/Tooltip/MudTooltip.razor.cs
@@ -1,18 +1,23 @@
 ﻿using System;
 using System.Globalization;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.Extensions;
+using MudBlazor.Interop;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
 {
     public partial class MudTooltip : MudComponentBase
     {
+        private ElementReference _containerRef, _tooltipRef;
+        private string _tooltipId = Guid.NewGuid().ToString();
+
         protected string ContainerClass => new CssBuilder("mud-tooltip-root")
             .AddClass("mud-tooltip-inline", Inline)
             .Build();
         protected string Classname => new CssBuilder("mud-tooltip")
-            .AddClass($"mud-tooltip-placement-{Placement.ToDescriptionString()}")
+            //.AddClass($"mud-tooltip-placement-{Placement.ToDescriptionString()}")
             .AddClass(Class)
             .Build();
 
@@ -51,15 +56,28 @@ namespace MudBlazor
         /// Tooltip content. May contain any valid html
         /// </summary>
         [Parameter] public RenderFragment TooltipContent { get; set; }
-
+        
         /// <summary>
         /// Determines if this component should be inline with it's surrounding (default) or if it should behave like a block element.
         /// </summary>
         [Parameter] public Boolean Inline { get; set; } = true;
 
+        [CascadingParameter] public bool Rtl { get; set; }
+
         protected string GetTimeDelay()
         {
             return $"transition-delay: {Delay.ToString(CultureInfo.InvariantCulture)}ms;{Style}";
+        }
+        
+        protected override async Task OnAfterRenderAsync(bool firstRender)
+        {
+            var options = new MudPositionOptions()
+            {
+                Center = true
+            };
+            options.SetDirection(Placement, Rtl);
+            await _tooltipRef.MudSetPositionRelativeToAsync(_containerRef, options);
+            await base.OnAfterRenderAsync(firstRender);
         }
     }
 }

--- a/src/MudBlazor/Extensions/ElementReferenceExtensions.cs
+++ b/src/MudBlazor/Extensions/ElementReferenceExtensions.cs
@@ -65,6 +65,9 @@ namespace MudBlazor
         public static ValueTask MudRemoveEventListenerAsync(this ElementReference elementReference, string @event, int eventId) =>
             elementReference.GetJSRuntime()?.InvokeVoidAsync("mudElementRef.removeEventListener", elementReference, eventId) ?? ValueTask.CompletedTask;
 
+        public static ValueTask MudSetPositionRelativeToAsync(this ElementReference elementReference, ElementReference relativeTo, MudPositionOptions options) =>
+            elementReference.GetJSRuntime()?.InvokeVoidAsync("mudElementRef.mudSetPositionRelativeTo", elementReference, relativeTo, options) ?? ValueTask.CompletedTask;
+
         private static object GetSerializationSpec(Type type)
         {
             var props = type.GetProperties();

--- a/src/MudBlazor/Interop/MudPositionOptions.cs
+++ b/src/MudBlazor/Interop/MudPositionOptions.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace MudBlazor.Interop
+{
+    public class MudPositionOptions
+    {
+        public Direction Direction { get; set; }
+
+        public bool Center { get; set; }
+
+        public bool ApplyReferenceWidth { get; set; }
+
+        internal void SetDirection(Placement placement, bool rtl)
+        {
+            switch (placement)
+            {
+                case Placement.Start:
+                    Direction = rtl ? Direction.Right : Direction.Left;
+                    break;
+                case Placement.End:
+                    Direction = rtl ? Direction.Left : Direction.Right;
+                    break;
+                case Placement.Top:
+                    Direction = Direction.Top;
+                    break;
+                case Placement.Bottom:
+                    Direction = Direction.Bottom;
+                    break;
+                default: break;
+            }
+        }
+    }
+}

--- a/src/MudBlazor/Interop/ScrollPosition.cs
+++ b/src/MudBlazor/Interop/ScrollPosition.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace MudBlazor.Interop
+{
+    public class ScrollPosition
+    {
+        public double Left { get; set; }
+        public double Top { get; set; }
+        public double Width { get; set; }
+        public double Height { get; set; }
+    }
+}

--- a/src/MudBlazor/Services/Scroll/ScrollManager.cs
+++ b/src/MudBlazor/Services/Scroll/ScrollManager.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Microsoft.JSInterop;
 using MudBlazor.Extensions;
+using MudBlazor.Interop;
 
 namespace MudBlazor
 {
@@ -26,6 +27,7 @@ namespace MudBlazor
         ValueTask ScrollToListItemAsync(string elementId, int increment, bool onEdges);
         ValueTask LockScrollAsync(string elementId, string cssClass);
         ValueTask UnlockScrollAsync(string elementId, string cssClass);
+        ValueTask<ScrollPosition> GetScrollPosition();
     }
 
     public class ScrollManager : IScrollManager
@@ -95,6 +97,9 @@ namespace MudBlazor
 
         public ValueTask UnlockScrollAsync(string elementId, string cssClass) =>
             _jSRuntime.InvokeVoidAsync("mudScrollManager.unlockScroll", elementId, cssClass);
+
+        public ValueTask<ScrollPosition> GetScrollPosition() =>
+            _jSRuntime.InvokeAsync<ScrollPosition>("mudScrollManager.getScrollPosition");
     }
 
     /// <summary>

--- a/src/MudBlazor/Services/ServiceCollectionExtensions.cs
+++ b/src/MudBlazor/Services/ServiceCollectionExtensions.cs
@@ -155,6 +155,16 @@ namespace MudBlazor.Services
         }
 
         /// <summary>
+        /// Adds body rendered as a scope instance.
+        /// </summary>
+        /// <param name="services">IServiceCollection</param>
+        public static IServiceCollection AddMudBodyRendered(this IServiceCollection services)
+        {
+            services.TryAddScoped<IBodyRenderService, BodyRenderService>();
+            return services;
+        }
+
+        /// <summary>
         /// Adds common services required by MudBlazor components
         /// </summary>
         /// <param name="services">IServiceCollection</param>
@@ -172,7 +182,8 @@ namespace MudBlazor.Services
                 .AddMudBlazorResizeObserverFactory()
                 .AddMudBlazorScrollManager()
                 .AddMudBlazorScrollListener()
-                .AddMudBlazorJsApi();
+                .AddMudBlazorJsApi()
+                .AddMudBodyRendered();
         }
 
         /// <summary>
@@ -195,7 +206,8 @@ namespace MudBlazor.Services
                 .AddMudBlazorResizeObserverFactory()
                 .AddMudBlazorScrollManager()
                 .AddMudBlazorScrollListener()
-                .AddMudBlazorJsApi();
+                .AddMudBlazorJsApi()
+                .AddMudBodyRendered();
         }
     }
 }

--- a/src/MudBlazor/Styles/components/_menu.scss
+++ b/src/MudBlazor/Styles/components/_menu.scss
@@ -10,11 +10,6 @@
 .mud-menu-container {
     max-width: max-content;
     width: max-content !important;
-
-    &.mud-menu-fullwidth {
-        width: 100% !important;
-        max-width: none;
-    }
 }
 
 .mud-menu-openonhover:hover .mud-popover {

--- a/src/MudBlazor/Styles/components/_tooltip.scss
+++ b/src/MudBlazor/Styles/components/_tooltip.scss
@@ -5,49 +5,49 @@
     &.mud-tooltip-inline {
         display: inline-block;
     }
+}
 
-    & .mud-tooltip {
-        color: var(--mud-palette-dark-text);
-        padding: 4px 8px;
-        text-align: center;
-        font-weight: 500;
-        font-size: 12px;
-        line-height: 1.4em;
-        width: max-content;
-        background-color: var(--mud-palette-grey-darker);
-        border-radius: var(--mud-default-borderradius);
-        position: absolute;
-        z-index: var(--mud-zindex-tooltip);
-        visibility: hidden;
-        opacity: 0;
-        transition: opacity .2s;
+.mud-tooltip {
+    color: var(--mud-palette-dark-text);
+    padding: 4px 8px;
+    text-align: center;
+    font-weight: 500;
+    font-size: 12px;
+    line-height: 1.4em;
+    width: max-content;
+    background-color: var(--mud-palette-grey-darker);
+    border-radius: var(--mud-default-borderradius);
+    position: absolute;
+    z-index: var(--mud-zindex-tooltip);
+    visibility: hidden;
+    opacity: 0;
+    transition: opacity .2s;
 
-        &.mud-tooltip-placement-top {
-            top: 0;
-            left: 50%;
-            transform: translate(-50%, calc(-100% - 10px));
-        }
-
-        &.mud-tooltip-placement-bottom {
-            bottom: 0;
-            left: 50%;
-            transform: translate(-50%, calc(100% + 10px));
-        }
-
-        &.mud-tooltip-placement-start {
-            top: 0;
-            left: 0;
-            transform: translateX(calc(-100% - 10px));
-        }
-
-        &.mud-tooltip-placement-end {
-            top: 0;
-            right: 0;
-            transform: translateX(calc(100% + 10px));
-        }
+    &.mud-tooltip-placement-top {
+        top: 0;
+        left: 50%;
+        transform: translate(-50%, calc(-100% - 10px));
     }
 
-    &:hover .mud-tooltip {
+    &.mud-tooltip-placement-bottom {
+        bottom: 0;
+        left: 50%;
+        transform: translate(-50%, calc(100% + 10px));
+    }
+
+    &.mud-tooltip-placement-start {
+        top: 0;
+        left: 0;
+        transform: translateX(calc(-100% - 10px));
+    }
+
+    &.mud-tooltip-placement-end {
+        top: 0;
+        right: 0;
+        transform: translateX(calc(100% + 10px));
+    }
+
+    &.mud-tooltip-hover {
         visibility: visible;
         opacity: 1;
     }

--- a/src/MudBlazor/TScripts/mudElementReference.js
+++ b/src/MudBlazor/TScripts/mudElementReference.js
@@ -118,5 +118,48 @@
         element.removeEventListener(event, this.eventListeners[eventId]);
         delete this.eventListeners[eventId];
     }
+
+    mudSetPositionRelativeTo(element, relativeTo, options) {
+        if (!element || !relativeTo)
+            return;
+
+        let elementSize = element.getBoundingClientRect();
+        let relativeToSize = relativeTo.getBoundingClientRect();
+        let scrollTop = document.documentElement.scrollTop;
+        let scrollLeft = document.documentElement.scrollLeft;
+
+        let offset = 0;
+        let style = "";
+
+        if (options.applyReferenceWidth) {
+            elementSize.width = relativeToSize.width;
+            style += `width: ${relativeToSize.width}px !important;max-width: none;`
+        }
+
+        switch (options.direction) {
+            case 0: //bottom
+                if (options.center)
+                    offset = (relativeToSize.width - elementSize.width) / 2;
+                style += `transform: translate(${scrollLeft + relativeToSize.left + offset}px, ${scrollTop + relativeToSize.bottom}px);`;
+                break;
+            case 1: //top
+                if (options.center)
+                    offset = (relativeToSize.width - elementSize.width) / 2;
+                style += `transform: translate(${scrollLeft + relativeToSize.left + offset}px, ${scrollTop + relativeToSize.top - elementSize.height}px);`;
+                break;
+            case 2: //left
+                if (options.center)
+                    offset = (relativeToSize.height - elementSize.height) / 2;
+                style += `transform: translate(${scrollLeft + relativeToSize.left - elementSize.width}px, ${scrollTop + relativeToSize.top + offset}px);`;
+                break;
+            case 3: //right
+                if (options.center)
+                    offset = (relativeToSize.height - elementSize.height) / 2;
+                style += `transform: translate(${scrollLeft + relativeToSize.right}px, ${scrollTop + relativeToSize.top + offset}px);`;
+                break;
+        }
+
+        element.setAttribute("style", style + element.getAttribute("style"));
+    }
 };
 window.mudElementRef = new MudElementReference();

--- a/src/MudBlazor/TScripts/mudScrollManager.js
+++ b/src/MudBlazor/TScripts/mudScrollManager.js
@@ -74,5 +74,14 @@
         let element = document.querySelector(selector) || document.body;
         element.classList.remove(lockclass);
     }
+
+    getScrollPosition() {
+        return {
+            top: document.documentElement.scrollTop,
+            left: document.documentElement.scrollLeft,
+            width: document.documentElement.scrollWidth,
+            height: document.documentElement.scrollHeight,
+        }
+    }
 };
 window.mudScrollManager = new MudScrollManager();


### PR DESCRIPTION
First of all, this is not ready yet, there are a plenty of works to do (not all previous features are available yet, also tests are failing).  I only wanted to share with you the concept and decide it worth to continue or not. In this PR I try to create a solution for the plenty of issues (bugs) with popups (menu, tooltip, etc.)

First of all, I created a body rendering mechanism, which allows to place a component outside of its parent directly into the application root. Basically this can solve all the clipping issues, because popups will not depend on the positions of its parents anymore. Unfortunately, this approach introduces several problems, like how to set up the correct position. I'm pretty sure this is impossible without JS at the moment, so I tried to keep its use to the bare minimum.  Only one JS function seems to be enough: `mudSetPositionRelativeTo`. I put all calculations here, otherwise there will be several JS-Blazor interop calls, which will increase the render latency especially in server mode.

For now I'm just curious about your opinions.