### PR TITLE
Table: Fix initial sort label not being set for table when using InitialDirection for MudTableSortLabel

### DIFF
--- a/src/MudBlazor/Components/Table/TableContext.cs
+++ b/src/MudBlazor/Components/Table/TableContext.cs
@@ -114,6 +114,7 @@ namespace MudBlazor
             var initial_sortlabel = SortLabels.FirstOrDefault(x => x.InitialDirection != SortDirection.None);
             if (initial_sortlabel == null)
                 return;
+            CurrentSortLabel = initial_sortlabel;
             UpdateSortLabels(initial_sortlabel);
             // this will trigger initial sorting of the table
             initial_sortlabel.SetSortDirection(initial_sortlabel.InitialDirection);


### PR DESCRIPTION
A separate PR for a small fix of #1702
