### PR TITLE
Fixes #1739 - MudMessageBox action buttons order reversed

### DIFF
--- a/src/MudBlazor.UnitTests/Components/MessageBoxTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MessageBoxTests.cs
@@ -28,9 +28,9 @@ namespace MudBlazor.UnitTests.Components
         public void TearDown() => ctx.Dispose();
 
         [Test, Timeout(3000)]
-        [TestCase(0, true)]
+        [TestCase(0, null)]
         [TestCase(1, false)]
-        [TestCase(2, null)]
+        [TestCase(2, true)]
         public async Task MessageBox_Should_ReturnTrue(int clickButtonIndex, bool? expectedResult)
         {
             var comp = ctx.RenderComponent<MudDialogProvider>();
@@ -48,9 +48,10 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("div.mud-dialog-container").Should().NotBe(null);
             comp.Find("div.mud-dialog-title").TrimmedText().Should().Contain("Boom!");
             comp.Find("div.mud-dialog-content").TrimmedText().Should().Contain("pickle");
-            comp.FindAll("button")[0].TrimmedText().Should().Be("Great");
+            comp.FindAll("button")[0].TrimmedText().Should().Be("Go away!");
             comp.FindAll("button")[1].TrimmedText().Should().Be("Whatever");
-            comp.FindAll("button")[2].TrimmedText().Should().Be("Go away!");
+            comp.FindAll("button")[2].TrimmedText().Should().Be("Great");
+
             // close by click on Great
             comp.FindAll("button")[clickButtonIndex].Click();
             comp.Markup.Trim().Should().BeEmpty();

--- a/src/MudBlazor/Components/MessageBox/MudMessageBox.razor
+++ b/src/MudBlazor/Components/MessageBox/MudMessageBox.razor
@@ -22,15 +22,15 @@
         }
     </DialogContent>
     <DialogActions>
-        @if (YesButton != null)
+        @if (CancelButton != null)
         {
-            <CascadingValue Value="@_yesCallback">
-                @YesButton
+            <CascadingValue Value="@_cancelCallback">
+                @CancelButton
             </CascadingValue>
         }
-        else if(!string.IsNullOrWhiteSpace(YesText))
+        else if(!string.IsNullOrWhiteSpace(CancelText))
         {
-            <MudButton Color="Color.Primary" OnClick="OnYesClicked">@YesText</MudButton>
+            <MudButton OnClick="OnCancelClicked">@CancelText</MudButton>
         }
         @if (NoButton != null)
         {
@@ -42,15 +42,15 @@
         {
             <MudButton OnClick="OnNoClicked">@NoText</MudButton>
         }
-        @if (CancelButton != null)
+        @if (YesButton != null)
         {
-            <CascadingValue Value="@_cancelCallback">
-                @CancelButton
+            <CascadingValue Value="@_yesCallback">
+                @YesButton
             </CascadingValue>
         }
-        else if(!string.IsNullOrWhiteSpace(CancelText))
+        else if(!string.IsNullOrWhiteSpace(YesText))
         {
-            <MudButton OnClick="OnCancelClicked">@CancelText</MudButton>
+            <MudButton Color="Color.Primary" OnClick="OnYesClicked">@YesText</MudButton>
         }
     </DialogActions>
 </MudDialog>


### PR DESCRIPTION
Fixes #1739
Changes the order of MudMessageBox action buttons from: `Yes -> No -> Cancel` to `Cancel -> No -> Yes`
