### PR TITLE
MudTable: Added ability to control column sorting directions ("Ascending", "Descending", "None")

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableServerSideDataTest3.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableServerSideDataTest3.razor
@@ -23,8 +23,8 @@
     /// </summary>
     private async Task<TableData<int>> ServerReload(TableState state)
     {
-        if (state.SortDirection != SortDirection.None && string.IsNullOrWhiteSpace(state.SortLabel))
-            throw new ArgumentException("SortDirection is set but SortLabel is not");
+        //if (state.SortDirection != SortDirection.None && string.IsNullOrWhiteSpace(state.SortLabel))
+        //    throw new ArgumentException("SortDirection is set but SortLabel is not");
 
         var p = state.Page*3;
         IEnumerable<int> data = new List<int>() { 1 + p, 2 + p, 3 + p };

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableServerSideDataTest3.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableServerSideDataTest3.razor
@@ -23,6 +23,9 @@
     /// </summary>
     private async Task<TableData<int>> ServerReload(TableState state)
     {
+        if (state.SortDirection != SortDirection.None && string.IsNullOrWhiteSpace(state.SortLabel))
+            throw new ArgumentException("SortDirection is set but SortLabel is not");
+
         var p = state.Page*3;
         IEnumerable<int> data = new List<int>() { 1 + p, 2 + p, 3 + p };
         totalItems = 99;

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -105,6 +105,12 @@ namespace MudBlazor
         [Parameter] public string SortLabel { get; set; }
 
         /// <summary>
+        /// If true allows table to be in an unsorted state through column clicks (i.e. first click sorts "Ascending", second "Descending", third "None").
+        /// If false only "Ascending" and "Descending" states are allowed (i.e. there always should be a column to sort).
+        /// </summary>
+        [Parameter] public bool AllowUnsorted { get; set; } = true;
+
+        /// <summary>
         /// If the table has more items than this number, it will break the rows into pages of said size.
         /// Note: requires a MudTablePager in PagerContent.
         /// </summary>

--- a/src/MudBlazor/Components/Table/MudTableSortLabel.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTableSortLabel.razor.cs
@@ -67,12 +67,19 @@ namespace MudBlazor
 
         public Task ToggleSortDirection()
         {
-            if (SortDirection == SortDirection.None)
-                return UpdateSortDirectionAsync(SortDirection.Ascending);
-            else if (SortDirection == SortDirection.Ascending)
-                return UpdateSortDirectionAsync(SortDirection.Descending);
-            else
-                return UpdateSortDirectionAsync(SortDirection.None);
+            switch (SortDirection)
+            {
+                case SortDirection.None:
+                    return UpdateSortDirectionAsync(SortDirection.Ascending);
+
+                case SortDirection.Ascending:
+                    return UpdateSortDirectionAsync(SortDirection.Descending);
+
+                case SortDirection.Descending:
+                    return UpdateSortDirectionAsync(Table.AllowUnsorted ? SortDirection.None : SortDirection.Ascending);
+            }
+
+            throw new NotImplementedException();
         }
 
         protected override void OnInitialized()


### PR DESCRIPTION
Added a property "AllowUnsorted" to MudTable to control sorted state.
When "AllowUnsorted" is set to true (default) the behavior is same as it is now - column sort states change in order "Ascending", "Descending", "None".
But when "AllowUnsorted" is false, then when a column is clicked for sorting, the states loop between "Ascending" and "Descending" so there is always at least one sorted column used.