### PR TITLE
Feature/portal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -381,3 +381,4 @@ src/MudBlazor.UnitTests/Generated/_AllApiPages.cs
 src/MudBlazor.UnitTests/Generated/_AllComponents.cs
 src/MudBlazor.Docs/NewFilesToBuild.txt
 /src/MudBlazor.Docs.Server/Properties/ServiceDependencies/mudblazortest - Web Deploy/profile.arm.json
+/src/MudBlazor/bundleconfig.json

--- a/src/MudBlazor.Docs/Extensions/DocsViewExtension.cs
+++ b/src/MudBlazor.Docs/Extensions/DocsViewExtension.cs
@@ -18,6 +18,7 @@ namespace MudBlazor.Docs.Extensions
                 config.SnackbarConfiguration.HideTransitionDuration = 500;
                 config.SnackbarConfiguration.ShowTransitionDuration = 500;
                 config.SnackbarConfiguration.SnackbarVariant = Variant.Filled;
+                
             });
 
             services.AddSingleton<IApiLinkService, ApiLinkService>();

--- a/src/MudBlazor.Docs/Pages/Playground.razor
+++ b/src/MudBlazor.Docs/Pages/Playground.razor
@@ -1,0 +1,147 @@
+﻿@page "/playground"
+
+
+
+@using System.Net.Http.Json
+@using MudBlazor.Examples.Data.Models
+@inject HttpClient httpClient
+
+<MudTable Items="@Elements.Take(4)" 
+    Hover="true" Breakpoint="Breakpoint.Sm"
+     FixedHeader="true" >
+    <HeaderContent>
+        <MudTh>Nr</MudTh>
+        <MudTh>Sign</MudTh>
+        <MudTh Style="text-align:center">
+            <MudTooltip>
+                <ChildContent>
+                    <MudIconButton Icon="@Icons.Material.Filled.Help" />
+                </ChildContent>
+                <TooltipContent>
+                    <MudText Typo="Typo.body2">Line One</MudText>
+                    <MudText Typo="Typo.body2">body2 content Line two with some long</MudText>                    
+                </TooltipContent>
+            </MudTooltip>
+            Name
+        </MudTh>
+        <MudTh>Name</MudTh>        
+        <MudTh>Position</MudTh>
+        <MudTh>Molar mass</MudTh>       
+        <MudTh>Molar mass</MudTh>       
+        <MudTh>Commands</MudTh> 
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd DataLabel="Nr">@context.Number</MudTd>
+        <MudTd DataLabel="Sign">@context.Sign</MudTd>
+        <MudTd DataLabel="Name">@context.Name</MudTd>        
+        <MudTd DataLabel="Name">@context.Name</MudTd>
+        <MudTd DataLabel="Position">@context.Position</MudTd>
+        <MudTd DataLabel="Molar mass">@context.Molar</MudTd>  
+        <MudTd DataLabel="Molar mass">@context.Molar</MudTd>  
+        <MudTd DataLabel="">
+            <MudItem>
+                <MudTooltip Text="Edit Transaction Type">
+                    <MudIconButton Icon="@Icons.Material.Outlined.Edit" Size="Size.Small">Edit</MudIconButton>  
+                </MudTooltip>                           
+                <MudTooltip Text="Delete Transaction Type">
+                    <MudIconButton Icon="@Icons.Material.Outlined.Delete" Size="Size.Small">Delete</MudIconButton>  
+                </MudTooltip>
+            </MudItem>
+        </MudTd>      
+    </RowTemplate>
+</MudTable> 
+<MudDivider/>
+<MudTabs Elevation="1" Rounded="true">
+    <MudTabPanel Text="Item One" ToolTip="ToolTip One">
+        <MudText>Item One</MudText>
+    </MudTabPanel>
+    <MudTabPanel Text="Item Two" ToolTip="ToolTip Two">
+        <MudText>Item Two</MudText>
+    </MudTabPanel>
+    <MudTabPanel Text="Item Three" ToolTip="ToolTip Three">
+        <MudText>Item Three</MudText>
+    </MudTabPanel>
+</MudTabs>
+<MudDivider/>
+
+
+
+<MudPaper Width="500px">
+    <MudList Clickable="true">
+        <MudListItem>
+            <div class="d-flex flex-row py-1">
+                <div class="d-flex flex-column">
+                    <MudAvatar Image="https://via.placeholder.com/70" Style="width:70px;height:70px;" Square="true" />
+                </div>
+                <div class="d-flex flex-column flex-grow-1 px-4">
+                    <MudText>Some text</MudText>
+                </div>
+                <div class="d-flex flex-column">
+                    <MudMenu Icon="@Icons.Material.Outlined.MoreVert" OffsetX="true" Direction="Direction.Left">
+                        <MudMenuItem>Enlist</MudMenuItem>
+                        <MudMenuItem>Barracks</MudMenuItem>
+                        <MudMenuItem>Armory</MudMenuItem>
+                    </MudMenu>            
+                </div>
+            </div>
+        </MudListItem>
+    </MudList>
+    <MudText Typo="Typo.caption">Popover displays but clipped</MudText>
+</MudPaper>
+
+ <MudDrawer @bind-Open="@open" Anchor="@anchor" Elevation="1" Variant="@DrawerVariant.Temporary" Color="Color.Primary" DisableOverlay="true">
+      <MudItem Class="d-flex justify-center align-center pa-4 ma-2">
+                    <MudMenu OffsetY="true" FullWidth="true" Style="z-index:1500 !important" Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Filled.Flight" EndIcon="@Icons.Filled.KeyboardArrowDown" Label="Menu" Class="rounded-lg">
+                        <MudMenuItem>Item 1</MudMenuItem>
+                        <MudMenuItem>Item 2</MudMenuItem>
+                        <MudMenuItem>Item 3</MudMenuItem>
+                    </MudMenu>
+
+                    <MudMenu OffsetY="true" FullWidth="true" Style="z-index:1500 !important" Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Filled.Flight" EndIcon="@Icons.Filled.KeyboardArrowUp" Label="Menu" Class="rounded-lg" Direction="Direction.Top">
+                        <MudMenuItem>Item 1</MudMenuItem>
+                        <MudMenuItem>Item 2</MudMenuItem>
+                        <MudMenuItem>Item 3</MudMenuItem>
+                    </MudMenu>
+</MudItem>
+    </MudDrawer>
+
+<MudDrawer @bind-Open="@open" Anchor="@anchor" Elevation="1" Variant="@DrawerVariant.Temporary" Color="Color.Primary" DisableOverlay="true">
+      <MudItem Class="d-flex justify-center align-center pa-4 ma-2">
+                    <MudMenu OffsetY="true" FullWidth="true" Style="z-index:1500 !important" Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Filled.Flight" EndIcon="@Icons.Filled.KeyboardArrowDown" Label="Menu" Class="rounded-lg">
+                        <MudMenuItem>Item 1</MudMenuItem>
+                        <MudMenuItem>Item 2</MudMenuItem>
+                        <MudMenuItem>Item 3</MudMenuItem>
+                    </MudMenu>
+
+                    <MudMenu OffsetY="true" FullWidth="true" Style="z-index:1500 !important" Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Filled.Flight" EndIcon="@Icons.Filled.KeyboardArrowUp" Label="Menu" Class="rounded-lg" Direction="Direction.Top">
+                        <MudMenuItem>Item 1</MudMenuItem>
+                        <MudMenuItem>Item 2</MudMenuItem>
+                        <MudMenuItem>Item 3</MudMenuItem>
+                    </MudMenu>
+</MudItem>
+    </MudDrawer>
+    <MudItem class="d-flex align-center justify-center" style="margin-top:20%">
+<MudButton OnClick="@(() => OpenDrawer(MudBlazor.Anchor.Bottom))">Drawer Bottom</MudButton>
+  <MudButton OnClick="@(() => OpenDrawer(MudBlazor.Anchor.Top))">Drawer Top</MudButton>
+  </MudItem>
+@code
+{
+    bool open;
+    MudBlazor.Anchor anchor;
+
+    void OpenDrawer(MudBlazor.Anchor anchor)
+    {
+        open = true;
+        this.anchor = anchor;
+    }
+}
+
+
+@code {
+    private IEnumerable<Element> Elements = new List<Element>();
+
+    protected override async Task OnInitializedAsync()
+    {
+        Elements = await httpClient.GetFromJsonAsync<List<Element>>("webapi/periodictable");
+    }    
+}

--- a/src/MudBlazor.Docs/Shared/MainLayout.razor
+++ b/src/MudBlazor.Docs/Shared/MainLayout.razor
@@ -19,7 +19,7 @@
             </MudAutocomplete>
             <MudAppBarSpacer />
             <div class="d-none d-md-flex align-center">
-                <MudMenu EndIcon="@Icons.Filled.KeyboardArrowDown" Label="Support" Color="Color.Inherit" Dense="true" Direction="Direction.Right" OffsetY="true">
+                <MudMenu IsPortalEnabled="false" EndIcon="@Icons.Filled.KeyboardArrowDown" Label="Support" Color="Color.Inherit" Dense="true" Direction="Direction.Right" OffsetY="true">
                     <MudText Typo="Typo.body2" Class="px-4 py-2"><b>Community Support</b></MudText>
                     <MudMenuItem Link="https://discord.gg/mudblazor" Target="_blank">Discord</MudMenuItem>
                     <MudMenuItem Link="https://gitter.im/MudBlazor/community" Target="_blank">Gitter</MudMenuItem>

--- a/src/MudBlazor.Docs/Shared/MainLayout.razor
+++ b/src/MudBlazor.Docs/Shared/MainLayout.razor
@@ -19,7 +19,7 @@
             </MudAutocomplete>
             <MudAppBarSpacer />
             <div class="d-none d-md-flex align-center">
-                <MudMenu IsPortalEnabled="false" EndIcon="@Icons.Filled.KeyboardArrowDown" Label="Support" Color="Color.Inherit" Dense="true" Direction="Direction.Right" OffsetY="true">
+                <MudMenu EndIcon="@Icons.Filled.KeyboardArrowDown" Label="Support" Color="Color.Inherit" Dense="true" Direction="Direction.Right" OffsetY="true">
                     <MudText Typo="Typo.body2" Class="px-4 py-2"><b>Community Support</b></MudText>
                     <MudMenuItem Link="https://discord.gg/mudblazor" Target="_blank">Discord</MudMenuItem>
                     <MudMenuItem Link="https://gitter.im/MudBlazor/community" Target="_blank">Gitter</MudMenuItem>

--- a/src/MudBlazor.Docs/Shared/MainLayout.razor
+++ b/src/MudBlazor.Docs/Shared/MainLayout.razor
@@ -19,7 +19,7 @@
             </MudAutocomplete>
             <MudAppBarSpacer />
             <div class="d-none d-md-flex align-center">
-                <MudMenu EndIcon="@Icons.Filled.KeyboardArrowDown" Label="Support" Color="Color.Inherit" Dense="true" Direction="Direction.Right" OffsetY="true">
+                <MudMenu IsFixed="@true" EndIcon="@Icons.Filled.KeyboardArrowDown" Label="Support" Color="Color.Inherit" Dense="true" Direction="Direction.Right" OffsetY="true">
                     <MudText Typo="Typo.body2" Class="px-4 py-2"><b>Community Support</b></MudText>
                     <MudMenuItem Link="https://discord.gg/mudblazor" Target="_blank">Discord</MudMenuItem>
                     <MudMenuItem Link="https://gitter.im/MudBlazor/community" Target="_blank">Gitter</MudMenuItem>
@@ -52,7 +52,7 @@
                     <MudIconButton Icon="@Icons.Material.Filled.FormatTextdirectionRToL" Color="Color.Inherit" OnClick="@((e) => RightToLeftToggle())" />
                 </MudTooltip>
             </div>
-            <MudMenu Icon="@Icons.Filled.Settings" Color="Color.Inherit" Dense="true" Direction="Direction.Right" OffsetY="true" Class="d-md-none">
+            <MudMenu IsFixed=@true Icon="@Icons.Filled.Settings" Color="Color.Inherit" Dense="true" Direction="Direction.Right" OffsetY="true" Class="d-md-none">
                 <div class="px-2">
                     @if (Wasm)
                     {

--- a/src/MudBlazor.Docs/Styles/components/_docssection.scss
+++ b/src/MudBlazor.Docs/Styles/components/_docssection.scss
@@ -70,14 +70,6 @@
         & > .mud-tooltip-root .mud-icon-button .mud-svg-icon {
             font-size: 1.25rem;
         }
-        
-        @media(max-width: 1280px) {
-            .mud-tooltip-root:last-child .mud-tooltip {
-                left: unset;
-                right: 0;
-                transform: translate(0%,calc(-100% - 10px));
-            }
-        }
     }
 
     & .docs-source-code {

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Portal/PortalMenu.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Portal/PortalMenu.razor
@@ -1,0 +1,5 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+<MudThemeProvider />
+<MudMenu>
+    <MudMenuItem>1</MudMenuItem>
+</MudMenu>

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -98,7 +98,7 @@ namespace MudBlazor.UnitTests.Components
             // type 3 characters and check if it has toggled the menu
             select.Find("input").Input("ala");
             await Task.Delay(200);
-            var menu = comp.Find("div.mud-popover");
+            var menu = comp.Find(".portal");
             comp.WaitForAssertion(() => menu.ClassList.Should().Contain("mud-popover-open"));
 
             // type 2 characters and check if it has toggled the menu

--- a/src/MudBlazor.UnitTests/Components/PortalTests.cs
+++ b/src/MudBlazor.UnitTests/Components/PortalTests.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) mudblazor 2021
+// License MIT
+
+#pragma warning disable CS1998 // async without await
+#pragma warning disable IDE1006 // leading underscore
+#pragma warning disable BL0005 // Set parameter outside component
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AngleSharp.Html.Dom;
+using Bunit;
+using FluentAssertions;
+using Microsoft.AspNetCore.Components.Web;
+using MudBlazor.UnitTests.TestComponents;
+using NUnit.Framework;
+using static MudBlazor.UnitTests.TestComponents.AutocompleteSetParametersInitialization;
+
+namespace MudBlazor.UnitTests.Components
+{
+
+    [TestFixture]
+    public class PortalTests
+    {
+        private Bunit.TestContext ctx;
+
+        [SetUp]
+        public void Setup()
+        {
+            ctx = new Bunit.TestContext();
+            ctx.AddTestServices();
+        }
+
+        [TearDown]
+        public void TearDown() => ctx.Dispose();
+
+        /// <summary>
+        /// Initial value should be shown and popup should not open.
+        /// </summary>
+        [Test]
+        public async Task AutocompleteTest1()
+        {
+            var comp = ctx.RenderComponent<PortalMenu>();
+            Console.WriteLine(comp.Markup);
+            // select elements needed for the test
+            var menuComp = comp.FindComponent<MudMenu>();
+            menuComp.Find("button")
+            
+            var portalContainer = comp.Find("#mud-portal-container");
+            var portal = comp.Find(".portal");
+            var autocomplete = menuComp.Instance;
+            
+           
+        }
+
+
+    }
+}

--- a/src/MudBlazor.UnitTests/Generated/ApiDocsTests.cs
+++ b/src/MudBlazor.UnitTests/Generated/ApiDocsTests.cs
@@ -25,6 +25,7 @@ namespace MudBlazor.UnitTests.Components
             ctx.Services.AddSingleton<IResizeListenerService>(new MockResizeListenerService());
             ctx.Services.AddTransient<IScrollManager, MockScrollManager>();
             ctx.Services.AddTransient<IScrollListener, MockScrollListener>();
+            ctx.Services.AddTransient<IPortal, Portal>();
             ctx.Services.AddTransient<IJsApiService, MockJsApiServices>();
             ctx.Services.AddTransient<IResizeObserver, MockResizeObserver>();
             ctx.Services.AddSingleton<IHeadElementHelper>(new MockHeadElementHelper());

--- a/src/MudBlazor.UnitTests/Generated/ExampleDocsTests.cs
+++ b/src/MudBlazor.UnitTests/Generated/ExampleDocsTests.cs
@@ -27,6 +27,7 @@ namespace MudBlazor.UnitTests.Components
             ctx.Services.AddSingleton<IResizeListenerService>(new MockResizeListenerService());
             ctx.Services.AddTransient<IScrollManager, MockScrollManager>();
             ctx.Services.AddTransient<IScrollListener, MockScrollListener>();
+            ctx.Services.AddTransient<IPortal, Portal>();
             ctx.Services.AddTransient<IJsApiService, MockJsApiServices>();
             ctx.Services.AddSingleton<IHeadElementHelper>(new MockHeadElementHelper());
             ctx.Services.AddTransient<IResizeObserver, MockResizeObserver>();

--- a/src/MudBlazor.UnitTests/Mocks/MockPortalService.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockPortalService.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using MudBlazor.Services;
+
+namespace MudBlazor.UnitTests.Mocks
+{
+    public class MockPortalService : IPortal
+    {
+        public Dictionary<Guid, PortalItem> Items { get; }
+
+        public event EventHandler OnChange;
+
+        public void AddOrUpdate(PortalItem item)
+        {
+            OnChange.Invoke(null, null);
+
+        }
+
+        public PortalItem GetItem(Guid id)
+        {
+            throw new NotImplementedException();
+            
+        }
+
+        public void Remove(PortalItem item)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -14,7 +14,7 @@
                           />
                 @if (_items!=null && _items.Length!=0)
                 {
-                    <MudPortal IsVisible="@IsOpen" >
+                    <MudPortal IsVisible="@IsOpen" IsEnabled="IsPortalEnabled" LockScroll="LockScroll">
                         <MudPopover Open="@IsOpen" MaxHeight="@MaxHeight" OffsetY="true">
                                 @*this must be the real scroll container, not the Popover, hence the maxheight*@
                             <MudList Clickable="true" Dense="@Dense" Style=@($"max-height: {MaxHeight}px; overflow-y:auto;")>

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -14,7 +14,7 @@
                           />
                 @if (_items!=null && _items.Length!=0)
                 {
-                    <MudPortal IsVisible="@IsOpen" IsEnabled="IsPortalEnabled" LockScroll="LockScroll">
+                    
                         <MudPopover Open="@IsOpen" MaxHeight="@MaxHeight" OffsetY="true">
                                 @*this must be the real scroll container, not the Popover, hence the maxheight*@
                             <MudList Clickable="true" Dense="@Dense" Style=@($"max-height: {MaxHeight}px; overflow-y:auto;")>
@@ -42,7 +42,7 @@
                                 }
                             </MudList>
                       </MudPopover>
-                  </MudPortal>
+                
                }
             </InputContent>
         </MudInputControl>       

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -14,33 +14,35 @@
                           />
                 @if (_items!=null && _items.Length!=0)
                 {
-                    <MudPopover Open="@IsOpen" MaxHeight="@MaxHeight" OffsetY="true">
-                            @*this must be the real scroll container, not the Popover, hence the maxheight*@
-                        <MudList Clickable="true" Dense="@Dense" Style=@($"max-height: {MaxHeight}px; overflow-y:auto;")>
-                            @for (var index= 0; index < _items.Length;index++ )
-                            {
-                                var item = _items[index];
-                                bool is_selected = index == _selectedListItemIndex;
-                                <MudListItem @key="@item" id="@GetListItemId(index)" OnClick="@(() => SelectOption(item))" Class="@(is_selected ? "mud-selected-item" : "")">
-                                    @if (ItemTemplate == null)
-                                    {
-                                        @GetItemString(item)
-                                    }
-                                    else if (is_selected)
-                                    {
-                                        @if (ItemSelectedTemplate == null)
-                                            @ItemTemplate(item)
+                    <MudPortal IsVisible="@IsOpen" >
+                        <MudPopover Open="@IsOpen" MaxHeight="@MaxHeight" OffsetY="true">
+                                @*this must be the real scroll container, not the Popover, hence the maxheight*@
+                            <MudList Clickable="true" Dense="@Dense" Style=@($"max-height: {MaxHeight}px; overflow-y:auto;")>
+                                @for (var index= 0; index < _items.Length;index++ )
+                                {
+                                    var item = _items[index];
+                                    bool is_selected = index == _selectedListItemIndex;
+                                    <MudListItem @key="@item" id="@GetListItemId(index)" OnClick="@(() => SelectOption(item))" Class="@(is_selected ? "mud-selected-item" : "")">
+                                        @if (ItemTemplate == null)
+                                        {
+                                            @GetItemString(item)
+                                        }
+                                        else if (is_selected)
+                                        {
+                                            @if (ItemSelectedTemplate == null)
+                                                @ItemTemplate(item)
+                                            else
+                                                @ItemSelectedTemplate(item)
+                                        }
                                         else
-                                            @ItemSelectedTemplate(item)
-                                    }
-                                    else
-                                    {
-                                        @ItemTemplate(item)
-                                    }
-                                </MudListItem>
-                            }
-                        </MudList>
-                  </MudPopover>
+                                        {
+                                            @ItemTemplate(item)
+                                        }
+                                    </MudListItem>
+                                }
+                            </MudList>
+                      </MudPopover>
+                  </MudPortal>
                }
             </InputContent>
         </MudInputControl>       

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -159,6 +159,10 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public EventCallback<bool> IsOpenChanged { get; set; }
 
+        [Parameter] public bool IsPortalEnabled { get; set; } = true;
+
+        [Parameter] public bool LockScroll { get; set; }
+
         public string CurrentIcon { get; set; }
 
         private MudInput<string> _elementReference;

--- a/src/MudBlazor/Components/Dialog/MudDialogProvider.razor
+++ b/src/MudBlazor/Components/Dialog/MudDialogProvider.razor
@@ -8,3 +8,4 @@
         }
     </CascadingValue>
 </CascadingValue>
+<MudPortalProvider/>

--- a/src/MudBlazor/Components/Dialog/MudDialogProvider.razor
+++ b/src/MudBlazor/Components/Dialog/MudDialogProvider.razor
@@ -8,4 +8,3 @@
         }
     </CascadingValue>
 </CascadingValue>
-<MudPortalProvider/>

--- a/src/MudBlazor/Components/Menu/MudMenu.razor
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor
@@ -8,7 +8,7 @@
     @if (ActivatorContent != null)
     {
         <CascadingValue Value="@((IActivatable) this)" IsFixed="true">
-            <div @onmouseup="ToggleMenu">
+            <div @onmouseup="ToggleMenu" @ref="_activatorRef">
                 @ActivatorContent
             </div>
         </CascadingValue>

--- a/src/MudBlazor/Components/Menu/MudMenu.razor
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor
@@ -16,15 +16,15 @@
     else if (String.IsNullOrEmpty(Icon))
     {
         <MudButton StartIcon="@StartIcon"
-                   EndIcon="@EndIcon"
-                   IconColor="@IconColor"
-                   Color="@Color"
-                   Size="@Size"
-                   Variant="@Variant"
-                   Disabled="@Disabled"
-                   DisableRipple="@DisableRipple"
-                   DisableElevation="@DisableElevation"
-                   @onclick="@ToggleMenu">
+               EndIcon="@EndIcon"
+               IconColor="@IconColor"
+               Color="@Color"
+               Size="@Size"
+               Variant="@Variant"
+               Disabled="@Disabled"
+               DisableRipple="@DisableRipple"
+               DisableElevation="@DisableElevation"
+               @onclick="@ToggleMenu">
             @Label
         </MudButton>
     }
@@ -32,15 +32,15 @@
     {
         <MudIconButton Icon="@Icon" Color="@Color" Size="@Size" Disabled="@Disabled" DisableRipple="@DisableRipple" @onclick="@ToggleMenu" />
     }
-   <MudPortal IsVisible="@_isOpen" IsEnabled="IsPortalEnabled" LockScroll="LockScroll">
-    <CascadingValue Value="@this">
+   
         <MudPopover Open="@_isOpen" Class="@MenuClassname" MaxHeight="@MaxHeight" Style="@PopoverStyle" Direction="@Direction" OffsetX="@OffsetX" OffsetY="@OffsetY">
-            <MudList Clickable="true" Dense="@Dense">
-                @ChildContent
-            </MudList>
+            <CascadingValue Value="@this">
+                <MudList Clickable="true" Dense="@Dense">
+                    @ChildContent
+                </MudList>
+            </CascadingValue>
         </MudPopover>
-    </CascadingValue>
-   </MudPortal>
+ 
     <MudOverlay Visible="@(_isOpen && ActivationEvent != MouseEvent.MouseOver)" OnClick="@ToggleMenu" LockScroll="false" />
 </div>
 

--- a/src/MudBlazor/Components/Menu/MudMenu.razor
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor
@@ -32,7 +32,7 @@
     {
         <MudIconButton Icon="@Icon" Color="@Color" Size="@Size" Disabled="@Disabled" DisableRipple="@DisableRipple" @onclick="@ToggleMenu" />
     }
-   <MudPortal IsVisible="@_isOpen"  >
+   <MudPortal IsVisible="@_isOpen" IsEnabled="IsPortalEnabled" >
     <CascadingValue Value="@this">
         <MudPopover Open="@_isOpen" Class="@MenuClassname" MaxHeight="@MaxHeight" Style="@PopoverStyle" Direction="@Direction" OffsetX="@OffsetX" OffsetY="@OffsetY">
             <MudList Clickable="true" Dense="@Dense">

--- a/src/MudBlazor/Components/Menu/MudMenu.razor
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor
@@ -32,7 +32,7 @@
     {
         <MudIconButton Icon="@Icon" Color="@Color" Size="@Size" Disabled="@Disabled" DisableRipple="@DisableRipple" @onclick="@ToggleMenu" />
     }
-   <MudPortal IsVisible="@_isOpen" IsEnabled="IsPortalEnabled" >
+   <MudPortal IsVisible="@_isOpen" IsEnabled="IsPortalEnabled" LockScroll="LockScroll">
     <CascadingValue Value="@this">
         <MudPopover Open="@_isOpen" Class="@MenuClassname" MaxHeight="@MaxHeight" Style="@PopoverStyle" Direction="@Direction" OffsetX="@OffsetX" OffsetY="@OffsetY">
             <MudList Clickable="true" Dense="@Dense">

--- a/src/MudBlazor/Components/Menu/MudMenu.razor
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor
@@ -32,7 +32,7 @@
     {
         <MudIconButton Icon="@Icon" Color="@Color" Size="@Size" Disabled="@Disabled" DisableRipple="@DisableRipple" @onclick="@ToggleMenu" />
     }
-    <MudPortal IsVisible="@_isOpen" IsEnabled="ActivationEvent != MouseEvent.MouseOver">
+   
     <CascadingValue Value="@this">
         <MudPopover Open="@_isOpen" Class="@MenuClassname" MaxHeight="@MaxHeight" Style="@PopoverStyle" Direction="@Direction" OffsetX="@OffsetX" OffsetY="@OffsetY">
             <MudList Clickable="true" Dense="@Dense">
@@ -40,7 +40,7 @@
             </MudList>
         </MudPopover>
     </CascadingValue>
-    </MudPortal>
+   
     <MudOverlay Visible="@(_isOpen && ActivationEvent != MouseEvent.MouseOver)" OnClick="@ToggleMenu" LockScroll="false" />
 </div>
 

--- a/src/MudBlazor/Components/Menu/MudMenu.razor
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor
@@ -32,6 +32,7 @@
     {
         <MudIconButton Icon="@Icon" Color="@Color" Size="@Size" Disabled="@Disabled" DisableRipple="@DisableRipple" @onclick="@ToggleMenu" />
     }
+    <MudPortal IsVisible="@_isOpen" IsEnabled="ActivationEvent != MouseEvent.MouseOver">
     <CascadingValue Value="@this">
         <MudPopover Open="@_isOpen" Class="@MenuClassname" MaxHeight="@MaxHeight" Style="@PopoverStyle" Direction="@Direction" OffsetX="@OffsetX" OffsetY="@OffsetY">
             <MudList Clickable="true" Dense="@Dense">
@@ -39,6 +40,7 @@
             </MudList>
         </MudPopover>
     </CascadingValue>
+    </MudPortal>
     <MudOverlay Visible="@(_isOpen && ActivationEvent != MouseEvent.MouseOver)" OnClick="@ToggleMenu" LockScroll="false" />
 </div>
 

--- a/src/MudBlazor/Components/Menu/MudMenu.razor
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor
@@ -32,7 +32,7 @@
     {
         <MudIconButton Icon="@Icon" Color="@Color" Size="@Size" Disabled="@Disabled" DisableRipple="@DisableRipple" @onclick="@ToggleMenu" />
     }
-   
+   <MudPortal IsVisible="@_isOpen"  >
     <CascadingValue Value="@this">
         <MudPopover Open="@_isOpen" Class="@MenuClassname" MaxHeight="@MaxHeight" Style="@PopoverStyle" Direction="@Direction" OffsetX="@OffsetX" OffsetY="@OffsetY">
             <MudList Clickable="true" Dense="@Dense">
@@ -40,7 +40,7 @@
             </MudList>
         </MudPopover>
     </CascadingValue>
-   
+   </MudPortal>
     <MudOverlay Visible="@(_isOpen && ActivationEvent != MouseEvent.MouseOver)" OnClick="@ToggleMenu" LockScroll="false" />
 </div>
 

--- a/src/MudBlazor/Components/Menu/MudMenu.razor
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor
@@ -4,7 +4,9 @@
 
 
 
-<div class="@Classname" style="@Style" oncontextmenu="@(ActivationEvent == MouseEvent.RightClick ? "return false;" : "")">
+<div class="@Classname" style="@Style" 
+     @onmouseenter="@(ActivationEvent== MouseEvent.MouseOver ? HandleMouseEnter : null)"
+     oncontextmenu="@(ActivationEvent == MouseEvent.RightClick ? "return false;" : "")">
     @if (ActivatorContent != null)
     {
         <CascadingValue Value="@((IActivatable) this)" IsFixed="true">
@@ -34,7 +36,7 @@
         <MudIconButton Icon="@Icon" Color="@Color" Size="@Size" Disabled="@Disabled" DisableRipple="@DisableRipple" @onclick="@ToggleMenu" />
     }
 
-        <MudPopover Open="@_isOpen" OpenOnHover="@(ActivationEvent == MouseEvent.MouseOver)" Class="@MenuClassname" MaxHeight="@MaxHeight" Style="@PopoverStyle" Direction="@Direction" OffsetX="@OffsetX" OffsetY="@OffsetY">
+        <MudPopover Open="@(_isOpen)"  Class="@MenuClassname" MaxHeight="@MaxHeight" Style="@PopoverStyle" Direction="@Direction" OffsetX="@OffsetX" OffsetY="@OffsetY">
             <CascadingValue Value="@this">
                 <MudList Clickable="true" Dense="@Dense">
                     @ChildContent
@@ -43,7 +45,7 @@
         </MudPopover>
 
  
-    <MudOverlay Visible="@(_isOpen && ActivationEvent != MouseEvent.MouseOver)" OnClick="@ToggleMenu" LockScroll="false" />
+    <MudOverlay Visible="@(_isOpen)" OnClick="@ToggleMenu" LockScroll="false" />
 </div>
 
 

--- a/src/MudBlazor/Components/Menu/MudMenu.razor
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor
@@ -24,6 +24,7 @@
                Disabled="@Disabled"
                DisableRipple="@DisableRipple"
                DisableElevation="@DisableElevation"
+              
                @onclick="@ToggleMenu">
             @Label
         </MudButton>
@@ -32,14 +33,15 @@
     {
         <MudIconButton Icon="@Icon" Color="@Color" Size="@Size" Disabled="@Disabled" DisableRipple="@DisableRipple" @onclick="@ToggleMenu" />
     }
-   
-        <MudPopover Open="@_isOpen" Class="@MenuClassname" MaxHeight="@MaxHeight" Style="@PopoverStyle" Direction="@Direction" OffsetX="@OffsetX" OffsetY="@OffsetY">
+
+        <MudPopover Open="@_isOpen" OpenOnHover="@(ActivationEvent == MouseEvent.MouseOver)" Class="@MenuClassname" MaxHeight="@MaxHeight" Style="@PopoverStyle" Direction="@Direction" OffsetX="@OffsetX" OffsetY="@OffsetY">
             <CascadingValue Value="@this">
                 <MudList Clickable="true" Dense="@Dense">
                     @ChildContent
                 </MudList>
             </CascadingValue>
         </MudPopover>
+
  
     <MudOverlay Visible="@(_isOpen && ActivationEvent != MouseEvent.MouseOver)" OnClick="@ToggleMenu" LockScroll="false" />
 </div>

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -1,7 +1,7 @@
-﻿using System.Globalization;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using MudBlazor.Extensions;
 using MudBlazor.Interfaces;
 using MudBlazor.Utilities;
 
@@ -126,27 +126,18 @@ namespace MudBlazor
         {
             if (Disabled)
                 return;
-            await SetPopoverStyle(args);
+            if (PositionAtCurser) await SetPopoverStyle(args);
             _isOpen = true;
             StateHasChanged();
         }
-        /// <summary>
-        /// Sets the popover style when there is an activator
-        /// </summary>
-        /// <param name="args"></param>
-        /// <returns></returns>
+
+        // Sets the popover style ONLY when there is an activator
         private async Task SetPopoverStyle(MouseEventArgs args)
         {
-            static string ToString(double? measure) =>
-               measure?.ToString(CultureInfo.InvariantCulture) + "px";
-
             var activatorRect = await _activatorRef.MudGetBoundingClientRectAsync();
-
-            PopoverStyle = PositionAtCurser
-                ? @$"position:relative;
-                     left:{ToString(args?.ClientX - activatorRect.Left)}; 
-                     top:{ToString(args?.ClientY - activatorRect.Top)};"
-                : null;
+            PopoverStyle = @$"position:relative;
+                              left:{(args?.ClientX - activatorRect.Left).ToPixels()};
+                              top:{(args?.ClientY - activatorRect.Top).ToPixels()};";
         }
 
         public async Task ToggleMenu(MouseEventArgs args)
@@ -172,8 +163,5 @@ namespace MudBlazor
         {
             await ToggleMenu(args);
         }
-
-
-
     }
 }

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -1,5 +1,4 @@
-﻿using System.Threading.Tasks;
-using Microsoft.AspNetCore.Components;
+﻿using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Extensions;
 using MudBlazor.Interfaces;
@@ -126,29 +125,22 @@ namespace MudBlazor
             StateHasChanged();
         }
 
-        public async Task OpenMenu(MouseEventArgs args)
+        public void OpenMenu(MouseEventArgs args)
         {
             if (Disabled)
                 return;
-            if (PositionAtCurser) await SetPopoverStyle(args);
+            if (PositionAtCurser) SetPopoverStyle(args);
             _isOpen = true;
             StateHasChanged();
         }
 
         // Sets the popover style ONLY when there is an activator
-        private async Task SetPopoverStyle(MouseEventArgs args)
+        private void SetPopoverStyle(MouseEventArgs args)
         {
-            var activatorRect = await _activatorRef.MudGetBoundingClientRectAsync();
-            PopoverStyle = IsPortalEnabled
-                ? @$"position:relative;
-                     left:{(args?.ClientX - activatorRect.Left).ToPixels()};
-                     top:{(args?.ClientY - activatorRect.Top).ToPixels()};"
-                : @$"position:fixed;
-                     left:{(args?.ClientX).ToPixels()};
-                     top:{(args?.ClientY).ToPixels()};";
+            PopoverStyle = @$"left:{args?.OffsetX.ToPixels()};top:{args?.OffsetY.ToPixels()};";
         }
 
-        public async Task ToggleMenu(MouseEventArgs args)
+        public void ToggleMenu(MouseEventArgs args)
         {
             if (Disabled)
                 return;
@@ -159,7 +151,7 @@ namespace MudBlazor
             if (_isOpen)
                 CloseMenu();
             else
-                await OpenMenu(args);
+                OpenMenu(args);
         }
 
         /// <summary>
@@ -167,9 +159,9 @@ namespace MudBlazor
         /// </summary>
         /// <param name="activator"></param>
         /// <param name="args"></param>
-        public async void Activate(object activator, MouseEventArgs args)
+        public void Activate(object activator, MouseEventArgs args)
         {
-            await ToggleMenu(args);
+            ToggleMenu(args);
         }
     }
 }

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -113,6 +113,8 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public RenderFragment ChildContent { get; set; }
 
+        [Parameter] public bool IsPortalEnabled { get; set; } = false;
+
         public string PopoverStyle { get; set; }
 
         public void CloseMenu()
@@ -135,9 +137,13 @@ namespace MudBlazor
         private async Task SetPopoverStyle(MouseEventArgs args)
         {
             var activatorRect = await _activatorRef.MudGetBoundingClientRectAsync();
-            PopoverStyle = @$"position:relative;
-                              left:{(args?.ClientX - activatorRect.Left).ToPixels()};
-                              top:{(args?.ClientY - activatorRect.Top).ToPixels()};";
+            PopoverStyle = IsPortalEnabled
+                ? @$"position:relative;
+                     left:{(args?.ClientX - activatorRect.Left).ToPixels()};
+                     top:{(args?.ClientY - activatorRect.Top).ToPixels()};"
+                : @$"position:fixed;
+                     left:{(args?.ClientX).ToPixels()};
+                     top:{(args?.ClientY).ToPixels()};";
         }
 
         public async Task ToggleMenu(MouseEventArgs args)

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -112,9 +112,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public RenderFragment ChildContent { get; set; }
 
-        [Parameter] public bool IsPortalEnabled { get; set; } = true;
-
-        [Parameter] public bool LockScroll { get; set; }
+        [Parameter] public bool IsFixed { get; set; }
 
         public string PopoverStyle { get; set; }
 

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -113,7 +113,9 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public RenderFragment ChildContent { get; set; }
 
-        [Parameter] public bool IsPortalEnabled { get; set; } = false;
+        [Parameter] public bool IsPortalEnabled { get; set; } = true;
+
+        [Parameter] public bool LockScroll { get; set; }
 
         public string PopoverStyle { get; set; }
 

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using System.Globalization;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Interfaces;
@@ -20,6 +21,7 @@ namespace MudBlazor
        .Build();
 
         private bool _isOpen;
+        private ElementReference _activatorRef;
 
         [Parameter] public string Label { get; set; }
 
@@ -120,16 +122,34 @@ namespace MudBlazor
             StateHasChanged();
         }
 
-        public void OpenMenu(MouseEventArgs args)
+        public async Task OpenMenu(MouseEventArgs args)
         {
             if (Disabled)
                 return;
-            PopoverStyle = PositionAtCurser ? $"position:fixed; left:{args?.ClientX}px; top:{args?.ClientY}px;" : null;
+            await SetPopoverStyle(args);
             _isOpen = true;
             StateHasChanged();
         }
+        /// <summary>
+        /// Sets the popover style when there is an activator
+        /// </summary>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        private async Task SetPopoverStyle(MouseEventArgs args)
+        {
+            static string ToString(double? measure) =>
+               measure?.ToString(CultureInfo.InvariantCulture) + "px";
 
-        public void ToggleMenu(MouseEventArgs args)
+            var activatorRect = await _activatorRef.MudGetBoundingClientRectAsync();
+
+            PopoverStyle = PositionAtCurser
+                ? @$"position:relative;
+                     left:{ToString(args?.ClientX - activatorRect.Left)}; 
+                     top:{ToString(args?.ClientY - activatorRect.Top)};"
+                : null;
+        }
+
+        public async Task ToggleMenu(MouseEventArgs args)
         {
             if (Disabled)
                 return;
@@ -140,7 +160,7 @@ namespace MudBlazor
             if (_isOpen)
                 CloseMenu();
             else
-                OpenMenu(args);
+                await OpenMenu(args);
         }
 
         /// <summary>
@@ -148,12 +168,12 @@ namespace MudBlazor
         /// </summary>
         /// <param name="activator"></param>
         /// <param name="args"></param>
-        public void Activate(object activator, MouseEventArgs args)
+        public async void Activate(object activator, MouseEventArgs args)
         {
-            ToggleMenu(args);
+            await ToggleMenu(args);
         }
 
-       
- 
+
+
     }
 }

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -116,6 +116,7 @@ namespace MudBlazor
 
         public string PopoverStyle { get; set; }
 
+
         public void CloseMenu()
         {
             _isOpen = false;
@@ -160,6 +161,15 @@ namespace MudBlazor
         public void Activate(object activator, MouseEventArgs args)
         {
             ToggleMenu(args);
+        }
+
+        private void HandleMouseEnter()
+        {
+            if (Disabled)
+                return;
+           
+            _isOpen = true;
+            StateHasChanged();
         }
     }
 }

--- a/src/MudBlazor/Components/Picker/MudPicker.razor
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor
@@ -8,29 +8,34 @@
 {
 
     protected virtual RenderFragment InputContent => 
-        @<MudTextField @ref="_inputReference" Label="@Label" @bind-Text="@Text" HelperText="@HelperText" Variant="@InputVariant" ReadOnly="@(!Editable)" T="string" Style="@Style"
-                    @onclick="(() => { if (!Editable) ToggleState(); })" OnAdornmentClick="ToggleState" Disabled="@Disabled" Adornment="@Adornment"
-                    AdornmentIcon="@InputIcon" IconSize="@IconSize" Margin="@Margin"
-                    Required="@Required" RequiredError="@RequiredError" Error="@Error" ErrorText="@ErrorText"/>;
+        @<div @ref="@_anchorRef">
+    <MudTextField @ref="_inputReference" Label="@Label" @bind-Text="@Text" HelperText="@HelperText" Variant="@InputVariant" ReadOnly="@(!Editable)" T="string" Style="@Style"
+                  @onclick="(() => { if (!Editable) ToggleState(); })" OnAdornmentClick="ToggleState" Disabled="@Disabled" Adornment="@Adornment"
+                  AdornmentIcon="@InputIcon" IconSize="@IconSize" Margin="@Margin"
+                  Required="@Required" RequiredError="@RequiredError" Error="@Error" ErrorText="@ErrorText" />
+</div>;
 
     protected virtual RenderFragment PickerContent => null;
 
     protected virtual RenderFragment Render => 
     @<CascadingValue Value="@this" IsFixed="true">
-        <div class="@PickerClass">
-            @if (PickerVariant != PickerVariant.Static)
-            {
-                <CascadingValue Name="Standalone" Value="false" IsFixed="true">
-                    @InputContent
-                </CascadingValue>
-            }
-            @if (IsOpen && PickerVariant == PickerVariant.Inline)
-            {
-               <div @ref="_pickerInlineRef" class="@PickerInlineClass">
-                   <MudPaper @attributes="UserAttributes" Class="@PickerPaperClass" Elevation="@_pickerElevation" Square="@_pickerSquare">
-                       <div class="@PickerContainerClass">
-                           @PickerContent
-                       </div>
+         <div class="@PickerClass">
+             @if (PickerVariant != PickerVariant.Static)
+             {
+         <CascadingValue Name="Standalone" Value="false" IsFixed="true">
+             @InputContent
+         </CascadingValue>}
+
+             @if (IsOpen && PickerVariant == PickerVariant.Inline)
+             {
+         <MudPortal IsVisible="@IsOpen" AnchorRef=@_anchorRef>
+             <div @ref="_pickerInlineRef" class="@PickerInlineClass">
+                 <MudPaper @attributes="UserAttributes" Class="@PickerPaperClass" Elevation="@_pickerElevation" Square="@_pickerSquare">
+                     <div class="@PickerContainerClass">
+
+
+                         @PickerContent
+                             </div>
                         @if (PickerActions != null)
                         {
                             <div class="@ActionClass">
@@ -39,6 +44,8 @@
                         }
                    </MudPaper>
                </div>
+         </MudPortal>
+
             }
             else if (PickerVariant == PickerVariant.Static)
             {

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -262,7 +262,7 @@ namespace MudBlazor
         }
 
         private MudTextField<string> _inputReference;
-
+        private ElementReference _anchorRef;
         public virtual ValueTask FocusAsync() => _inputReference?.FocusAsync() ?? ValueTask.CompletedTask;
 
         public virtual ValueTask SelectAsync() => _inputReference?.SelectAsync() ?? ValueTask.CompletedTask;

--- a/src/MudBlazor/Components/Popover/MudPopover.razor
+++ b/src/MudBlazor/Components/Popover/MudPopover.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
-<MudPortal IsVisible="Open" IsEnabled="true">
+
     <div @attributes="UserAttributes" class="@PopoverClass" style="@PopoverStyles">
         @ChildContent
     </div>
-</MudPortal>
+

--- a/src/MudBlazor/Components/Popover/MudPopover.razor
+++ b/src/MudBlazor/Components/Popover/MudPopover.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
-<MudPortal IsVisible="@Open">
+<MudPortal IsVisible="@Open" Direction=@Direction>
     <div @ref=@_popoverRef @attributes="UserAttributes" class="@PopoverClass" style="@PopoverStyles">
         @ChildContent
     </div>

--- a/src/MudBlazor/Components/Popover/MudPopover.razor
+++ b/src/MudBlazor/Components/Popover/MudPopover.razor
@@ -1,7 +1,8 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
-
+<MudPortal IsVisible="@Open">
     <div @ref=@_popoverRef @attributes="UserAttributes" class="@PopoverClass" style="@PopoverStyles">
         @ChildContent
     </div>
+</MudPortal>
 

--- a/src/MudBlazor/Components/Popover/MudPopover.razor
+++ b/src/MudBlazor/Components/Popover/MudPopover.razor
@@ -1,6 +1,7 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
-
-<div @attributes="UserAttributes" class="@PopoverClass" style="@PopoverStyles">
-    @ChildContent
-</div>
+<MudPortal IsVisible="Open" IsEnabled="true">
+    <div @attributes="UserAttributes" class="@PopoverClass" style="@PopoverStyles">
+        @ChildContent
+    </div>
+</MudPortal>

--- a/src/MudBlazor/Components/Popover/MudPopover.razor
+++ b/src/MudBlazor/Components/Popover/MudPopover.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
 
-    <div @attributes="UserAttributes" class="@PopoverClass" style="@PopoverStyles">
+    <div @ref=@_popoverRef @attributes="UserAttributes" class="@PopoverClass" style="@PopoverStyles">
         @ChildContent
     </div>
 

--- a/src/MudBlazor/Components/Popover/MudPopover.razor
+++ b/src/MudBlazor/Components/Popover/MudPopover.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
-<MudPortal IsVisible="@Open" Direction=@Direction>
+<MudPortal IsVisible="@Open" Direction=@Direction OffsetX=@OffsetX OffsetY=@OffsetY>
     <div @ref=@_popoverRef @attributes="UserAttributes" class="@PopoverClass" style="@PopoverStyles">
         @ChildContent
     </div>

--- a/src/MudBlazor/Components/Popover/MudPopover.razor
+++ b/src/MudBlazor/Components/Popover/MudPopover.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
-<MudPortal IsVisible="@Open" Direction=@Direction OffsetX=@OffsetX OffsetY=@OffsetY>
+<MudPortal  IsVisible=@Open Direction=@Direction OffsetX=@OffsetX OffsetY=@OffsetY>
     <div @ref=@_popoverRef @attributes="UserAttributes" class="@PopoverClass" style="@PopoverStyles">
         @ChildContent
     </div>

--- a/src/MudBlazor/Components/Popover/MudPopover.razor.cs
+++ b/src/MudBlazor/Components/Popover/MudPopover.razor.cs
@@ -11,10 +11,7 @@ namespace MudBlazor
         private ElementReference _popoverRef;
         protected string PopoverClass =>
            new CssBuilder("mud-popover")
-            .AddClass("mud-popover-open", Open)
-            .AddClass($"mud-popover-{Direction.ToDescriptionString()}")
-            .AddClass("mud-popover-offset-y", OffsetY)
-            .AddClass("mud-popover-offset-x", OffsetX)
+            .AddClass("mud-popover-open", Open)           
             .AddClass("mud-paper")
             .AddClass("mud-paper-square", Square)
             .AddClass($"mud-elevation-{Elevation}")

--- a/src/MudBlazor/Components/Popover/MudPopover.razor.cs
+++ b/src/MudBlazor/Components/Popover/MudPopover.razor.cs
@@ -62,59 +62,55 @@ namespace MudBlazor
         /// <summary>
         /// If true, the select menu will open either before or after the input depending on the direction.
         /// </summary>
-        [Parameter] public bool OffsetY { get; set; }
+        [Parameter] public bool OffsetY { get; set; } = true;
 
         /// <summary>
         /// Child content of the component.
         /// </summary>
         [Parameter] public RenderFragment ChildContent { get; set; }
 
-        protected override async Task OnAfterRenderAsync(bool firstRender)
-        {
-            await SetDirection();
 
-        }
 
-        private async Task SetDirection()
-        {
-            if (!Open) return;
-            var rect = await _popoverRef.MudGetBoundingClientRectAsync();
-            var viewport = await WindowSize.GetBrowserWindowSize();
-            Direction direction = Direction;
+        //private async Task SetDirection()
+        //{
+        //    if (!Open) return;
+        //    var rect = await _popoverRef.MudGetBoundingClientRectAsync();
+        //    var viewport = await WindowSize.GetBrowserWindowSize();
+        //    var direction = Direction;
 
-            switch (Direction)
-            {
-                case Direction.Bottom:
-                    if (rect.Bottom > viewport.Height)
-                    {
-                        direction = Direction.Top;
-                    }
-                    break;
+        //    switch (Direction)
+        //    {
+        //        case Direction.Bottom:
+        //            if (rect.Bottom > viewport.Height)
+        //            {
+        //                direction = Direction.Top;
+        //            }
+        //            break;
 
-                case Direction.Top:
-                    if (rect.Top < 0)
-                    {
-                        direction = Direction.Bottom;
-                    }
-                    break;
-                case Direction.Left:
-                    if (rect.Left < 0)
-                    {
-                        direction = Direction.Right;
-                    }
-                    break;
-                case Direction.Right:
-                    if (rect.Right > viewport.Width)
-                    {
-                        direction = Direction.Left;
-                    }
-                    break;
-            }
-            if (direction != Direction)
-            {
-                Direction = direction;
-                StateHasChanged();
-            }
-        }
+        //        case Direction.Top:
+        //            if (rect.Top < 0)
+        //            {
+        //                direction = Direction.Bottom;
+        //            }
+        //            break;
+        //        case Direction.Left:
+        //            if (rect.Left < 0)
+        //            {
+        //                direction = Direction.Right;
+        //            }
+        //            break;
+        //        case Direction.Right:
+        //            if (rect.Right > viewport.Width)
+        //            {
+        //                direction = Direction.Left;
+        //            }
+        //            break;
+        //    }
+        //    if (direction != Direction)
+        //    {
+        //        Direction = direction;
+        //        StateHasChanged();
+        //    }
+        //}
     }
 }

--- a/src/MudBlazor/Components/Popover/MudPopover.razor.cs
+++ b/src/MudBlazor/Components/Popover/MudPopover.razor.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Components;
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
 using MudBlazor.Extensions;
 using MudBlazor.Utilities;
 
@@ -7,6 +8,7 @@ namespace MudBlazor
 {
     public partial class MudPopover : MudComponentBase
     {
+        private ElementReference _popoverRef;
         protected string PopoverClass =>
            new CssBuilder("mud-popover")
             .AddClass("mud-popover-open", Open)
@@ -24,6 +26,8 @@ namespace MudBlazor
             .AddStyle("max-height", $"{MaxHeight}px", MaxHeight != null)
             .AddStyle(Style)
             .Build();
+
+        [Inject] public IBrowserWindowSizeProvider WindowSize { get; set; }
 
         /// <summary>
         /// The higher the number, the heavier the drop-shadow. 0 for no shadow set to 8 by default.
@@ -64,5 +68,53 @@ namespace MudBlazor
         /// Child content of the component.
         /// </summary>
         [Parameter] public RenderFragment ChildContent { get; set; }
+
+        protected override async Task OnAfterRenderAsync(bool firstRender)
+        {
+            await SetDirection();
+
+        }
+
+        private async Task SetDirection()
+        {
+            if (!Open) return;
+            var rect = await _popoverRef.MudGetBoundingClientRectAsync();
+            var viewport = await WindowSize.GetBrowserWindowSize();
+            Direction direction = Direction;
+
+            switch (Direction)
+            {
+                case Direction.Bottom:
+                    if (rect.Bottom > viewport.Height)
+                    {
+                        direction = Direction.Top;
+                    }
+                    break;
+
+                case Direction.Top:
+                    if (rect.Top < 0)
+                    {
+                        direction = Direction.Bottom;
+                    }
+                    break;
+                case Direction.Left:
+                    if (rect.Left < 0)
+                    {
+                        direction = Direction.Right;
+                    }
+                    break;
+                case Direction.Right:
+                    if (rect.Right > viewport.Width)
+                    {
+                        direction = Direction.Left;
+                    }
+                    break;
+            }
+            if (direction != Direction)
+            {
+                Direction = direction;
+                StateHasChanged();
+            }
+        }
     }
 }

--- a/src/MudBlazor/Components/Popover/MudPopover.razor.cs
+++ b/src/MudBlazor/Components/Popover/MudPopover.razor.cs
@@ -27,8 +27,6 @@ namespace MudBlazor
             .AddStyle(Style)
             .Build();
 
-        [Inject] public IBrowserWindowSizeProvider WindowSize { get; set; }
-
         /// <summary>
         /// The higher the number, the heavier the drop-shadow. 0 for no shadow set to 8 by default.
         /// </summary>
@@ -71,46 +69,6 @@ namespace MudBlazor
 
 
 
-        //private async Task SetDirection()
-        //{
-        //    if (!Open) return;
-        //    var rect = await _popoverRef.MudGetBoundingClientRectAsync();
-        //    var viewport = await WindowSize.GetBrowserWindowSize();
-        //    var direction = Direction;
-
-        //    switch (Direction)
-        //    {
-        //        case Direction.Bottom:
-        //            if (rect.Bottom > viewport.Height)
-        //            {
-        //                direction = Direction.Top;
-        //            }
-        //            break;
-
-        //        case Direction.Top:
-        //            if (rect.Top < 0)
-        //            {
-        //                direction = Direction.Bottom;
-        //            }
-        //            break;
-        //        case Direction.Left:
-        //            if (rect.Left < 0)
-        //            {
-        //                direction = Direction.Right;
-        //            }
-        //            break;
-        //        case Direction.Right:
-        //            if (rect.Right > viewport.Width)
-        //            {
-        //                direction = Direction.Left;
-        //            }
-        //            break;
-        //    }
-        //    if (direction != Direction)
-        //    {
-        //        Direction = direction;
-        //        StateHasChanged();
-        //    }
-        //}
+        
     }
 }

--- a/src/MudBlazor/Components/Popover/MudPopover.razor.cs
+++ b/src/MudBlazor/Components/Popover/MudPopover.razor.cs
@@ -10,8 +10,11 @@ namespace MudBlazor
     {
         private ElementReference _popoverRef;
         protected string PopoverClass =>
-           new CssBuilder("mud-popover")
-            .AddClass("mud-popover-open", Open)           
+         new CssBuilder("mud-popover")
+            .AddClass("mud-popover-open", Open)
+            .AddClass($"mud-popover-{Direction.ToDescriptionString()}")
+            .AddClass("mud-popover-offset-y", OffsetY)
+            .AddClass("mud-popover-offset-x", OffsetX)
             .AddClass("mud-paper")
             .AddClass("mud-paper-square", Square)
             .AddClass($"mud-elevation-{Elevation}")

--- a/src/MudBlazor/Components/Popover/MudPopover.razor.cs
+++ b/src/MudBlazor/Components/Popover/MudPopover.razor.cs
@@ -47,6 +47,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public bool Open { get; set; }
 
+        [Parameter] public bool OpenOnHover { get; set; }
         /// <summary>
         /// Sets the direction the popover will start from relative to its parent.
         /// </summary>

--- a/src/MudBlazor/Components/Portal/MudPortal.razor
+++ b/src/MudBlazor/Components/Portal/MudPortal.razor
@@ -2,13 +2,10 @@
 @if (IsEnabled){
     @if (IsVisible)
     {
-        <div id="mud-portal-input"
-             @ref=@_portalRef 
-             style="width:100%;position:absolute;height:100%" />
+        <div @ref=@_portalRef style="width:100%;position:absolute;height:100%" />
     }
 
-}
-else
+} else
 {
     @ChildContent
 }

--- a/src/MudBlazor/Components/Portal/MudPortal.razor
+++ b/src/MudBlazor/Components/Portal/MudPortal.razor
@@ -1,12 +1,13 @@
 ﻿@namespace MudBlazor
+@inherits MudComponentBase
 @if (IsEnabled){
     @if (IsVisible)
     {
-        <div @ref=@_portalRef style="width:100%;position:absolute;height:100%" />
+        <div @ref=@_portalRef 
+             style=@($"top:0;pointer-events:none;width:100%;position:absolute;height:100%;z-index:1;{Style}") />
     }
 
 } else
 {
     @ChildContent
 }
-    

--- a/src/MudBlazor/Components/Portal/MudPortal.razor
+++ b/src/MudBlazor/Components/Portal/MudPortal.razor
@@ -1,0 +1,15 @@
+﻿@namespace MudBlazor
+@if (IsEnabled){
+    @if (IsVisible)
+    {
+        <div id="mud-portal-input"
+             @ref=@_portalRef 
+             style="width:100%;position:absolute;height:100%" />
+    }
+
+}
+else
+{
+    @ChildContent
+}
+    

--- a/src/MudBlazor/Components/Portal/MudPortal.razor
+++ b/src/MudBlazor/Components/Portal/MudPortal.razor
@@ -1,13 +1,7 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
-@if (IsEnabled){
-    @if (IsVisible)
-    {
-        <div @ref=@_portalRef 
-             style=@($"top:0;pointer-events:none;width:100%;position:absolute;height:100%;z-index:1;{Style}") />
-    }
 
-} else
+@if (IsVisible)
 {
-    @ChildContent
+    <div class="portal" @ref=@_portalRef data-id=@_id/>
 }

--- a/src/MudBlazor/Components/Portal/MudPortal.razor
+++ b/src/MudBlazor/Components/Portal/MudPortal.razor
@@ -1,7 +1,6 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
 
-@if (IsVisible)
-{
+ 
     <div class="portal" @ref=@_portalRef data-id=@_id/>
-}
+ 

--- a/src/MudBlazor/Components/Portal/MudPortal.razor
+++ b/src/MudBlazor/Components/Portal/MudPortal.razor
@@ -1,11 +1,12 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
- 
- 
-    <div class="portal" @ref=@_portalRef data-id=@_id>
-    <div class=@FragmentClass style="position:relative">
-        
-        @ChildContent
+
+@if (IsVisible)
+{
+    <div class="portal" @ref=@_portalRef>
+        <div @ref="@_fragmentRef">
+            @ChildContent
+        </div>
     </div>
-    </div>
- 
+}
+

--- a/src/MudBlazor/Components/Portal/MudPortal.razor
+++ b/src/MudBlazor/Components/Portal/MudPortal.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
 
-@if (IsVisible)
+@if (IsVisible )
 {
     <div class="portal" @ref=@_portalRef>
         <div @ref="@_fragmentRef">

--- a/src/MudBlazor/Components/Portal/MudPortal.razor
+++ b/src/MudBlazor/Components/Portal/MudPortal.razor
@@ -1,6 +1,11 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
-
  
-    <div class="portal" @ref=@_portalRef data-id=@_id/>
+ 
+    <div class="portal" @ref=@_portalRef data-id=@_id>
+    <div class=@FragmentClass style="position:relative">
+        
+        @ChildContent
+    </div>
+    </div>
  

--- a/src/MudBlazor/Components/Portal/MudPortal.razor.cs
+++ b/src/MudBlazor/Components/Portal/MudPortal.razor.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using MudBlazor.Interop;
+using MudBlazor.Services;
+
+namespace MudBlazor
+{
+    public partial class MudPortal : ComponentBase, IDisposable
+    {
+        private Guid _id = Guid.NewGuid();
+
+        private ElementReference _portalRef;
+
+
+        private PortalItem _portalItem = new();
+
+        [Inject] public IPortal Portal { get; set; }
+
+        [Inject] public IResizeListenerService WindowResizeListener { get; set; }
+
+        [Parameter] public bool Autopositioned { get; set; } = true;
+
+        [Parameter] public BoundingClientRect ClientRect { get; set; }
+
+        [Parameter] public RenderFragment ChildContent { get; set; }
+
+        [Parameter] public bool IsVisible { get; set; }
+
+        [Parameter] public bool IsEnabled { get; set; } = true;
+
+        [Parameter] public bool AutoResize { get; set; } = true;
+
+        protected override async Task OnAfterRenderAsync(bool firstRender)
+        {
+
+            if (IsVisible && AutoResize)
+            {
+                WindowResizeListener.OnResized += OnResized;
+            }
+            else
+            {
+
+                WindowResizeListener.OnResized -= OnResized;
+            }
+
+            if (IsVisible)
+            {
+                await ConfigurePortalItem();
+                Portal.AddOrUpdate(_portalItem);
+            }
+            else
+            {
+                Portal.Remove(_portalItem);
+            }
+        }
+
+
+        private async Task ConfigurePortalItem()
+        {
+            _portalItem.Id = _id;
+            _portalItem.Fragment = ChildContent;
+            _portalItem.ClientRect = await _portalRef.MudGetRelativeClientRectAsync();
+            _portalItem.Autopositioned = Autopositioned;
+        }
+
+        private void OnResized(object sender, BrowserWindowSize e)
+        {
+            Task.Run(async () =>
+           {
+               _portalItem.ClientRect = await _portalRef.MudGetRelativeClientRectAsync();
+               Portal.AddOrUpdate(_portalItem);
+           }).AndForget();
+        }
+
+
+
+        protected virtual void Dispose(bool disposing)
+        {
+            Portal.Remove(_portalItem);
+
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+
+
+
+    }
+}

--- a/src/MudBlazor/Components/Portal/MudPortal.razor.cs
+++ b/src/MudBlazor/Components/Portal/MudPortal.razor.cs
@@ -5,7 +5,7 @@ using MudBlazor.Services;
 
 namespace MudBlazor
 {
-    public partial class MudPortal : IDisposable
+    public partial class MudPortal : MudComponentBase, IDisposable
     {
         private Guid _id = Guid.NewGuid();
         private PortalItem _portalItem = new();
@@ -26,6 +26,10 @@ namespace MudBlazor
         [Parameter] public Placement Placement { get; set; }
 
         [Parameter] public Direction Direction { get; set; }
+
+        [Parameter] public bool OffsetX { get; set; }
+
+        [Parameter] public bool OffsetY { get; set; }
 
         [Parameter] public bool Autopositioned { get; set; } = true;
 
@@ -81,6 +85,8 @@ namespace MudBlazor
             _portalItem.PortalType = PortalType;
             _portalItem.Placement = Placement;
             _portalItem.Direction = Direction;
+            _portalItem.OffsetX = OffsetX;
+            _portalItem.OffsetY = OffsetY;
             _portalItem.Fragment = ChildContent;
             _portalItem.AutoDirection = AutoDirection;
             _portalItem.Position = IsFixed ? "fixed" : "absolute";

--- a/src/MudBlazor/Components/Portal/MudPortal.razor.cs
+++ b/src/MudBlazor/Components/Portal/MudPortal.razor.cs
@@ -12,7 +12,7 @@ namespace MudBlazor
         private PortalItem _portalItem = new();
         private bool? _hasFixedAncestor = null;
 
-        [Inject] public IPortal Portal { get; set; }
+        [Inject] internal IPortal Portal { get; set; }
 
         [Inject] public IResizeListenerService WindowResizeListener { get; set; }
 
@@ -35,7 +35,7 @@ namespace MudBlazor
         {
             if (!IsEnabled) return;
             if (_portalRef.Id != null)
-                _hasFixedAncestor = _hasFixedAncestor ?? await _portalRef.MudHasFixedAncestorsAsync();
+                _hasFixedAncestor ??= await _portalRef.MudHasFixedAncestorsAsync();
             await ConfigurePortalItem();
             ConfigureResizeListener();
             await AddOrRemovePortalItem();

--- a/src/MudBlazor/Components/Portal/MudPortal.razor.cs
+++ b/src/MudBlazor/Components/Portal/MudPortal.razor.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
-using MudBlazor.Interop;
 using MudBlazor.Services;
 
 namespace MudBlazor
@@ -25,28 +24,29 @@ namespace MudBlazor
 
         [Parameter] public bool AutoDirection { get; set; } = true;
 
-        [Parameter] public BoundingClientRect ClientRect { get; set; }
-
         [Parameter] public RenderFragment ChildContent { get; set; }
 
         [Parameter] public bool IsVisible { get; set; }
 
-        [Parameter] public bool IsEnabled { get; set; } = true;
+        [Parameter] public bool IsEnabled { get; set; } = false;
 
-        [Parameter] public bool LockScroll { get; set; } = false;
+        [Parameter] public bool LockScroll { get; set; }
 
 
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
+            if (!IsEnabled) return;
 
             if (IsVisible && Autopositioned)
             {
                 WindowResizeListener.OnResized += OnWindowResize;
             }
-            else
+
+            if (!IsVisible && Autopositioned)
             {
                 WindowResizeListener.OnResized -= OnWindowResize;
             }
+
 
             if (IsVisible)
             {
@@ -59,6 +59,7 @@ namespace MudBlazor
                 if (LockScroll) await ScrollManager.UnlockScrollAsync();
                 Portal.Remove(_portalItem);
             }
+
         }
 
 

--- a/src/MudBlazor/Components/Portal/MudPortal.razor.cs
+++ b/src/MudBlazor/Components/Portal/MudPortal.razor.cs
@@ -31,6 +31,8 @@ namespace MudBlazor
 
         [Parameter] public bool AutoResize { get; set; } = true;
 
+        [Parameter] public bool LockScroll { get; set; }
+
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
 
@@ -40,7 +42,6 @@ namespace MudBlazor
             }
             else
             {
-
                 WindowResizeListener.OnResized -= OnResized;
             }
 
@@ -73,8 +74,6 @@ namespace MudBlazor
            }).AndForget();
         }
 
-
-
         protected virtual void Dispose(bool disposing)
         {
             Portal.Remove(_portalItem);
@@ -86,9 +85,5 @@ namespace MudBlazor
             Dispose(true);
             GC.SuppressFinalize(this);
         }
-
-
-
-
     }
 }

--- a/src/MudBlazor/Components/Portal/MudPortal.razor.cs
+++ b/src/MudBlazor/Components/Portal/MudPortal.razor.cs
@@ -24,7 +24,9 @@ namespace MudBlazor
         [Parameter] public Type PortalType { get; set; }
 
         [Parameter] public Placement Placement { get; set; }
-        
+
+        [Parameter] public Direction Direction { get; set; }
+
         [Parameter] public bool Autopositioned { get; set; } = true;
 
         [Parameter] public bool AutoDirection { get; set; } = true;
@@ -78,6 +80,7 @@ namespace MudBlazor
             _portalItem.Id = _id;
             _portalItem.PortalType = PortalType;
             _portalItem.Placement = Placement;
+            _portalItem.Direction = Direction;
             _portalItem.Fragment = ChildContent;
             _portalItem.AutoDirection = AutoDirection;
             _portalItem.Position = IsFixed ? "fixed" : "absolute";

--- a/src/MudBlazor/Components/Portal/MudPortal.razor.cs
+++ b/src/MudBlazor/Components/Portal/MudPortal.razor.cs
@@ -75,17 +75,28 @@ namespace MudBlazor
                 _portalItem.AnchorRect.Top -=
                     _portalItem.FragmentRect.Height 
                     + _portalItem.FragmentRect.Top
-                    - _portalItem.AnchorRect.Top ;
+                    - _portalItem.AnchorRect.Top 
+                    ;
 
             }
             if (_portalItem.FragmentRect.IsOutsideTop)
             {
-                _portalItem.AnchorRect.Top += _portalItem.FragmentRect.Height + _portalItem.AnchorRect.Height;
+                _portalItem.AnchorRect.Top +=
+                    _portalItem.AnchorRect.Top
+                    - _portalItem.FragmentRect.Top
+                    + _portalItem.AnchorRect.Height
+                    + _portalItem.AnchorRect.Top
+                    - _portalItem.FragmentRect.Bottom;
 
             }
             if (_portalItem.FragmentRect.IsOutsideLeft)
             {
-                _portalItem.AnchorRect.Left += _portalItem.FragmentRect.Width + _portalItem.AnchorRect.Width;
+                _portalItem.AnchorRect.Left += 
+                    _portalItem.AnchorRect.Left 
+                    - _portalItem.FragmentRect.Left 
+                    + _portalItem.AnchorRect.Width
+                    + _portalItem.AnchorRect.Left
+                    - _portalItem.FragmentRect.Right;
 
             }
             if (_portalItem.FragmentRect.IsOutsideRight)

--- a/src/MudBlazor/Components/Portal/MudPortal.razor.cs
+++ b/src/MudBlazor/Components/Portal/MudPortal.razor.cs
@@ -39,6 +39,8 @@ namespace MudBlazor
 
         [Parameter] public Type Type { get; set; }
 
+        [Parameter] public ElementReference AnchorRef{ get; set; }
+
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
             if (IsVisible)
@@ -77,6 +79,9 @@ namespace MudBlazor
         private async Task ConfigureRects()
         {
             await JS.InvokeVoidAsync("window.setStylePositionInParent", _portalRef, "relative");
+            
+            var apagarAnchorRect = await AnchorRef.MudGetBoundingClientRectAsync();
+            if (apagarAnchorRect.Width > 1000000) return;
             _portalItem.AnchorRect = await _portalRef.MudGetBoundingClientRectAsync();
             _portalItem.FragmentRect = await _fragmentRef.MudGetClientRectFromFirstChildAsync();
 
@@ -98,7 +103,7 @@ namespace MudBlazor
             if (_portalItem.FragmentRect.IsOutsideBottom)
             {
                 _portalItem.AnchorRect.Top -=
-                   2 * ( (_portalItem.FragmentRect.Top - _portalItem.AnchorRect.Bottom))
+                   2 * (_portalItem.FragmentRect.Top - _portalItem.AnchorRect.Bottom)
                     + _portalItem.AnchorRect.Height
                     + _portalItem.FragmentRect.Height;
 
@@ -149,7 +154,7 @@ namespace MudBlazor
             _portalItem.OpenOnHover = ActivationEvent == MouseEvent.MouseOver;
         }
 
-        //warning this listenir doesn't work too well, create other
+       
         private void OnWindowResize(object sender, BrowserWindowSize e)
         {
             Task.Run(async () =>

--- a/src/MudBlazor/Components/Portal/MudPortal.razor.cs
+++ b/src/MudBlazor/Components/Portal/MudPortal.razor.cs
@@ -70,43 +70,41 @@ namespace MudBlazor
 
         private void ConfigurePosition()
         {
+            if (_portalItem.FragmentRect is null || _portalItem.AnchorRect is null) return;
+
             if (_portalItem.FragmentRect.IsOutsideBottom)
             {
                 _portalItem.AnchorRect.Top -=
-                    _portalItem.FragmentRect.Height 
-                    + _portalItem.FragmentRect.Top
-                    - _portalItem.AnchorRect.Top 
-                    ;
+                   2 * (_portalItem.FragmentRect.Top - _portalItem.AnchorRect.Bottom)
+                    + _portalItem.AnchorRect.Height
+                    + _portalItem.FragmentRect.Height;
 
             }
             if (_portalItem.FragmentRect.IsOutsideTop)
             {
                 _portalItem.AnchorRect.Top +=
-                    _portalItem.AnchorRect.Top
-                    - _portalItem.FragmentRect.Top
-                    + _portalItem.AnchorRect.Height
-                    + _portalItem.AnchorRect.Top
-                    - _portalItem.FragmentRect.Bottom;
+                  2 * (_portalItem.AnchorRect.Top - _portalItem.FragmentRect.Bottom)
+                  + _portalItem.AnchorRect.Height
+                  + _portalItem.FragmentRect.Height;
 
             }
             if (_portalItem.FragmentRect.IsOutsideLeft)
             {
-                _portalItem.AnchorRect.Left += 
-                    _portalItem.AnchorRect.Left 
-                    - _portalItem.FragmentRect.Left 
-                    + _portalItem.AnchorRect.Width
-                    + _portalItem.AnchorRect.Left
-                    - _portalItem.FragmentRect.Right;
+                _portalItem.AnchorRect.Left +=
+                   2 * (_portalItem.AnchorRect.Left - _portalItem.FragmentRect.Right)
+                   + _portalItem.FragmentRect.Width
+                   + _portalItem.AnchorRect.Width;
 
             }
             if (_portalItem.FragmentRect.IsOutsideRight)
             {
-                _portalItem.AnchorRect.Left -= _portalItem.FragmentRect.Width + _portalItem.AnchorRect.Width;
+                _portalItem.AnchorRect.Left -=
+                   2 * (_portalItem.FragmentRect.Left - _portalItem.AnchorRect.Right)
+                   + _portalItem.FragmentRect.Width
+                   + _portalItem.AnchorRect.Width;
+
 
             }
-
-
-
 
         }
 
@@ -123,8 +121,11 @@ namespace MudBlazor
            {
                await ConfigureAnchorRect();
                await Task.Delay(0);
-               if (IsVisible) { 
-                   Portal.AddOrUpdate(_portalItem); } else { Portal.Remove(_portalItem); }
+               if (IsVisible)
+               {
+                   Portal.AddOrUpdate(_portalItem);
+               }
+               else { Portal.Remove(_portalItem); }
            }).AndForget();
         }
 

--- a/src/MudBlazor/Components/Portal/MudPortal.razor.cs
+++ b/src/MudBlazor/Components/Portal/MudPortal.razor.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
+using MudBlazor.Extensions;
 using MudBlazor.Services;
+using MudBlazor.Utilities;
 
 namespace MudBlazor
 {
@@ -112,5 +114,12 @@ namespace MudBlazor
             Dispose(true);
             GC.SuppressFinalize(this);
         }
+
+        private string FragmentClass=> 
+            new CssBuilder("portal-fragment-hidden")
+            .AddClass("mud-popover-offset-x", OffsetX)
+            .AddClass("mud-popover-offset-y", OffsetY)
+            .AddClass($"mud-popover-{Direction.ToDescriptionString()}")
+            .Build();
     }
 }

--- a/src/MudBlazor/Components/Portal/MudPortalItem.razor
+++ b/src/MudBlazor/Components/Portal/MudPortalItem.razor
@@ -1,14 +1,16 @@
 ﻿@namespace MudBlazor
 @*this is the element where the popover will be anchored*@
-<div class=@AnchorClass data-id=@Item.Id style=@AnchorStyle @ref=@_anchorRef>
-    @if (!_hasBeenRendered)
-    {
+@if (!_hasBeenRendered)
+{
+    <div class=@AnchorClass data-id=@Item.Id style=@AnchorStyle @ref=@_anchorRef>
         <div class=@FragmentClass @ref=@_fragmentRef>
             @Item.Fragment
         </div>
-    }
-    else
-    {
+    </div>
+}
+else
+{
+    <div style=@FragmentStyle>
         @Item.Fragment
-    }
-</div>
+    </div>
+}

--- a/src/MudBlazor/Components/Portal/MudPortalItem.razor
+++ b/src/MudBlazor/Components/Portal/MudPortalItem.razor
@@ -1,7 +1,14 @@
 ﻿@namespace MudBlazor
 @*this is the element where the popover will be anchored*@
-<div class="portal-anchor" data-id=@Item.Id style=@AnchorStyle @ref=@_anchorRef>
-    <div class="portal-fragment" @ref=@_fragmentRef>
+<div class=@AnchorClass data-id=@Item.Id style=@AnchorStyle @ref=@_anchorRef>
+    @if (!_hasBeenRendered)
+    {
+        <div class=@FragmentClass @ref=@_fragmentRef>
+            @Item.Fragment
+        </div>
+    }
+    else
+    {
         @Item.Fragment
-    </div>
+    }
 </div>

--- a/src/MudBlazor/Components/Portal/MudPortalItem.razor
+++ b/src/MudBlazor/Components/Portal/MudPortalItem.razor
@@ -1,0 +1,6 @@
+﻿@namespace MudBlazor
+<span  @ref=@_fragmentReference style=@Style>
+
+    @Item.Fragment
+    
+</span>

--- a/src/MudBlazor/Components/Portal/MudPortalItem.razor
+++ b/src/MudBlazor/Components/Portal/MudPortalItem.razor
@@ -1,6 +1,7 @@
 ﻿@namespace MudBlazor
-<span  @ref=@_fragmentReference style=@Style>
-
-    @Item.Fragment
-    
-</span>
+@*this is the element where the popover will be anchored*@
+<div class="portal-anchor" data-id=@Item.Id style=@AnchorStyle @ref=@_anchorRef>
+    <div class="portal-fragment" @ref=@_fragmentRef>
+        @Item.Fragment
+    </div>
+</div>

--- a/src/MudBlazor/Components/Portal/MudPortalItem.razor
+++ b/src/MudBlazor/Components/Portal/MudPortalItem.razor
@@ -1,16 +1,19 @@
 ﻿@namespace MudBlazor
+@using MudBlazor.Extensions
 @*this is the element where the popover will be anchored*@
 @if (!_hasBeenRendered)
 {
     <div class=@AnchorClass data-id=@Item.Id style=@AnchorStyle @ref=@_anchorRef>
-        <div class=@FragmentClass @ref=@_fragmentRef>
+        <div class=@PopoverClass @ref=@_fragmentRef >
             @Item.Fragment
         </div>
     </div>
 }
 else
 {
-    <div style=@FragmentStyle>
+    <div  style=@FragmentStyle>
+       
         @Item.Fragment
+        
     </div>
 }

--- a/src/MudBlazor/Components/Portal/MudPortalItem.razor
+++ b/src/MudBlazor/Components/Portal/MudPortalItem.razor
@@ -2,7 +2,7 @@
 @using MudBlazor.Extensions
 
 @*this is the element where the popover will be anchored*@
-<div style=@AnchorStyle class="portal-anchor">
+<div style=@AnchorStyle class=@AnchorClass>
     @Item.Fragment
 </div>
 

--- a/src/MudBlazor/Components/Portal/MudPortalItem.razor
+++ b/src/MudBlazor/Components/Portal/MudPortalItem.razor
@@ -1,19 +1,10 @@
 ﻿@namespace MudBlazor
 @using MudBlazor.Extensions
+
 @*this is the element where the popover will be anchored*@
-@if (!_hasBeenRendered)
-{
-    <div class=@AnchorClass data-id=@Item.Id style=@AnchorStyle @ref=@_anchorRef>
-        <div class=@PopoverClass @ref=@_fragmentRef >
-            @Item.Fragment
-        </div>
-    </div>
-}
-else
-{
-    <div  style=@FragmentStyle>
-       
-        @Item.Fragment
-        
-    </div>
-}
+<div style=@AnchorStyle class="portal-anchor">
+    @Item.Fragment
+</div>
+
+   
+ 

--- a/src/MudBlazor/Components/Portal/MudPortalItem.razor.cs
+++ b/src/MudBlazor/Components/Portal/MudPortalItem.razor.cs
@@ -1,0 +1,62 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using MudBlazor.Extensions;
+using MudBlazor.Interop;
+using MudBlazor.Services;
+using MudBlazor.Utilities;
+
+namespace MudBlazor
+{
+    public partial class MudPortalItem
+    {
+        private ElementReference _fragmentReference;
+        private BoundingClientRect _fragmentRect;
+        private string _right, _left;
+
+       
+
+        private string Style => new StyleBuilder()
+            .AddStyle("left", _left, _left.IsNonEmpty())
+            .AddStyle("right", _right, _right.IsNonEmpty())
+            .AddStyle("bottom", (-(_fragmentRect?.Height + 10)).ToPixels())
+            .AddStyle("height", "max-content")
+            .AddStyle("width", "max-content")
+            .AddStyle("position", "absolute", Item.PortalType == typeof(MudTooltip))
+            .Build();
+
+        [Parameter] public RenderFragment ChildContent { get; set; }
+
+        [Parameter] public PortalItem Item { get; set; }
+
+
+        [Inject] public IBrowserWindowSizeProvider ViewPort { get; set; }
+
+        public void Update() => StateHasChanged();              
+
+        protected override async Task OnAfterRenderAsync(bool firstRender)
+        {
+
+            var size = await ViewPort.GetBrowserWindowSize();
+            if (size.Width > 0) return;
+            if (_fragmentRect == null)
+            {
+                _fragmentRect = await _fragmentReference.MudGetBoundingClientRectAsync();
+                StateHasChanged();
+            }
+
+            if (Item.Placement == Placement.Bottom || Item.Placement == Placement.Top)
+            {
+                _left = (Item.ClientRect?.Width / 2 - _fragmentRect?.Width / 2).ToPixels();
+
+            }
+
+            if (_fragmentRect?.Right > size.Width)
+            {
+                _right = "0";
+                _left = "unset";
+
+
+            }
+        }
+    }
+}

--- a/src/MudBlazor/Components/Portal/MudPortalItem.razor.cs
+++ b/src/MudBlazor/Components/Portal/MudPortalItem.razor.cs
@@ -45,7 +45,15 @@ namespace MudBlazor
             .AddClass("mud-popover-offset-x", Item.OffsetX)
             .Build();
 
-        
+        private string FragmentStyle =>
+            new StyleBuilder()
+            
+            .AddStyle("position", "absolute")
+            .AddStyle("top", Item.FragmentRect?.AbsoluteTop.ToPixels())
+            .AddStyle("left", Item.FragmentRect?.AbsoluteLeft.ToPixels())
+            .AddStyle("height", Item.FragmentRect?.Height.ToPixels())
+            .AddStyle("width", Item.AnchorRect?.Width.ToPixels())            
+            .Build();
 
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {

--- a/src/MudBlazor/Components/Portal/MudPortalItem.razor.cs
+++ b/src/MudBlazor/Components/Portal/MudPortalItem.razor.cs
@@ -39,27 +39,21 @@ namespace MudBlazor
 
         private string FragmentClass =>
             new CssBuilder("portal-fragment")
-            .AddClass($"mud-popover-{Item.Direction.ToDescriptionString()}")
             .AddClass("portal-fragment-hidden", !_hasBeenRendered)
+            .AddClass($"mud-popover-{Item.Direction.ToDescriptionString()}")
+            .AddClass("mud-popover-offset-y", Item.OffsetY)
+            .AddClass("mud-popover-offset-x", Item.OffsetX)
             .Build();
 
-        private void SetDirection()
-        {
-            //nom funciona porque fragment rect height =0 quando position fixed
-            if (Item.FragmentRect.IsOutOfViewPort)
-            {
-                if (Item.Direction == Direction.Bottom) Item.AnchorRect.Top -= Item.FragmentRect.Height;
-                if (Item.Direction == Direction.Top) Item.AnchorRect.Top += Item.FragmentRect.Height;
-            }
-        }
+        
 
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
             if (firstRender)
             {
                 Item.FragmentRect = await _fragmentRef.MudGetBoundingClientRectAsync();
-                //SetDirection();
-                _hasBeenRendered = false;
+                Item.FragmentRect.SetRectInsideViewPort();
+                _hasBeenRendered = true;
                 StateHasChanged();
             }
         }

--- a/src/MudBlazor/Components/Portal/MudPortalItem.razor.cs
+++ b/src/MudBlazor/Components/Portal/MudPortalItem.razor.cs
@@ -9,89 +9,17 @@ namespace MudBlazor
 {
     public partial class MudPortalItem
     {
-        private bool _hasBeenRendered;
-        private ElementReference _fragmentRef;
-        private ElementReference _anchorRef;
         [Parameter] public RenderFragment ChildContent { get; set; }
 
         [Parameter] public PortalItem Item { get; set; }
 
-        public void Update() => StateHasChanged();
-
-        protected override bool ShouldRender()
-        {
-            return base.ShouldRender();
-        }
-        private string AnchorClass =>
-            new CssBuilder("portal-anchor")
-            .AddClass("portal-anchor-hidden", !_hasBeenRendered)
-            .Build();
-
-        private string PopoverAnchorStyle =>
+        private string  AnchorStyle =>
             new StyleBuilder()
-            .AddStyle("top", Item.AnchorRect?.AbsoluteTop.ToPixels())
-            .AddStyle("left", Item.AnchorRect?.AbsoluteLeft.ToPixels())
-            .AddStyle("height", Item.AnchorRect?.Height.ToPixels())
-            .AddStyle("width", Item.AnchorRect?.Width.ToPixels())
+            .AddStyle("top", Item.AnchorRect.AbsoluteTop.ToPixels())
+            .AddStyle("left", Item.AnchorRect.AbsoluteLeft.ToPixels())
+            .AddStyle("height", Item.AnchorRect.Height.ToPixels())
+            .AddStyle("width", Item.AnchorRect.Width.ToPixels())
             .AddStyle("z-index", new ZIndex().Popover.ToString(), Item.Position == "fixed")
             .Build();
-
-        private string TooltipAnchorStyle=>
-            new StyleBuilder()
-            .AddStyle("top", (Item.AnchorRect?.AbsoluteBottom).ToPixels())
-            .AddStyle("left", Item.AnchorRect?.AbsoluteLeft.ToPixels())
-            .AddStyle("z-index", new ZIndex().Popover.ToString(), Item.Position == "fixed")
-            .Build();
-
-        private string PopoverClass =>
-            new CssBuilder("portal-fragment")
-            .AddClass("portal-fragment-hidden", !_hasBeenRendered)
-            .AddClass($"mud-popover-{Item.Direction.ToDescriptionString()}")
-            .AddClass("mud-popover-offset-y", Item.OffsetY)
-            .AddClass("mud-popover-offset-x", Item.OffsetX)
-            .Build();
-
-        private string PopoverStyle =>
-            new StyleBuilder()
-            .AddStyle("position", "absolute")
-            .AddStyle("top", Item.FragmentRect?.AbsoluteTop.ToPixels())
-            .AddStyle("left", Item.FragmentRect?.AbsoluteLeft.ToPixels())
-            .AddStyle("height", Item.FragmentRect?.Height.ToPixels())
-            .AddStyle("width", Item.AnchorRect?.Width.ToPixels())
-            .Build();
-
-        private string TooltipStyle => new StyleBuilder()
-            .AddStyle("position", "absolute")
-            .AddStyle("top", Item.FragmentRect?.AbsoluteTop.ToPixels())
-            .AddStyle("left", Item.FragmentRect?.AbsoluteLeft.ToPixels())
-            .AddStyle("transform", $"translate({(Item.AnchorRect.Width / 2 - Item.FragmentRect.Width / 2).ToPixels()}, 10px)", Item.Placement==Placement.Bottom)
-            .AddStyle("transform", $"translate({(Item.AnchorRect.Width / 2 - Item.FragmentRect.Width / 2).ToPixels()}, -{(Item.AnchorRect.Height +10 + Item.FragmentRect.Height).ToPixels()})", Item.Placement==Placement.Top)
-            .AddStyle("transform", $"translate({(Item.AnchorRect.Width+10).ToPixels()}, -{(Item.AnchorRect.Height/2 + Item.FragmentRect.Height/2).ToPixels()})", Item.Placement==Placement.End)
-            .AddStyle("transform", $"translate(-{(Item.FragmentRect.Width+10).ToPixels()}, -{(Item.AnchorRect.Height / 2 + Item.FragmentRect.Height / 2).ToPixels()})", Item.Placement == Placement.Start)
-            .Build()
-            ;
-
-       
-
-        private string AnchorStyle =>
-          Item.PortalType == typeof(MudTooltip)
-              ? TooltipAnchorStyle
-              : PopoverAnchorStyle;
-
-        private string FragmentStyle =>
-            Item.PortalType == typeof(MudTooltip)
-                ? TooltipStyle
-                : PopoverStyle;
-       
-        protected override async Task OnAfterRenderAsync(bool firstRender)
-        {
-            if (firstRender)
-            {
-                Item.FragmentRect = await _fragmentRef.MudGetBoundingClientRectAsync();
-                 Item.FragmentRect.SetRectInsideViewPort();
-                _hasBeenRendered = true;
-                StateHasChanged();
-            }
-        }
     }
 }

--- a/src/MudBlazor/Components/Portal/MudPortalItem.razor.cs
+++ b/src/MudBlazor/Components/Portal/MudPortalItem.razor.cs
@@ -27,9 +27,8 @@ namespace MudBlazor
             .AddClass("portal-anchor-hidden", !_hasBeenRendered)
             .Build();
 
-        private string AnchorStyle =>
+        private string PopoverAnchorStyle =>
             new StyleBuilder()
-            .AddStyle("position", Item.Position, _hasBeenRendered)
             .AddStyle("top", Item.AnchorRect?.AbsoluteTop.ToPixels())
             .AddStyle("left", Item.AnchorRect?.AbsoluteLeft.ToPixels())
             .AddStyle("height", Item.AnchorRect?.Height.ToPixels())
@@ -37,7 +36,14 @@ namespace MudBlazor
             .AddStyle("z-index", new ZIndex().Popover.ToString(), Item.Position == "fixed")
             .Build();
 
-        private string FragmentClass =>
+        private string TooltipAnchorStyle=>
+            new StyleBuilder()
+            .AddStyle("top", (Item.AnchorRect?.AbsoluteBottom).ToPixels())
+            .AddStyle("left", Item.AnchorRect?.AbsoluteLeft.ToPixels())
+            .AddStyle("z-index", new ZIndex().Popover.ToString(), Item.Position == "fixed")
+            .Build();
+
+        private string PopoverClass =>
             new CssBuilder("portal-fragment")
             .AddClass("portal-fragment-hidden", !_hasBeenRendered)
             .AddClass($"mud-popover-{Item.Direction.ToDescriptionString()}")
@@ -45,22 +51,44 @@ namespace MudBlazor
             .AddClass("mud-popover-offset-x", Item.OffsetX)
             .Build();
 
-        private string FragmentStyle =>
+        private string PopoverStyle =>
             new StyleBuilder()
-            
             .AddStyle("position", "absolute")
             .AddStyle("top", Item.FragmentRect?.AbsoluteTop.ToPixels())
             .AddStyle("left", Item.FragmentRect?.AbsoluteLeft.ToPixels())
             .AddStyle("height", Item.FragmentRect?.Height.ToPixels())
-            .AddStyle("width", Item.AnchorRect?.Width.ToPixels())            
+            .AddStyle("width", Item.AnchorRect?.Width.ToPixels())
             .Build();
 
+        private string TooltipStyle => new StyleBuilder()
+            .AddStyle("position", "absolute")
+            .AddStyle("top", Item.FragmentRect?.AbsoluteTop.ToPixels())
+            .AddStyle("left", Item.FragmentRect?.AbsoluteLeft.ToPixels())
+            .AddStyle("transform", $"translate({(Item.AnchorRect.Width / 2 - Item.FragmentRect.Width / 2).ToPixels()}, 10px)", Item.Placement==Placement.Bottom)
+            .AddStyle("transform", $"translate({(Item.AnchorRect.Width / 2 - Item.FragmentRect.Width / 2).ToPixels()}, -{(Item.AnchorRect.Height +10 + Item.FragmentRect.Height).ToPixels()})", Item.Placement==Placement.Top)
+            .AddStyle("transform", $"translate({(Item.AnchorRect.Width+10).ToPixels()}, -{(Item.AnchorRect.Height/2 + Item.FragmentRect.Height/2).ToPixels()})", Item.Placement==Placement.End)
+            .AddStyle("transform", $"translate(-{(Item.FragmentRect.Width+10).ToPixels()}, -{(Item.AnchorRect.Height / 2 + Item.FragmentRect.Height / 2).ToPixels()})", Item.Placement == Placement.Start)
+            .Build()
+            ;
+
+       
+
+        private string AnchorStyle =>
+          Item.PortalType == typeof(MudTooltip)
+              ? TooltipAnchorStyle
+              : PopoverAnchorStyle;
+
+        private string FragmentStyle =>
+            Item.PortalType == typeof(MudTooltip)
+                ? TooltipStyle
+                : PopoverStyle;
+       
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
             if (firstRender)
             {
                 Item.FragmentRect = await _fragmentRef.MudGetBoundingClientRectAsync();
-                Item.FragmentRect.SetRectInsideViewPort();
+                 Item.FragmentRect.SetRectInsideViewPort();
                 _hasBeenRendered = true;
                 StateHasChanged();
             }

--- a/src/MudBlazor/Components/Portal/MudPortalItem.razor.cs
+++ b/src/MudBlazor/Components/Portal/MudPortalItem.razor.cs
@@ -12,19 +12,23 @@ namespace MudBlazor
         [Parameter] public RenderFragment ChildContent { get; set; }
 
         [Parameter] public PortalItem Item { get; set; }
+        private string AnchorClass =>
+            new CssBuilder("portal-anchor")
+            .AddClass("portal-anchor-hoverable", Item.OpenOnHover)
+            .Build();
 
-        private string  AnchorStyle =>
+        private string AnchorStyle =>
             new StyleBuilder()
-            .AddStyle("top", Item.CssPosition == "fixed" 
-                ? Item.AnchorRect.Top.ToPixels()
-                : Item.AnchorRect.AbsoluteTop.ToPixels())
+            .AddStyle("top", Item.CssPosition == "fixed"
+                ? Item.AnchorRect?.Top.ToPixels()
+                : Item.AnchorRect?.AbsoluteTop.ToPixels())
             .AddStyle("left", Item.CssPosition == "fixed"
-                ? Item.AnchorRect.Left.ToPixels() 
-                : Item.AnchorRect.AbsoluteLeft.ToPixels())
-             .AddStyle("height", Item.AnchorRect.Height.ToPixels())
-            .AddStyle("width", Item.AnchorRect.Width.ToPixels())
+                ? Item.AnchorRect?.Left.ToPixels()
+                : Item.AnchorRect?.AbsoluteLeft.ToPixels())
+             .AddStyle("height", Item.AnchorRect?.Height.ToPixels())
+            .AddStyle("width", Item.AnchorRect?.Width.ToPixels())
             .AddStyle("position", Item.CssPosition)
-            .AddStyle("z-index", new ZIndex().Popover.ToString(), Item.CssPosition == "fixed")
+            .AddStyle("z-index", new ZIndex().Popover.ToString(), Item.CssPosition == "fixed" || Item.OpenOnHover)
             .Build();
     }
 }

--- a/src/MudBlazor/Components/Portal/MudPortalItem.razor.cs
+++ b/src/MudBlazor/Components/Portal/MudPortalItem.razor.cs
@@ -15,11 +15,16 @@ namespace MudBlazor
 
         private string  AnchorStyle =>
             new StyleBuilder()
-            .AddStyle("top", Item.AnchorRect.AbsoluteTop.ToPixels())
-            .AddStyle("left", Item.AnchorRect.AbsoluteLeft.ToPixels())
-            .AddStyle("height", Item.AnchorRect.Height.ToPixels())
+            .AddStyle("top", Item.CssPosition == "fixed" 
+                ? Item.AnchorRect.Top.ToPixels()
+                : Item.AnchorRect.AbsoluteTop.ToPixels())
+            .AddStyle("left", Item.CssPosition == "fixed"
+                ? Item.AnchorRect.Left.ToPixels() 
+                : Item.AnchorRect.AbsoluteLeft.ToPixels())
+             .AddStyle("height", Item.AnchorRect.Height.ToPixels())
             .AddStyle("width", Item.AnchorRect.Width.ToPixels())
-            .AddStyle("z-index", new ZIndex().Popover.ToString(), Item.Position == "fixed")
+            .AddStyle("position", Item.CssPosition)
+            .AddStyle("z-index", new ZIndex().Popover.ToString(), Item.CssPosition == "fixed")
             .Build();
     }
 }

--- a/src/MudBlazor/Components/Portal/MudPortalProvider.razor
+++ b/src/MudBlazor/Components/Portal/MudPortalProvider.razor
@@ -8,9 +8,11 @@
     @foreach (var item in Portal.Items)
     {
         @*this is the element where the popover will be anchored*@
-        <div @key=@item.Key class="portal" data-blazor=@item.Value.Id
+        <div @key=@item.Key class="portal-anchor portal" data-blazor=@item.Value.Id
              style=@GetAnchorStyle(item.Value)>
-            @item.Value.Fragment
+
+             <MudPortalItem @ref=@item.Value.Reference Item="@item.Value" />
+
         </div>
     }
 </div>

--- a/src/MudBlazor/Components/Portal/MudPortalProvider.razor
+++ b/src/MudBlazor/Components/Portal/MudPortalProvider.razor
@@ -8,7 +8,7 @@
     @foreach (var item in Portal.Items)
     {
         @*this is the element where the popover will be anchored*@
-        <div data-blazor="@item.Value.Id"
+        <div class="portal" data-blazor="@item.Value.Id"
              style=@(item.Value.AutoDirection 
                 ? GetAnchorStyle(item.Value)
                 : null)>

--- a/src/MudBlazor/Components/Portal/MudPortalProvider.razor
+++ b/src/MudBlazor/Components/Portal/MudPortalProvider.razor
@@ -1,19 +1,9 @@
-﻿ 
-@namespace MudBlazor  
-@using MudBlazor.Services
- @using System.Globalization
-
+﻿@namespace MudBlazor
 <div id="mud-portal-container">
 
-    @foreach (var item in Portal.Items)
+    @foreach (var (key, item) in Portal.Items)
     {
-        @*this is the element where the popover will be anchored*@
-        <div @key=@item.Key class="portal-anchor portal" data-blazor=@item.Value.Id
-             style=@GetAnchorStyle(item.Value)>
-
-             <MudPortalItem @ref=@item.Value.Reference Item="@item.Value" />
-
-        </div>
+        <MudPortalItem @key=@key Item="@item" />
     }
 </div>
 

--- a/src/MudBlazor/Components/Portal/MudPortalProvider.razor
+++ b/src/MudBlazor/Components/Portal/MudPortalProvider.razor
@@ -3,16 +3,16 @@
 @using MudBlazor.Services
  @using System.Globalization
 
-<div id="mudblazor-portal">
+<div id="mud-portal-container">
 
-@foreach (var item in Portal.Items)
-{
-    <div @ref=@_menuRef data-blazor="@item.Value.Id"
-                        style=@(item.Value.Autopositioned 
-                            ? GetItemStyle(item.Value)
-                            :null)>
-        @item.Value.Fragment
-    </div>
-}
+    @foreach (var item in Portal.Items)
+    {
+        <div @ref=@_menuRef data-blazor="@item.Value.Id"
+                            style=@(item.Value.Autopositioned 
+                                ? GetItemStyle(item.Value)
+                                :null)>
+            @item.Value.Fragment
+        </div>
+    }
 </div>
 

--- a/src/MudBlazor/Components/Portal/MudPortalProvider.razor
+++ b/src/MudBlazor/Components/Portal/MudPortalProvider.razor
@@ -8,10 +8,8 @@
     @foreach (var item in Portal.Items)
     {
         @*this is the element where the popover will be anchored*@
-        <div class="portal" data-blazor="@item.Value.Id"
-             style=@(item.Value.AutoDirection 
-                ? GetAnchorStyle(item.Value)
-                : null)>
+        <div @key=@item.Key class="portal" data-blazor=@item.Value.Id
+             style=@GetAnchorStyle(item.Value)>
             @item.Value.Fragment
         </div>
     }

--- a/src/MudBlazor/Components/Portal/MudPortalProvider.razor
+++ b/src/MudBlazor/Components/Portal/MudPortalProvider.razor
@@ -1,0 +1,18 @@
+﻿ 
+@namespace MudBlazor  
+@using MudBlazor.Services
+ @using System.Globalization
+
+<div id="mudblazor-portal">
+
+@foreach (var item in Portal.Items)
+{
+    <div @ref=@_menuRef data-blazor="@item.Value.Id"
+                        style=@(item.Value.Autopositioned 
+                            ? GetItemStyle(item.Value)
+                            :null)>
+        @item.Value.Fragment
+    </div>
+}
+</div>
+

--- a/src/MudBlazor/Components/Portal/MudPortalProvider.razor
+++ b/src/MudBlazor/Components/Portal/MudPortalProvider.razor
@@ -7,10 +7,11 @@
 
     @foreach (var item in Portal.Items)
     {
-        <div @ref=@_menuRef data-blazor="@item.Value.Id"
-                            style=@(item.Value.Autopositioned 
-                                ? GetItemStyle(item.Value)
-                                :null)>
+        @*this is the element where the popover will be anchored*@
+        <div data-blazor="@item.Value.Id"
+             style=@(item.Value.Autopositioned 
+                ? GetAnchorStyle(item.Value)
+                : null)>
             @item.Value.Fragment
         </div>
     }

--- a/src/MudBlazor/Components/Portal/MudPortalProvider.razor
+++ b/src/MudBlazor/Components/Portal/MudPortalProvider.razor
@@ -9,7 +9,7 @@
     {
         @*this is the element where the popover will be anchored*@
         <div data-blazor="@item.Value.Id"
-             style=@(item.Value.Autopositioned 
+             style=@(item.Value.AutoDirection 
                 ? GetAnchorStyle(item.Value)
                 : null)>
             @item.Value.Fragment

--- a/src/MudBlazor/Components/Portal/MudPortalProvider.razor
+++ b/src/MudBlazor/Components/Portal/MudPortalProvider.razor
@@ -1,5 +1,5 @@
 ﻿@namespace MudBlazor
-<div id="mud-portal-container">
+<div id="mud-portal-container" data-items=@(Portal.Items.Count())>
 
     @foreach (var (key, item) in Portal.Items)
     {

--- a/src/MudBlazor/Components/Portal/MudPortalProvider.razor
+++ b/src/MudBlazor/Components/Portal/MudPortalProvider.razor
@@ -1,5 +1,5 @@
 ﻿@namespace MudBlazor
-<div id="mud-portal-container" data-items=@(Portal.Items.Count())>
+<div id="mud-portal-container" data-items=@(Portal.Items.Count()) >
 
     @foreach (var (key, item) in Portal.Items)
     {

--- a/src/MudBlazor/Components/Portal/MudPortalProvider.razor.cs
+++ b/src/MudBlazor/Components/Portal/MudPortalProvider.razor.cs
@@ -27,14 +27,7 @@ namespace MudBlazor
         protected override void OnInitialized() => Portal.OnChange += Refresh;
 
         void Refresh(object e, EventArgs c) => InvokeAsync(StateHasChanged);
-
-        protected override async Task OnAfterRenderAsync(bool firstRender)
-        {
-            var size = await _portaledItem.MudGetBoundingClientRectAsync();
-            var height = size.Height;
-
-        }
-
+        
         public void Dispose()
         {
             Portal.OnChange -= Refresh;

--- a/src/MudBlazor/Components/Portal/MudPortalProvider.razor.cs
+++ b/src/MudBlazor/Components/Portal/MudPortalProvider.razor.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.Extensions;
 using MudBlazor.Services;
@@ -9,7 +8,7 @@ namespace MudBlazor
 {
     public partial class MudPortalProvider : IDisposable
     {
-        
+
 
         [Inject] internal IPortal Portal { get; set; }
 
@@ -26,8 +25,9 @@ namespace MudBlazor
 
         protected override void OnInitialized() => Portal.OnChange += Refresh;
 
+        //TODO Refresh only individual items
         void Refresh(object e, EventArgs c) => InvokeAsync(StateHasChanged);
-        
+
         public void Dispose()
         {
             Portal.OnChange -= Refresh;

--- a/src/MudBlazor/Components/Portal/MudPortalProvider.razor.cs
+++ b/src/MudBlazor/Components/Portal/MudPortalProvider.razor.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Globalization;
+using Microsoft.AspNetCore.Components;
+using MudBlazor.Services;
+using MudBlazor.Utilities;
+
+namespace MudBlazor
+{
+    public partial class MudPortalProvider : IDisposable
+    {
+
+        ElementReference _menuRef;
+
+        [Inject] public IPortal Portal { get; set; }
+
+
+        private string GetItemStyle(PortalItem item)
+        {
+            string ToString(double? measure) => measure?.ToString(CultureInfo.InvariantCulture) + "px";
+
+            var result = new StyleBuilder()
+                .AddStyle("position", "absolute")
+                .AddStyle("z-index", new ZIndex().Popover.ToString())
+                .AddStyle("width", ToString(item.ClientRect?.Width))
+                .AddStyle("top", ToString(item.ClientRect?.Bottom))
+                .AddStyle("left", ToString(item.ClientRect?.Left))
+
+                .Build();
+            return result;
+        }
+
+        protected override void OnInitialized()
+        {
+            Portal.OnChange += Refresh;
+        }
+
+        void Refresh(object e, EventArgs c)
+        {
+            InvokeAsync(StateHasChanged);
+        }
+
+        public void Dispose()
+        {
+            Portal.OnChange -= Refresh;
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/src/MudBlazor/Components/Portal/MudPortalProvider.razor.cs
+++ b/src/MudBlazor/Components/Portal/MudPortalProvider.razor.cs
@@ -12,11 +12,14 @@ namespace MudBlazor
 
         private string GetAnchorStyle(PortalItem item) =>
             new StyleBuilder()
-                   .AddStyle("position", "absolute")
+                   
+                   .AddStyle("position", item.Position)
                    .AddStyle("top", item.ClientRect?.Top.ToPixels())
                    .AddStyle("left", item.ClientRect?.Left.ToPixels())
                    .AddStyle("height", item.ClientRect?.Height.ToPixels())
                    .AddStyle("width", item.ClientRect?.Width.ToPixels())
+                   .AddStyle("z-index", new ZIndex().Popover.ToString(), item.Position == "fixed")
+
                    .Build();
 
         protected override void OnInitialized() => Portal.OnChange += Refresh;

--- a/src/MudBlazor/Components/Portal/MudPortalProvider.razor.cs
+++ b/src/MudBlazor/Components/Portal/MudPortalProvider.razor.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using System.Globalization;
 using Microsoft.AspNetCore.Components;
+using MudBlazor.Extensions;
 using MudBlazor.Services;
 using MudBlazor.Utilities;
 
@@ -8,37 +8,20 @@ namespace MudBlazor
 {
     public partial class MudPortalProvider : IDisposable
     {
-
-
-
         [Inject] public IPortal Portal { get; set; }
 
+        private string GetAnchorStyle(PortalItem item) =>
+            new StyleBuilder()
+                   .AddStyle("position", "absolute")
+                   .AddStyle("top", item.ClientRect?.Top.ToPixels())
+                   .AddStyle("left", item.ClientRect?.Left.ToPixels())
+                   .AddStyle("height", item.ClientRect?.Height.ToPixels())
+                   .AddStyle("width", item.ClientRect?.Width.ToPixels())
+                   .Build();
 
-        private string GetAnchorStyle(PortalItem item)
-        {
-            static string ToString(double? measure) =>
-                measure?.ToString(CultureInfo.InvariantCulture) + "px";
+        protected override void OnInitialized() => Portal.OnChange += Refresh;
 
-            var result = new StyleBuilder()
-                .AddStyle("position", "absolute")
-                //  .AddStyle("z-index", new ZIndex().Popover.ToString())
-                .AddStyle("width", ToString(item.ClientRect?.Width))
-                .AddStyle("top", ToString(item.ClientRect?.Top))
-                .AddStyle("height", ToString(item.ClientRect?.Height))
-                .AddStyle("left", ToString(item.ClientRect?.Left))
-                .Build();
-            return result;
-        }
-
-        protected override void OnInitialized()
-        {
-            Portal.OnChange += Refresh;
-        }
-
-        void Refresh(object e, EventArgs c)
-        {
-            InvokeAsync(StateHasChanged);
-        }
+        void Refresh(object e, EventArgs c) => InvokeAsync(StateHasChanged);
 
         public void Dispose()
         {

--- a/src/MudBlazor/Components/Portal/MudPortalProvider.razor.cs
+++ b/src/MudBlazor/Components/Portal/MudPortalProvider.razor.cs
@@ -9,23 +9,23 @@ namespace MudBlazor
     public partial class MudPortalProvider : IDisposable
     {
 
-        ElementReference _menuRef;
+
 
         [Inject] public IPortal Portal { get; set; }
 
 
-        private string GetItemStyle(PortalItem item)
+        private string GetAnchorStyle(PortalItem item)
         {
             static string ToString(double? measure) =>
                 measure?.ToString(CultureInfo.InvariantCulture) + "px";
 
             var result = new StyleBuilder()
                 .AddStyle("position", "absolute")
-                .AddStyle("z-index", new ZIndex().Popover.ToString())
+                //  .AddStyle("z-index", new ZIndex().Popover.ToString())
                 .AddStyle("width", ToString(item.ClientRect?.Width))
-                .AddStyle("top", ToString(item.ClientRect.Top))
-                .AddStyle("height", ToString(item.ClientRect.Height))
-                .AddStyle("left", ToString(item.ClientRect?.Left))               
+                .AddStyle("top", ToString(item.ClientRect?.Top))
+                .AddStyle("height", ToString(item.ClientRect?.Height))
+                .AddStyle("left", ToString(item.ClientRect?.Left))
                 .Build();
             return result;
         }

--- a/src/MudBlazor/Components/Portal/MudPortalProvider.razor.cs
+++ b/src/MudBlazor/Components/Portal/MudPortalProvider.razor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.Extensions;
 using MudBlazor.Services;
@@ -8,23 +9,31 @@ namespace MudBlazor
 {
     public partial class MudPortalProvider : IDisposable
     {
-        [Inject] public IPortal Portal { get; set; }
+        
+
+        [Inject] internal IPortal Portal { get; set; }
 
         private string GetAnchorStyle(PortalItem item) =>
             new StyleBuilder()
-                   
+
                    .AddStyle("position", item.Position)
                    .AddStyle("top", item.ClientRect?.Top.ToPixels())
                    .AddStyle("left", item.ClientRect?.Left.ToPixels())
                    .AddStyle("height", item.ClientRect?.Height.ToPixels())
                    .AddStyle("width", item.ClientRect?.Width.ToPixels())
                    .AddStyle("z-index", new ZIndex().Popover.ToString(), item.Position == "fixed")
-
                    .Build();
 
         protected override void OnInitialized() => Portal.OnChange += Refresh;
 
         void Refresh(object e, EventArgs c) => InvokeAsync(StateHasChanged);
+
+        protected override async Task OnAfterRenderAsync(bool firstRender)
+        {
+            var size = await _portaledItem.MudGetBoundingClientRectAsync();
+            var height = size.Height;
+
+        }
 
         public void Dispose()
         {

--- a/src/MudBlazor/Components/Portal/MudPortalProvider.razor.cs
+++ b/src/MudBlazor/Components/Portal/MudPortalProvider.razor.cs
@@ -1,32 +1,17 @@
 ﻿using System;
 using Microsoft.AspNetCore.Components;
-using MudBlazor.Extensions;
 using MudBlazor.Services;
-using MudBlazor.Utilities;
 
 namespace MudBlazor
 {
     public partial class MudPortalProvider : IDisposable
     {
-
-
         [Inject] internal IPortal Portal { get; set; }
-
-        private string GetAnchorStyle(PortalItem item) =>
-            new StyleBuilder()
-
-                   .AddStyle("position", item.Position)
-                   .AddStyle("top", item.ClientRect?.Top.ToPixels())
-                   .AddStyle("left", item.ClientRect?.Left.ToPixels())
-                   .AddStyle("height", item.ClientRect?.Height.ToPixels())
-                   .AddStyle("width", item.ClientRect?.Width.ToPixels())
-                   .AddStyle("z-index", new ZIndex().Popover.ToString(), item.Position == "fixed")
-                   .Build();
 
         protected override void OnInitialized() => Portal.OnChange += Refresh;
 
         //TODO Refresh only individual items
-        void Refresh(object e, EventArgs c) => InvokeAsync(StateHasChanged);
+        private void Refresh(object e, EventArgs c) => InvokeAsync(StateHasChanged);
 
         public void Dispose()
         {

--- a/src/MudBlazor/Components/Portal/MudPortalProvider.razor.cs
+++ b/src/MudBlazor/Components/Portal/MudPortalProvider.razor.cs
@@ -16,15 +16,16 @@ namespace MudBlazor
 
         private string GetItemStyle(PortalItem item)
         {
-            string ToString(double? measure) => measure?.ToString(CultureInfo.InvariantCulture) + "px";
+            static string ToString(double? measure) =>
+                measure?.ToString(CultureInfo.InvariantCulture) + "px";
 
             var result = new StyleBuilder()
                 .AddStyle("position", "absolute")
                 .AddStyle("z-index", new ZIndex().Popover.ToString())
                 .AddStyle("width", ToString(item.ClientRect?.Width))
-                .AddStyle("top", ToString(item.ClientRect?.Bottom))
-                .AddStyle("left", ToString(item.ClientRect?.Left))
-
+                .AddStyle("top", ToString(item.ClientRect.Top))
+                .AddStyle("height", ToString(item.ClientRect.Height))
+                .AddStyle("left", ToString(item.ClientRect?.Left))               
                 .Build();
             return result;
         }

--- a/src/MudBlazor/Components/Portal/MudPortalProvider.razor.cs
+++ b/src/MudBlazor/Components/Portal/MudPortalProvider.razor.cs
@@ -1,12 +1,19 @@
 ﻿using System;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.Services;
+using MudBlazor.Utilities;
 
 namespace MudBlazor
 {
     public partial class MudPortalProvider : IDisposable
     {
         [Inject] internal IPortal Portal { get; set; }
+
+        [CascadingParameter] public bool RightToLeft { get; set; }
+
+        private string ClassName => new CssBuilder()
+            .AddClass("mud-application-layout-rtl", RightToLeft==true)
+            .Build();
 
         protected override void OnInitialized() => Portal.OnChange += Refresh;
 

--- a/src/MudBlazor/Components/Portal/MudPortalProvider.razor.cs
+++ b/src/MudBlazor/Components/Portal/MudPortalProvider.razor.cs
@@ -11,8 +11,14 @@ namespace MudBlazor
         protected override void OnInitialized() => Portal.OnChange += Refresh;
 
         //TODO Refresh only individual items
-        private void Refresh(object e, EventArgs c) => InvokeAsync(StateHasChanged);
-
+        private void Refresh(object e, EventArgs c)
+        {
+            InvokeAsync(StateHasChanged);
+        }
+        protected override void OnAfterRender(bool firstRender)
+        {
+            base.OnAfterRender(firstRender);
+        }
         public void Dispose()
         {
             Portal.OnChange -= Refresh;

--- a/src/MudBlazor/Components/Portal/PortalItem.cs
+++ b/src/MudBlazor/Components/Portal/PortalItem.cs
@@ -10,11 +10,17 @@ namespace MudBlazor.Services
 
         public RenderFragment Fragment { get; set; }
 
-        public BoundingClientRect ClientRect { get; set; }
+        public BoundingClientRect AnchorRect { get; set; }
+
+        public BoundingClientRect FragmentRect { get; set; }
 
         public bool AutoDirection { get; set; }
 
         public string Position { get; set; } = "absolute";
+
+        public int ViewportHeight { get; set; }
+
+        public int ViewportWidth { get; set; }
 
         public Type PortalType { get; set; }
 

--- a/src/MudBlazor/Components/Portal/PortalItem.cs
+++ b/src/MudBlazor/Components/Portal/PortalItem.cs
@@ -16,5 +16,10 @@ namespace MudBlazor.Services
 
         public string Position { get; set; } = "absolute";
 
+        public Type PortalType { get; set; }
+
+        public Placement Placement { get; set; }
+
+        public MudPortalItem Reference { get; set; }
     }
 }

--- a/src/MudBlazor/Components/Portal/PortalItem.cs
+++ b/src/MudBlazor/Components/Portal/PortalItem.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using Microsoft.AspNetCore.Components;
+using MudBlazor.Interop;
+
+namespace MudBlazor.Services
+{
+    public class PortalItem
+    {
+        public Guid Id { get; set; }
+
+        public RenderFragment Fragment { get; set; }
+
+        public BoundingClientRect ClientRect { get; set; }
+
+        public bool AutoDirection { get; set; }
+
+        public string Position { get; set; } = "absolute";
+
+    }
+}

--- a/src/MudBlazor/Components/Portal/PortalItem.cs
+++ b/src/MudBlazor/Components/Portal/PortalItem.cs
@@ -28,6 +28,10 @@ namespace MudBlazor.Services
 
         public Direction Direction { get; set; }
 
+        public bool OffsetX { get; set; }
+
+        public bool OffsetY { get; set; }
+
         public MudPortalItem Reference { get; set; }
     }
 }

--- a/src/MudBlazor/Components/Portal/PortalItem.cs
+++ b/src/MudBlazor/Components/Portal/PortalItem.cs
@@ -26,6 +26,8 @@ namespace MudBlazor.Services
 
         public Placement Placement { get; set; }
 
+        public Direction Direction { get; set; }
+
         public MudPortalItem Reference { get; set; }
     }
 }

--- a/src/MudBlazor/Components/Portal/PortalItem.cs
+++ b/src/MudBlazor/Components/Portal/PortalItem.cs
@@ -14,6 +14,8 @@ namespace MudBlazor.Services
 
         public BoundingClientRect FragmentRect { get; set; }
 
-        public string Position { get; set; } = "absolute";
+        public string CssPosition { get; set; } = "absolute";
+
+        public Type Type { get; set; }
     }
 }

--- a/src/MudBlazor/Components/Portal/PortalItem.cs
+++ b/src/MudBlazor/Components/Portal/PortalItem.cs
@@ -17,5 +17,7 @@ namespace MudBlazor.Services
         public string CssPosition { get; set; } = "absolute";
 
         public Type Type { get; set; }
+
+        public bool OpenOnHover { get; set; }
     }
 }

--- a/src/MudBlazor/Components/Portal/PortalItem.cs
+++ b/src/MudBlazor/Components/Portal/PortalItem.cs
@@ -14,24 +14,6 @@ namespace MudBlazor.Services
 
         public BoundingClientRect FragmentRect { get; set; }
 
-        public bool AutoDirection { get; set; }
-
         public string Position { get; set; } = "absolute";
-
-        public int ViewportHeight { get; set; }
-
-        public int ViewportWidth { get; set; }
-
-        public Type PortalType { get; set; }
-
-        public Placement Placement { get; set; }
-
-        public Direction Direction { get; set; }
-
-        public bool OffsetX { get; set; }
-
-        public bool OffsetY { get; set; }
-
-        public MudPortalItem Reference { get; set; }
     }
 }

--- a/src/MudBlazor/Components/Portal/PortalService.cs
+++ b/src/MudBlazor/Components/Portal/PortalService.cs
@@ -28,7 +28,7 @@ namespace MudBlazor.Services
                 if (item == null)
                     _items.Add(newItem.Id, newItem);
                 else
-                    item.ClientRect = newItem.ClientRect;
+                    item.AnchorRect = newItem.AnchorRect;
             }
             OnChange?.Invoke(this, null);
         }

--- a/src/MudBlazor/Components/Portal/PortalService.cs
+++ b/src/MudBlazor/Components/Portal/PortalService.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Components;
+using MudBlazor.Interop;
+
+namespace MudBlazor.Services
+{
+    public interface IPortal
+    {
+        Dictionary<Guid, PortalItem> Items { get; }
+        PortalItem GetItem(Guid id);
+        void AddOrUpdate(PortalItem item);
+        void Remove(PortalItem item);
+
+        event EventHandler OnChange;
+    }
+    public class Portal : IPortal
+    {
+        private Dictionary<Guid, PortalItem> _items = new();
+
+
+        private readonly object _lockObj = new();
+
+        public event EventHandler OnChange;
+
+        public void AddOrUpdate(PortalItem newItem)
+        {
+            lock (_lockObj)
+            {
+                _items.TryGetValue(newItem.Id, out var item);
+                if (item == null)
+                    _items.Add(newItem.Id, newItem);
+                else
+                    item.ClientRect = newItem.ClientRect;
+            }
+            OnChange?.Invoke(this, null);
+        }
+
+        public PortalItem GetItem(Guid id)
+        {
+            lock (_lockObj)
+            {
+                return _items[id];
+            }
+        }
+
+
+        public Dictionary<Guid, PortalItem> Items
+        {
+            get
+            {
+                lock (_lockObj)
+                {
+                    return _items;
+                }
+            }
+        }
+
+        public void Remove(PortalItem item)
+        {
+            lock (_lockObj)
+            {
+                _items.Remove(item.Id);
+            }
+            OnChange?.Invoke(this, null);
+        }
+    }
+
+
+
+    public class PortalItem
+    {
+
+        public Guid Id { get; set; }
+
+        public RenderFragment Fragment { get; set; }
+
+        public BoundingClientRect ClientRect { get; set; }
+
+        public bool Autopositioned { get; set; }
+
+    }
+}

--- a/src/MudBlazor/Components/Portal/PortalService.cs
+++ b/src/MudBlazor/Components/Portal/PortalService.cs
@@ -16,11 +16,8 @@ namespace MudBlazor.Services
     }
     public class Portal : IPortal
     {
-        private Dictionary<Guid, PortalItem> _items = new();
-
-
+        private readonly Dictionary<Guid, PortalItem> _items = new();
         private readonly object _lockObj = new();
-
         public event EventHandler OnChange;
 
         public void AddOrUpdate(PortalItem newItem)
@@ -66,18 +63,15 @@ namespace MudBlazor.Services
         }
     }
 
-
-
     public class PortalItem
     {
-
         public Guid Id { get; set; }
 
         public RenderFragment Fragment { get; set; }
 
         public BoundingClientRect ClientRect { get; set; }
 
-        public bool Autopositioned { get; set; }
+        public bool AutoDirection { get; set; }
 
     }
 }

--- a/src/MudBlazor/Components/Portal/PortalService.cs
+++ b/src/MudBlazor/Components/Portal/PortalService.cs
@@ -73,5 +73,7 @@ namespace MudBlazor.Services
 
         public bool AutoDirection { get; set; }
 
+        public string Position { get; set; } = "absolute";
+
     }
 }

--- a/src/MudBlazor/Components/Portal/PortalService.cs
+++ b/src/MudBlazor/Components/Portal/PortalService.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using Microsoft.AspNetCore.Components;
-using MudBlazor.Interop;
 
 namespace MudBlazor.Services
 {
-    public interface IPortal
+    internal interface IPortal
     {
         Dictionary<Guid, PortalItem> Items { get; }
         PortalItem GetItem(Guid id);
@@ -14,10 +12,12 @@ namespace MudBlazor.Services
 
         event EventHandler OnChange;
     }
-    public class Portal : IPortal
+    internal class Portal : IPortal, IDisposable
     {
         private readonly Dictionary<Guid, PortalItem> _items = new();
         private readonly object _lockObj = new();
+        private bool _disposedValue;
+
         public event EventHandler OnChange;
 
         public void AddOrUpdate(PortalItem newItem)
@@ -41,7 +41,6 @@ namespace MudBlazor.Services
             }
         }
 
-
         public Dictionary<Guid, PortalItem> Items
         {
             get
@@ -61,19 +60,23 @@ namespace MudBlazor.Services
             }
             OnChange?.Invoke(this, null);
         }
-    }
 
-    public class PortalItem
-    {
-        public Guid Id { get; set; }
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposedValue)
+            {
+                if (disposing)
+                {
+                    _items.Clear();
+                }
+                _disposedValue = true;
+            }
+        }
 
-        public RenderFragment Fragment { get; set; }
-
-        public BoundingClientRect ClientRect { get; set; }
-
-        public bool AutoDirection { get; set; }
-
-        public string Position { get; set; } = "absolute";
-
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
     }
 }

--- a/src/MudBlazor/Components/Portal/PortalService.cs
+++ b/src/MudBlazor/Components/Portal/PortalService.cs
@@ -54,6 +54,7 @@ namespace MudBlazor.Services
 
         public void Remove(PortalItem item)
         {
+            if (_items.Count == 0) return;
             lock (_lockObj)
             {
                 _items.Remove(item.Id);

--- a/src/MudBlazor/Components/Portal/Viewport.cs
+++ b/src/MudBlazor/Components/Portal/Viewport.cs
@@ -1,0 +1,14 @@
+﻿using MudBlazor.Interop;
+
+namespace MudBlazor
+{
+    public static class Viewport
+    {
+        public static bool IsOutOfView(BoundingClientRect rect) =>
+            rect.Bottom > rect.WindowHeight
+            || rect.Top < 0
+            || rect.Left < 0
+            || rect.Right > rect.WindowWidth;
+    }
+}
+

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -10,23 +10,22 @@
                 <MudInput @ref="_elementReference" Variant="@Variant" Value="@(Strict && !IsValueInList ? null : Text)" DisableUnderLine="@DisableUnderLine" Disabled=@Disabled ReadOnly="true"
                           Class="mud-select-input" Error="@Error" AdornmentIcon="@CurrentIcon" Adornment="Adornment.End" AdornmentColor="@AdornmentColor" IconSize="@IconSize" Margin="@Margin"
                           InputType="@(CanRenderValue || (Strict && !IsValueInList) ? InputType.Hidden : InputType.Text)"
-                          Clearable="@Clearable" OnClearButtonClick="@SelectClearButtonClickHandlerAsync"
-                          >
+                          Clearable="@Clearable" OnClearButtonClick="@SelectClearButtonClickHandlerAsync">
                     @if (CanRenderValue)
-                    {
-                        @GetSelectedValuePresenter()
+                        {
+                    @GetSelectedValuePresenter()
                     }
                 </MudInput>
             </InputContent>
         </MudInputControl>
         <MudPortal IsVisible="@_isOpen" IsEnabled="IsPortalEnabled" LockScroll="LockScroll">
-            <CascadingValue Value="@((IMudSelect)this)" IsFixed="true">
-                <MudPopover Open="@_isOpen" MaxHeight="@MaxHeight" Direction="@Direction" OffsetX="@OffsetX" OffsetY="@OffsetY">
+            <MudPopover Open="@_isOpen" MaxHeight="@MaxHeight" Direction="@Direction" OffsetX="@OffsetX" OffsetY="@OffsetY">
+                <CascadingValue Value="@((IMudSelect)this)" IsFixed="true">
                     <MudList Clickable="true" Dense="@Dense">
                         @ChildContent
                     </MudList>
-                </MudPopover>
-            </CascadingValue>
+                </CascadingValue>
+            </MudPopover>
         </MudPortal>
     </div>
 </CascadingValue>

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -19,7 +19,7 @@
                 </MudInput>
             </InputContent>
         </MudInputControl>
-        <MudPortal IsVisible="@_isOpen" >
+        <MudPortal IsVisible="@_isOpen" IsEnabled="IsPortalEnabled" LockScroll="LockScroll">
             <CascadingValue Value="@((IMudSelect)this)" IsFixed="true">
                 <MudPopover Open="@_isOpen" MaxHeight="@MaxHeight" Direction="@Direction" OffsetX="@OffsetX" OffsetY="@OffsetY">
                     <MudList Clickable="true" Dense="@Dense">

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -18,7 +18,6 @@
                 </MudInput>
             </InputContent>
         </MudInputControl>
-        <MudPortal IsVisible="@_isOpen" IsEnabled="IsPortalEnabled" LockScroll="LockScroll">
             <MudPopover Open="@_isOpen" MaxHeight="@MaxHeight" Direction="@Direction" OffsetX="@OffsetX" OffsetY="@OffsetY">
                 <CascadingValue Value="@((IMudSelect)this)" IsFixed="true">
                     <MudList Clickable="true" Dense="@Dense">
@@ -26,7 +25,6 @@
                     </MudList>
                 </CascadingValue>
             </MudPopover>
-        </MudPortal>
     </div>
 </CascadingValue>
 

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -19,13 +19,15 @@
                 </MudInput>
             </InputContent>
         </MudInputControl>
-        <CascadingValue Value="@((IMudSelect)this)" IsFixed="true">
-            <MudPopover Open="@_isOpen" MaxHeight="@MaxHeight" Direction="@Direction" OffsetX="@OffsetX" OffsetY="@OffsetY">
-                <MudList Clickable="true" Dense="@Dense">
-                    @ChildContent
-                </MudList>
-            </MudPopover>
-        </CascadingValue>
+        <MudPortal IsVisible="@_isOpen" >
+            <CascadingValue Value="@((IMudSelect)this)" IsFixed="true">
+                <MudPopover Open="@_isOpen" MaxHeight="@MaxHeight" Direction="@Direction" OffsetX="@OffsetX" OffsetY="@OffsetY">
+                    <MudList Clickable="true" Dense="@Dense">
+                        @ChildContent
+                    </MudList>
+                </MudPopover>
+            </CascadingValue>
+        </MudPortal>
     </div>
 </CascadingValue>
 

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -111,6 +111,10 @@ namespace MudBlazor
             }
         }
 
+        [Parameter] public bool IsPortalEnabled { get; set; } = true;
+
+        [Parameter] public bool LockScroll { get; set; } 
+
         public MudSelect()
         {
             IconSize = Size.Medium;

--- a/src/MudBlazor/Components/Table/MudTableSortLabel.razor
+++ b/src/MudBlazor/Components/Table/MudTableSortLabel.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor
-@typeparam T;
+@typeparam T
 @inherits MudComponentBase
-@implements IDisposable;
+@implements IDisposable
 
 <span  @onclick="ToggleSortDirection" class="@Classname" style="@Style" @attributes="@UserAttributes">
     @if (!AppendIcon)

--- a/src/MudBlazor/Components/ThemeProvider/MudThemeProvider.razor
+++ b/src/MudBlazor/Components/ThemeProvider/MudThemeProvider.razor
@@ -9,3 +9,4 @@
 </style>
 
 @((MarkupString)BuildTheme())
+<MudPortalProvider />

--- a/src/MudBlazor/Components/Tooltip/MudTooltip.razor
+++ b/src/MudBlazor/Components/Tooltip/MudTooltip.razor
@@ -2,18 +2,22 @@
 @inherits MudComponentBase
 
 <div class="@ContainerClass">
+    <div  @onmouseover="()=>IsVisible=true" @onmouseout="()=>IsVisible=false">
     @ChildContent
+    </div>
     @if (!String.IsNullOrEmpty(Text) || TooltipContent != null)
     {
-        <div class="@Classname" style="@GetTimeDelay()">
-            @if (TooltipContent != null)
-            {
-                @TooltipContent
-            }
-            else
-            {
-                @Text
-            }
-        </div>
+        <MudPortal IsVisible=@IsVisible Style="@(GetTimeDelay())">
+            <div class="@Classname" style="@(GetTimeDelay())">
+                    @if (TooltipContent != null)
+                    {
+                        @TooltipContent
+                    }
+                    else
+                    {
+                        @Text
+                    }
+            </div>
+        </MudPortal>
     }
 </div>

--- a/src/MudBlazor/Components/Tooltip/MudTooltip.razor
+++ b/src/MudBlazor/Components/Tooltip/MudTooltip.razor
@@ -2,21 +2,16 @@
 @inherits MudComponentBase
 
 <div  @attributes="UserAttributes" class="@ContainerClass">
-    <div  @onmouseover="@HandleMouseOver" @onmouseout="@HandleMouseOut">
-    @ChildContent
+    <div style="background: red;" @onmouseover="@HandleMouseOver" @onmouseout="@HandleMouseOut">
+        @ChildContent
     </div>
     @if (!String.IsNullOrEmpty(Text) || TooltipContent != null)
     {
-        <MudPortal IsVisible=@IsVisible Style="@(GetTimeDelay())">
-            <div class="@Classname" style="@(GetTimeDelay())">
-                    @if (TooltipContent != null)
-                    {
-                        @TooltipContent
-                    }
-                    else
-                    {
-                        @Text
-                    }
+        <MudPortal IsVisible=@IsVisible>
+            <div @ref=@_tooltipRef class="@Classname" style=@($"{GetTimeDelay()}{Style};")>
+                     
+                        @(TooltipContent!=null ?TooltipContent : Text)
+                    
             </div>
         </MudPortal>
     }

--- a/src/MudBlazor/Components/Tooltip/MudTooltip.razor
+++ b/src/MudBlazor/Components/Tooltip/MudTooltip.razor
@@ -2,17 +2,24 @@
 @inherits MudComponentBase
 
 <div  @attributes="UserAttributes" class="@ContainerClass">
-    <div style="background: red;" @onmouseover="@HandleMouseOver" @onmouseout="@HandleMouseOut">
+    <div  @onmouseenter=@HandleMouseOver @onmouseleave=@HandleMouseOut>
         @ChildContent
     </div>
     @if (!String.IsNullOrEmpty(Text) || TooltipContent != null)
     {
-        <MudPortal IsVisible=@IsVisible>
-            <div @ref=@_tooltipRef class="@Classname" style=@($"{GetTimeDelay()}{Style};")>
-                     
-                        @(TooltipContent!=null ?TooltipContent : Text)
-                    
+        <MudPortal IsVisible=true PortalType=@this.GetType() Placement=@Placement>
+
+            <div class=@Classname data-placement=@Placement @ref=@_tooltipRef style=@Stylename>
+                @if (TooltipContent != null)
+                {
+                    @TooltipContent 
+                }
+                else
+                {
+                    @Text
+                }
             </div>
+
         </MudPortal>
     }
 </div>

--- a/src/MudBlazor/Components/Tooltip/MudTooltip.razor
+++ b/src/MudBlazor/Components/Tooltip/MudTooltip.razor
@@ -7,7 +7,7 @@
     </div>
     @if (!String.IsNullOrEmpty(Text) || TooltipContent != null)
     {
-        <MudPortal IsVisible=true PortalType=@this.GetType() Placement=@Placement>
+        <MudPortal IsVisible=@IsVisible PortalType=@this.GetType() Placement=@Placement>
 
             <div class=@Classname data-placement=@Placement @ref=@_tooltipRef style=@Stylename>
                 @if (TooltipContent != null)

--- a/src/MudBlazor/Components/Tooltip/MudTooltip.razor
+++ b/src/MudBlazor/Components/Tooltip/MudTooltip.razor
@@ -7,7 +7,7 @@
     </div>
     @if (!String.IsNullOrEmpty(Text) || TooltipContent != null)
     {
-        <MudPortal IsVisible=@IsVisible PortalType=@this.GetType() Placement=@Placement>
+        <MudPopover Open=true OffsetY="true" Elevation="0" Style="overflow:visible;background-color:transparent">
 
             <div class=@Classname data-placement=@Placement @ref=@_tooltipRef style=@Stylename>
                 @if (TooltipContent != null)
@@ -20,6 +20,6 @@
                 }
             </div>
 
-        </MudPortal>
+        </MudPopover>
     }
 </div>

--- a/src/MudBlazor/Components/Tooltip/MudTooltip.razor
+++ b/src/MudBlazor/Components/Tooltip/MudTooltip.razor
@@ -1,8 +1,8 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
 
-<div class="@ContainerClass">
-    <div  @onmouseover="()=>IsVisible=true" @onmouseout="()=>IsVisible=false">
+<div  @attributes="UserAttributes" class="@ContainerClass">
+    <div  @onmouseover="@HandleMouseOver" @onmouseout="@HandleMouseOut">
     @ChildContent
     </div>
     @if (!String.IsNullOrEmpty(Text) || TooltipContent != null)

--- a/src/MudBlazor/Components/Tooltip/MudTooltip.razor
+++ b/src/MudBlazor/Components/Tooltip/MudTooltip.razor
@@ -7,7 +7,7 @@
     </div>
     @if (!String.IsNullOrEmpty(Text) || TooltipContent != null)
     {
-        <MudPortal IsVisible=@IsVisible OffsetY="true" Placement=@Placement PortalType=@this.GetType()>
+        <MudPortal Type=@this.GetType() IsVisible=@IsVisible OffsetY="true" Placement=@Placement PortalType=@this.GetType()>
 
             <div class=@Classname data-placement=@Placement @ref=@_tooltipRef style=@Stylename>
                 @if (TooltipContent != null)

--- a/src/MudBlazor/Components/Tooltip/MudTooltip.razor
+++ b/src/MudBlazor/Components/Tooltip/MudTooltip.razor
@@ -7,7 +7,7 @@
     </div>
     @if (!String.IsNullOrEmpty(Text) || TooltipContent != null)
     {
-        <MudPopover Open=true OffsetY="true" Elevation="0" Style="overflow:visible;background-color:transparent">
+        <MudPortal IsVisible=true OffsetY="true" Placement=@Placement PortalType=@this.GetType()>
 
             <div class=@Classname data-placement=@Placement @ref=@_tooltipRef style=@Stylename>
                 @if (TooltipContent != null)
@@ -20,6 +20,6 @@
                 }
             </div>
 
-        </MudPopover>
+        </MudPortal>
     }
 </div>

--- a/src/MudBlazor/Components/Tooltip/MudTooltip.razor
+++ b/src/MudBlazor/Components/Tooltip/MudTooltip.razor
@@ -7,7 +7,7 @@
     </div>
     @if (!String.IsNullOrEmpty(Text) || TooltipContent != null)
     {
-        <MudPortal IsVisible=true OffsetY="true" Placement=@Placement PortalType=@this.GetType()>
+        <MudPortal IsVisible=@IsVisible OffsetY="true" Placement=@Placement PortalType=@this.GetType()>
 
             <div class=@Classname data-placement=@Placement @ref=@_tooltipRef style=@Stylename>
                 @if (TooltipContent != null)

--- a/src/MudBlazor/Components/Tooltip/MudTooltip.razor
+++ b/src/MudBlazor/Components/Tooltip/MudTooltip.razor
@@ -1,13 +1,13 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
 
-<div  @attributes="UserAttributes" class="@ContainerClass">
+<div  @attributes="UserAttributes" class="@ContainerClass" @ref="@_anchorRef">
     <div  @onmouseenter=@HandleMouseOver @onmouseleave=@HandleMouseOut>
         @ChildContent
     </div>
     @if (!String.IsNullOrEmpty(Text) || TooltipContent != null)
     {
-        <MudPortal Type=@this.GetType() IsVisible=@IsVisible OffsetY="true" Placement=@Placement PortalType=@this.GetType()>
+        <MudPortal Type=@this.GetType() IsVisible=@IsVisible AnchorRef="@_anchorRef">
 
             <div class=@Classname  style=@Stylename>
                 @if (TooltipContent != null)
@@ -23,3 +23,4 @@
         </MudPortal>
     }
 </div>
+

--- a/src/MudBlazor/Components/Tooltip/MudTooltip.razor
+++ b/src/MudBlazor/Components/Tooltip/MudTooltip.razor
@@ -9,7 +9,7 @@
     {
         <MudPortal Type=@this.GetType() IsVisible=@IsVisible OffsetY="true" Placement=@Placement PortalType=@this.GetType()>
 
-            <div class=@Classname data-placement=@Placement @ref=@_tooltipRef style=@Stylename>
+            <div class=@Classname  style=@Stylename>
                 @if (TooltipContent != null)
                 {
                     @TooltipContent 

--- a/src/MudBlazor/Components/Tooltip/MudTooltip.razor.cs
+++ b/src/MudBlazor/Components/Tooltip/MudTooltip.razor.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Globalization;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
-using MudBlazor.Extensions;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
@@ -13,10 +11,32 @@ namespace MudBlazor
         protected string ContainerClass => new CssBuilder("mud-tooltip-root")
             .AddClass("mud-tooltip-inline", Inline)
             .Build();
-        protected string Classname => new CssBuilder("mud-tooltip")
-            .AddClass($"mud-tooltip-placement-{Placement.ToDescriptionString()}")
-            .AddClass(Class)
-            .Build();
+        protected string Classname
+        {
+            get
+            {
+                var result = new CssBuilder("mud-tooltip")
+                    //.AddClass($"mud-tooltip-placement-{Placement.ToDescriptionString()}")
+                    .AddClass("mud-tooltip-visible", IsVisible)
+                    .AddClass(Class)
+                    .Build();
+
+                return result;
+            }
+        }
+
+
+        protected string Stylename
+        {
+            get
+            {
+                var result = new StyleBuilder()
+                    .AddStyle($"transition-delay: {Delay.ToString(CultureInfo.InvariantCulture)}ms")
+                    .AddStyle(Style)
+                    .Build();
+                return result;
+            }
+        }
 
         [Inject] public IBrowserWindowSizeProvider WindowSize { get; set; }
 
@@ -62,83 +82,21 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public Boolean Inline { get; set; } = true;
 
-        [Parameter] public bool IsVisible { get; set; }
+        public bool IsVisible { get; set; }
 
-        private void HandleMouseOver()
+        public void HandleMouseOver()
         {
             IsVisible = true;
-            Console.WriteLine("in");
-        }
-
-        private void HandleMouseOut()
-        {
-            IsVisible = false;
-            Console.WriteLine("out");
-        }
-
-        protected string GetTimeDelay()
-        {
-            return $"transition-delay: {Delay.ToString(CultureInfo.InvariantCulture)}ms;";
-        }
-
-        protected override async Task OnAfterRenderAsync(bool firstRender)
-        {
-            await SetDirection();
-        }
-
-        private async Task SetDirection()
-        {
-
-            if (!IsVisible) { return; }
-            if (_tooltipRef.Context == null) { return; }
-            var rect = await _tooltipRef.MudGetBoundingClientRectAsync();
-            if (rect == null) { return; }
-
-
-            Console.WriteLine("render");
-
-            var viewport = await WindowSize.GetBrowserWindowSize();
-            string style = "";
-            var placement = Placement;
-            switch (Placement)
-            {
-                case Placement.Top:
-                case Placement.Bottom:
-                    if (rect.Top < 0 && Placement == Placement.Top)
-                    { placement = Placement.Bottom; }
-                    if (rect.Bottom > viewport.Height && Placement == Placement.Bottom)
-                    { placement = Placement.Top; }
-
-                    if (rect.Right > viewport.Width)
-                    {
-                        style = $"right:{(rect.Right - viewport.Width - 14).ToPixels()};left:unset;";
-                    }
-                    if (rect.Left < 0)
-                    {
-                        style = $"left:14px;right:unset;";
-                    }
-                    break;
-
-
-
-                case Placement.Start:
-                case Placement.End:
-                    if (rect.Left < 0 && Placement == Placement.Start)
-                    { placement = Placement.End; }
-                    if (rect.Right > viewport.Width && Placement == Placement.End)
-                    { placement = Placement.Start; }
-
-
-                    if (rect.Top < 0) { style = $"top:14px;bottom:unset;"; }
-                    if (rect.Bottom > viewport.Height)
-                    { style = $"bottom:{(rect.Bottom - viewport.Height - 14).ToPixels()};top:unset;"; }
-                    break;
-
-            }
-            Style = style;
             StateHasChanged();
         }
+        private void HandleMouseOut() => IsVisible = false;
 
+        protected override void OnAfterRender(bool firstRender)
+        {
+            base.OnAfterRender(firstRender);
+        }
     }
 
 }
+
+

--- a/src/MudBlazor/Components/Tooltip/MudTooltip.razor.cs
+++ b/src/MudBlazor/Components/Tooltip/MudTooltip.razor.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Globalization;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.Extensions;
+using MudBlazor.Interop;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
@@ -15,6 +17,7 @@ namespace MudBlazor
             .AddClass($"mud-tooltip-placement-{Placement.ToDescriptionString()}")
             .AddClass(Class)
             .Build();
+    
 
         /// <summary>
         /// Sets the text to be displayed inside the tooltip.
@@ -57,9 +60,12 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public Boolean Inline { get; set; } = true;
 
+        [Parameter] public bool IsVisible { get; set; }
+
         protected string GetTimeDelay()
         {
-            return $"transition-delay: {Delay.ToString(CultureInfo.InvariantCulture)}ms;{Style}";
+            return $"transition-delay: {Delay.ToString(CultureInfo.InvariantCulture)}ms;{Style};";
         }
+               
     }
 }

--- a/src/MudBlazor/Components/Tooltip/MudTooltip.razor.cs
+++ b/src/MudBlazor/Components/Tooltip/MudTooltip.razor.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Globalization;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.Extensions;
-using MudBlazor.Interop;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
@@ -17,7 +15,7 @@ namespace MudBlazor
             .AddClass($"mud-tooltip-placement-{Placement.ToDescriptionString()}")
             .AddClass(Class)
             .Build();
-    
+
 
         /// <summary>
         /// Sets the text to be displayed inside the tooltip.
@@ -56,16 +54,21 @@ namespace MudBlazor
         [Parameter] public RenderFragment TooltipContent { get; set; }
 
         /// <summary>
-        /// Determines if this component should be inline with it's surrounding (default) or if it should behave like a block element.
+        /// Determines if this component should 
+        /// with it's surrounding (default) or if it should behave like a block element.
         /// </summary>
         [Parameter] public Boolean Inline { get; set; } = true;
 
         [Parameter] public bool IsVisible { get; set; }
 
+        private void HandleMouseOver() => IsVisible = true;
+
+        private void HandleMouseOut() => IsVisible = false;
+
         protected string GetTimeDelay()
         {
             return $"transition-delay: {Delay.ToString(CultureInfo.InvariantCulture)}ms;{Style};";
         }
-               
+
     }
 }

--- a/src/MudBlazor/Components/Tooltip/MudTooltip.razor.cs
+++ b/src/MudBlazor/Components/Tooltip/MudTooltip.razor.cs
@@ -8,7 +8,7 @@ namespace MudBlazor
 {
     public partial class MudTooltip : MudComponentBase
     {
-        private ElementReference _tooltipRef;
+     
         protected string ContainerClass => new CssBuilder("mud-tooltip-root")
             .AddClass("mud-tooltip-inline", Inline)
             .Build();
@@ -38,8 +38,6 @@ namespace MudBlazor
                 return result;
             }
         }
-
-        [Inject] public IBrowserWindowSizeProvider WindowSize { get; set; }
 
         /// <summary>
         /// Sets the text to be displayed inside the tooltip.

--- a/src/MudBlazor/Components/Tooltip/MudTooltip.razor.cs
+++ b/src/MudBlazor/Components/Tooltip/MudTooltip.razor.cs
@@ -17,7 +17,7 @@ namespace MudBlazor
             get
             {
                 var result = new CssBuilder("mud-tooltip")
-                    //.AddClass($"mud-tooltip-placement-{Placement.ToDescriptionString()}")
+                    .AddClass($"mud-tooltip-placement-{Placement.ToDescriptionString()}")
                     .AddClass("mud-tooltip-visible", IsVisible)
                     .AddClass(Class)
                     .Build();

--- a/src/MudBlazor/Components/Tooltip/MudTooltip.razor.cs
+++ b/src/MudBlazor/Components/Tooltip/MudTooltip.razor.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using Microsoft.AspNetCore.Components;
+using MudBlazor.Extensions;
 using MudBlazor.Utilities;
 
 namespace MudBlazor

--- a/src/MudBlazor/Components/Tooltip/MudTooltip.razor.cs
+++ b/src/MudBlazor/Components/Tooltip/MudTooltip.razor.cs
@@ -39,6 +39,9 @@ namespace MudBlazor
             }
         }
 
+        private ElementReference _anchorRef;
+
+
         /// <summary>
         /// Sets the text to be displayed inside the tooltip.
         /// </summary>

--- a/src/MudBlazor/Extensions/ElementReferenceExtensions.cs
+++ b/src/MudBlazor/Extensions/ElementReferenceExtensions.cs
@@ -48,6 +48,17 @@ namespace MudBlazor
         public static ValueTask<BoundingClientRect> MudGetBoundingClientRectAsync(this ElementReference elementReference) =>
             elementReference.GetJSRuntime()?.InvokeAsync<BoundingClientRect>("mudElementRef.getBoundingClientRect", elementReference) ?? ValueTask.FromResult(new BoundingClientRect());
 
+        /// <summary>
+        /// It's like bounding client rect, but gets the client rectangle relative to the window,
+        /// not to the viewport
+        /// </summary>
+        /// <param name="elementReference"></param>
+        public static ValueTask<BoundingClientRect> MudGetRelativeClientRectAsync(this ElementReference elementReference) => elementReference.GetJSRuntime()?
+            .InvokeAsync<BoundingClientRect>("mudElementRef.getRelativeClientRect", elementReference)
+            ?? ValueTask.FromResult(new BoundingClientRect());
+
+
+
         public static ValueTask MudChangeCssVariableAsync(this ElementReference elementReference, string variableName, int value) =>
             elementReference.GetJSRuntime()?.InvokeVoidAsync("mudElementRef.changeCssVariable", elementReference, variableName, value) ?? ValueTask.CompletedTask;
 

--- a/src/MudBlazor/Extensions/ElementReferenceExtensions.cs
+++ b/src/MudBlazor/Extensions/ElementReferenceExtensions.cs
@@ -58,6 +58,14 @@ namespace MudBlazor
             ?? ValueTask.FromResult(new BoundingClientRect());
 
 
+        /// <summary>
+        /// Returns true if the element has an ancestor with style position == "fixed"
+        /// </summary>
+        /// <param name="elementReference"></param>
+        public static ValueTask<bool> MudHasFixedAncestorsAsync(this ElementReference elementReference) => elementReference.GetJSRuntime()?
+            .InvokeAsync<bool>("mudElementRef.hasFixedAncestors", elementReference)
+            ?? ValueTask.FromResult(false);
+
 
         public static ValueTask MudChangeCssVariableAsync(this ElementReference elementReference, string variableName, int value) =>
             elementReference.GetJSRuntime()?.InvokeVoidAsync("mudElementRef.changeCssVariable", elementReference, variableName, value) ?? ValueTask.CompletedTask;

--- a/src/MudBlazor/Extensions/ElementReferenceExtensions.cs
+++ b/src/MudBlazor/Extensions/ElementReferenceExtensions.cs
@@ -48,15 +48,6 @@ namespace MudBlazor
         public static ValueTask<BoundingClientRect> MudGetBoundingClientRectAsync(this ElementReference elementReference) =>
             elementReference.GetJSRuntime()?.InvokeAsync<BoundingClientRect>("mudElementRef.getBoundingClientRect", elementReference) ?? ValueTask.FromResult(new BoundingClientRect());
 
-        /// <summary>
-        /// It's like bounding client rect, but gets the client rectangle relative to the window,
-        /// not to the viewport
-        /// </summary>
-        /// <param name="elementReference"></param>
-        public static ValueTask<BoundingClientRect> MudGetRelativeClientRectAsync(this ElementReference elementReference) => elementReference.GetJSRuntime()?
-            .InvokeAsync<BoundingClientRect>("mudElementRef.getRelativeClientRect", elementReference)
-            ?? ValueTask.FromResult(new BoundingClientRect());
-
 
         /// <summary>
         /// Returns true if the element has an ancestor with style position == "fixed"

--- a/src/MudBlazor/Extensions/ElementReferenceExtensions.cs
+++ b/src/MudBlazor/Extensions/ElementReferenceExtensions.cs
@@ -49,6 +49,10 @@ namespace MudBlazor
             elementReference.GetJSRuntime()?.InvokeAsync<BoundingClientRect>("mudElementRef.getBoundingClientRect", elementReference) ?? ValueTask.FromResult(new BoundingClientRect());
 
 
+        public static ValueTask<BoundingClientRect> MudGetClientRectFromFirstChildAsync(this ElementReference elementReference) =>
+            elementReference.GetJSRuntime()?.InvokeAsync<BoundingClientRect>("mudElementRef.getClientRectFromFirstChild", elementReference) ?? ValueTask.FromResult(new BoundingClientRect());
+
+
         /// <summary>
         /// Returns true if the element has an ancestor with style position == "fixed"
         /// </summary>

--- a/src/MudBlazor/Extensions/NumberExtensions.cs
+++ b/src/MudBlazor/Extensions/NumberExtensions.cs
@@ -1,0 +1,11 @@
+﻿using System.Globalization;
+
+namespace MudBlazor.Extensions
+{
+    internal static class NumberExtensions
+    {
+        internal static string ToPixels(this double? value) => value?.ToString(CultureInfo.InvariantCulture) + "px";
+
+        internal static string ToPixels(this double value) => value.ToString(CultureInfo.InvariantCulture) + "px";
+    }
+}

--- a/src/MudBlazor/Extensions/NumberExtensions.cs
+++ b/src/MudBlazor/Extensions/NumberExtensions.cs
@@ -4,6 +4,11 @@ namespace MudBlazor.Extensions
 {
     internal static class NumberExtensions
     {
+        /// <summary>
+        /// Converts double to string using dot as decimal separator independently of the culture and ads "px"
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         internal static string ToPixels(this double? value) => value?.ToString(CultureInfo.InvariantCulture) + "px";
 
         internal static string ToPixels(this double value) => value.ToString(CultureInfo.InvariantCulture) + "px";

--- a/src/MudBlazor/Extensions/ParameterViewExtensions.cs
+++ b/src/MudBlazor/Extensions/ParameterViewExtensions.cs
@@ -8,5 +8,17 @@ namespace MudBlazor
         {
             return view.TryGetValue<T>(parameterName, out var _);
         }
+
+        public static bool HasChanged<T>(this ParameterView view, T parameter, string parameterName)
+        {
+            view.TryGetValue<T>(parameterName, out var newValue);
+            return !Equals(parameter, newValue);
+        }
+
+        public static T GetValue<T>(this ParameterView view, string parameterName)
+        {
+            var contains = view.TryGetValue<T>(parameterName, out var value);
+            return contains ? value : default(T);
+        }
     }
 }

--- a/src/MudBlazor/Interop/BoundingClientRect.cs
+++ b/src/MudBlazor/Interop/BoundingClientRect.cs
@@ -29,11 +29,13 @@ namespace MudBlazor.Interop
 
         public double AbsoluteBottom => Bottom + ScrollY;
 
+        public bool IsOutOfViewPort => 
+            Bottom > WindowHeight
+            || Top < 0
+            || Left < 0
+            || Right > WindowWidth;
 
 
-        
-
-        
     }
 
 }

--- a/src/MudBlazor/Interop/BoundingClientRect.cs
+++ b/src/MudBlazor/Interop/BoundingClientRect.cs
@@ -14,6 +14,26 @@ namespace MudBlazor.Interop
         public double Right { get; set; }
         public double Bottom { get; set; }
         public double Left { get; set; }
+
+        public double WindowHeight { get; set; }
+        public double WindowWidth { get; set; }
+
+        public double ScrollX { get; set; }
+        public double ScrollY { get; set; }
+
+        public double AbsoluteLeft => Left + ScrollX;
+
+        public double AbsoluteTop => Top + ScrollY;
+
+        public double AbsoluteRight => Right + ScrollX;
+
+        public double AbsoluteBottom => Bottom + ScrollY;
+
+
+
+        
+
+        
     }
 
 }

--- a/src/MudBlazor/Interop/BoundingClientRect.cs
+++ b/src/MudBlazor/Interop/BoundingClientRect.cs
@@ -29,14 +29,23 @@ namespace MudBlazor.Interop
 
         public double AbsoluteBottom => Bottom + ScrollY;
 
-        public bool IsOutOfViewPort => 
+        public bool IsOutOfViewPort =>
             Bottom > WindowHeight
             || Top < 0
             || Left < 0
             || Right > WindowWidth;
 
+        public void SetRectInsideViewPort()
+        {
 
+            if (WindowHeight - Bottom < 0) Bottom = 0;
+            if (WindowWidth - Right < 0) Right = 0;
+            if (Top < 0) Top = 0;
+            if (Left < 0) Left = 0;
+
+        }
     }
 
 }
 
+º

--- a/src/MudBlazor/Interop/BoundingClientRect.cs
+++ b/src/MudBlazor/Interop/BoundingClientRect.cs
@@ -37,9 +37,20 @@ namespace MudBlazor.Interop
 
         public void SetRectInsideViewPort()
         {
+            var bottomDiff = WindowHeight - Bottom;
+            if (bottomDiff < 0)
+            {
+                Bottom = WindowHeight ;
+                Top = Bottom - Height;
+            }
+            var rightDiff = WindowWidth - Right;
+            if (rightDiff < 0)
+            {
+                Right = WindowWidth ;
+                Left = Right - Width;
+                
+            }
 
-            if (WindowHeight - Bottom < 0) Bottom = 0;
-            if (WindowWidth - Right < 0) Right = 0;
             if (Top < 0) Top = 0;
             if (Left < 0) Left = 0;
 
@@ -48,4 +59,3 @@ namespace MudBlazor.Interop
 
 }
 
-º

--- a/src/MudBlazor/Interop/BoundingClientRect.cs
+++ b/src/MudBlazor/Interop/BoundingClientRect.cs
@@ -29,30 +29,39 @@ namespace MudBlazor.Interop
 
         public double AbsoluteBottom => Bottom + ScrollY;
 
-        public bool IsOutOfViewPort =>
-            Bottom > WindowHeight
-            || Top < 0
-            || Left < 0
-            || Right > WindowWidth;
+        //check if the rect is outside of the viewport
+        public bool IsOutsideBottom => Bottom > WindowHeight;
+        public bool IsOutsideLeft => Left < 0;
+        public bool IsOutsideTop => Top < 0;
+        public bool IsOutsideRight => Right > WindowWidth;
+
 
         public void SetRectInsideViewPort()
         {
-            var bottomDiff = WindowHeight - Bottom;
-            if (bottomDiff < 0)
+
+            if (IsOutsideBottom)
             {
-                Bottom = WindowHeight ;
-                Top = Bottom - Height;
-            }
-            var rightDiff = WindowWidth - Right;
-            if (rightDiff < 0)
-            {
-                Right = WindowWidth ;
-                Left = Right - Width;
-                
+                Bottom = WindowHeight;
+                Top = Bottom - Height;//top must be corrected
             }
 
-            if (Top < 0) Top = 0;
-            if (Left < 0) Left = 0;
+            if (IsOutsideRight)
+            {
+                Right = WindowWidth;
+                Left = Right - Width; //left must be corrected
+            }
+
+            if (IsOutsideTop)
+            {
+                Top = 0;
+                Bottom = Height;
+            }
+
+            if (IsOutsideLeft)
+            {
+                Left = 0;
+                Right = Width;
+            }
 
         }
     }

--- a/src/MudBlazor/Interop/BoundingClientRect.cs
+++ b/src/MudBlazor/Interop/BoundingClientRect.cs
@@ -31,39 +31,14 @@ namespace MudBlazor.Interop
 
         //check if the rect is outside of the viewport
         public bool IsOutsideBottom => Bottom > WindowHeight;
+
         public bool IsOutsideLeft => Left < 0;
+
         public bool IsOutsideTop => Top < 0;
+
         public bool IsOutsideRight => Right > WindowWidth;
 
 
-        public void SetRectInsideViewPort()
-        {
-
-            if (IsOutsideBottom)
-            {
-                Bottom = WindowHeight;
-                Top = Bottom - Height;//top must be corrected
-            }
-
-            if (IsOutsideRight)
-            {
-                Right = WindowWidth;
-                Left = Right - Width; //left must be corrected
-            }
-
-            if (IsOutsideTop)
-            {
-                Top = 0;
-                Bottom = Height;
-            }
-
-            if (IsOutsideLeft)
-            {
-                Left = 0;
-                Right = Width;
-            }
-
-        }
     }
 
 }

--- a/src/MudBlazor/Interop/EventHandlers.cs
+++ b/src/MudBlazor/Interop/EventHandlers.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+
+namespace MudBlazor
+{
+    /// <summary>
+    /// see https://github.com/dotnet/aspnetcore/issues/13104
+    /// </summary>
+    [EventHandler("onmouseenter", typeof(MouseEventArgs), true, true)]
+    [EventHandler("onmouseleave", typeof(MouseEventArgs), true, true)]
+    public static class EventHandlers
+    {
+
+    }
+}

--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -101,6 +101,7 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="TScripts\combined\" />
+    <Folder Include="wwwroot\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -96,11 +96,11 @@
   <ItemGroup>
     <Content Remove="compilerconfig.json" />
     <Content Remove="excubowebcompiler.json" />
+    <Content Remove="wwwroot\MudBlazor.min.js" />
     <Content Remove="**/*/DoNotRemove.txt" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="TScripts\combined\" />
-    <Folder Include="wwwroot\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MudBlazor/Services/Scroll/ScrollManager.cs
+++ b/src/MudBlazor/Services/Scroll/ScrollManager.cs
@@ -24,8 +24,8 @@ namespace MudBlazor
         ValueTask ScrollToTopAsync(string id, ScrollBehavior scrollBehavior = ScrollBehavior.Auto);
         ValueTask ScrollToYearAsync(string elementId);
         ValueTask ScrollToListItemAsync(string elementId, int increment, bool onEdges);
-        ValueTask LockScrollAsync(string elementId, string cssClass);
-        ValueTask UnlockScrollAsync(string elementId, string cssClass);
+        ValueTask LockScrollAsync(string selector = "body", string cssClass = "scroll-locked");
+        ValueTask UnlockScrollAsync(string selector = "body", string cssClass = "scroll-locked");
     }
 
     public class ScrollManager : IScrollManager
@@ -56,13 +56,13 @@ namespace MudBlazor
         /// <summary>
         /// Scrolls to the coordinates of the element
         /// </summary>
-        /// <param name="id">id of element</param>
+        /// <param name="selector">element selector</param>
         /// <param name="left">x coordinate</param>
         /// <param name="top">y coordinate</param>
         /// <param name="behavior">smooth or auto</param>
         /// <returns></returns>
-        public ValueTask ScrollToAsync(string id, int left, int top, ScrollBehavior behavior) =>
-            _jSRuntime.InvokeVoidAsync("mudScrollManager.scrollTo", id, left, top, behavior.ToDescriptionString());
+        public ValueTask ScrollToAsync(string selector, int left, int top, ScrollBehavior behavior) =>
+            _jSRuntime.InvokeVoidAsync("mudScrollManager.scrollTo", selector, left, top, behavior.ToDescriptionString());
 
         [Obsolete]
         public async Task ScrollTo(int left, int top, ScrollBehavior behavior) =>
@@ -90,11 +90,11 @@ namespace MudBlazor
         public ValueTask ScrollToListItemAsync(string elementId, int increment, bool onEdges) =>
             _jSRuntime.InvokeVoidAsync("mudScrollManager.scrollToListItem", elementId, increment, onEdges);
 
-        public ValueTask LockScrollAsync(string elementId, string cssClass) =>
-            _jSRuntime.InvokeVoidAsync("mudScrollManager.lockScroll", elementId, cssClass);
+        public ValueTask LockScrollAsync(string selector = "body", string cssClass = "scroll-locked") =>
+            _jSRuntime.InvokeVoidAsync("mudScrollManager.lockScroll", selector, cssClass);
 
-        public ValueTask UnlockScrollAsync(string elementId, string cssClass) =>
-            _jSRuntime.InvokeVoidAsync("mudScrollManager.unlockScroll", elementId, cssClass);
+        public ValueTask UnlockScrollAsync(string selector = "body", string cssClass = "scroll-locked") =>
+            _jSRuntime.InvokeVoidAsync("mudScrollManager.unlockScroll", selector, cssClass);
     }
 
     /// <summary>

--- a/src/MudBlazor/Services/ServiceCollectionExtensions.cs
+++ b/src/MudBlazor/Services/ServiceCollectionExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -145,6 +144,16 @@ namespace MudBlazor.Services
         }
 
         /// <summary>
+        ///     Adds a portal
+        /// </summary>
+        /// <param name="services">IServiceCollection</param>
+        public static IServiceCollection AddMudBlazorPortal(this IServiceCollection services)
+        {
+            services.TryAddSingleton<IPortal, Portal>();
+            return services;
+        }
+
+        /// <summary>
         /// Adds JsApi as a transient instance.
         /// </summary>
         /// <param name="services">IServiceCollection</param>
@@ -172,7 +181,8 @@ namespace MudBlazor.Services
                 .AddMudBlazorResizeObserverFactory()
                 .AddMudBlazorScrollManager()
                 .AddMudBlazorScrollListener()
-                .AddMudBlazorJsApi();
+                .AddMudBlazorJsApi()
+                .AddMudBlazorPortal();
         }
 
         /// <summary>
@@ -195,7 +205,8 @@ namespace MudBlazor.Services
                 .AddMudBlazorResizeObserverFactory()
                 .AddMudBlazorScrollManager()
                 .AddMudBlazorScrollListener()
-                .AddMudBlazorJsApi();
+                .AddMudBlazorJsApi()
+                .AddMudBlazorPortal();
         }
     }
 }

--- a/src/MudBlazor/Services/ServiceCollectionExtensions.cs
+++ b/src/MudBlazor/Services/ServiceCollectionExtensions.cs
@@ -149,7 +149,7 @@ namespace MudBlazor.Services
         /// <param name="services">IServiceCollection</param>
         public static IServiceCollection AddMudBlazorPortal(this IServiceCollection services)
         {
-            services.TryAddSingleton<IPortal, Portal>();
+            services.TryAddScoped<IPortal, Portal>();
             return services;
         }
 

--- a/src/MudBlazor/Styles/MudBlazor.scss
+++ b/src/MudBlazor/Styles/MudBlazor.scss
@@ -66,6 +66,7 @@
 @import 'components/_inputlabel';
 @import 'components/_overlay';
 @import 'components/_treeview';
+@import 'components/_portal.scss';
 
 @import 'utilities/_flex';
 @import 'utilities/_float';

--- a/src/MudBlazor/Styles/components/_popover.scss
+++ b/src/MudBlazor/Styles/components/_popover.scss
@@ -2,13 +2,15 @@
     width: 100%;
     outline: 0;
     z-index: calc(var(--mud-zindex-popover) + 1);
-    display: none;
+    visibility:hidden;
+    opacity:0;
     position: absolute;
     overflow-x: hidden;
     overflow-y: auto;
 
     &.mud-popover-open {
-        display: block;
+        visibility:visible;
+        opacity:1;
         animation: mud-animation-fadein 251ms;
     }
 

--- a/src/MudBlazor/Styles/components/_popover.scss
+++ b/src/MudBlazor/Styles/components/_popover.scss
@@ -13,40 +13,45 @@
         opacity:1;
         animation: mud-animation-fadein 251ms;
     }
+}
 
-    &.mud-popover-top {
-        bottom:0;
-        &.mud-popover-offset-y {
-            bottom: 100%;
-            top:auto;
-        }
+.mud-popover-top {
+    bottom: 0;
+
+    &.mud-popover-offset-y {
+        bottom: 100%;
+        top: auto;
+    }
+}
+
+.mud-popover-bottom {
+    top: 0;
+
+    &.mud-popover-offset-y {
+        top: 100%;
+        bottom: auto;
+    }
+}
+
+.mud-popover-left {
+    left: 0;
+
+    &.mud-popover-offset-x {
+        right: 100%;
+        left: auto;
+    }
+}
+
+.mud-popover-right {
+    right: 0;
+
+    &.mud-popover-offset-x {
+        left: 100%;
+        right: auto;
     }
 
-    &.mud-popover-bottom {
-        top:0;
-        &.mud-popover-offset-y {
-            top: 100%;
-            bottom:auto;
-        }
-    }
-
-    &.mud-popover-left {
-        left:0;
-        &.mud-popover-offset-x {
-            right: 100%;
-            left:auto;
-        }
-    }
-
-    &.mud-popover-right {
-        right:0;
-        &.mud-popover-offset-x {
-            left: 100%;
-            right:auto;
-        }
-        &.mud-popover-offset-y {
-            top: 100%;
-            bottom:auto;
-        }
+    &.mud-popover-offset-y {
+        top: 100%;
+        bottom: auto;
     }
 }

--- a/src/MudBlazor/Styles/components/_portal.scss
+++ b/src/MudBlazor/Styles/components/_portal.scss
@@ -1,6 +1,5 @@
 ﻿.portal{
     pointer-events:none;
-    outline:5px solid red;
     width:100%;
     height:100%;
     top:0;
@@ -16,12 +15,61 @@
     pointer-events: none;
 }
 
-
+.portal-anchor-hidden{
+    /*visibility:hidden;
+    opacity:0;*/
+    overflow:hidden;
+}
+.portal-anchor *{
+    pointer-events:all;
+}
 
 .portal-fragment {
-    outline: 5px solid blue;
-    pointer-events: all;
+    outline: 5px solid blue;   
     width: max-content;
     height: max-content;
- 
+}
+
+
+
+
+.mud-popover-top {
+    bottom: 0;
+
+    &.mud-popover-offset-y {
+        bottom: 100%;
+        top: auto;
+    }
+}
+
+.mud-popover-bottom {
+    top: 0;
+
+    &.mud-popover-offset-y {
+        top: 100%;
+        bottom: auto;
+    }
+}
+
+.mud-popover-left {
+    left: 0;
+
+    &.mud-popover-offset-x {
+        right: 100%;
+        left: auto;
+    }
+}
+
+.mud-popover-right {
+    right: 0;
+
+    &.mud-popover-offset-x {
+        left: 100%;
+        right: auto;
+    }
+
+    &.mud-popover-offset-y {
+        top: 100%;
+        bottom: auto;
+    }
 }

--- a/src/MudBlazor/Styles/components/_portal.scss
+++ b/src/MudBlazor/Styles/components/_portal.scss
@@ -1,6 +1,27 @@
 ﻿.portal{
     pointer-events:none;
+    outline:5px solid red;
+    width:100%;
+    height:100%;
+    top:0;
+    left:0;
+    position:absolute;
 }
-.portal>*{
-    pointer-events:all;
+
+
+.portal-anchor {
+    outline: 5px solid green;   
+    position: absolute;
+    z-index: 11111;
+    pointer-events: none;
+}
+
+
+
+.portal-fragment {
+    outline: 5px solid blue;
+    pointer-events: all;
+    width: max-content;
+    height: max-content;
+ 
 }

--- a/src/MudBlazor/Styles/components/_portal.scss
+++ b/src/MudBlazor/Styles/components/_portal.scss
@@ -16,8 +16,8 @@
 }
 
 .portal-anchor-hidden{
-    /*visibility:hidden;
-    opacity:0;*/
+    visibility:hidden;
+    opacity:0;
     overflow:hidden;
 }
 .portal-anchor *{
@@ -26,50 +26,17 @@
 
 .portal-fragment {
     outline: 5px solid blue;   
+    width: 100%;    
+    position:absolute;
+}
+
+.portal-fragment-hidden {
     width: max-content;
     height: max-content;
-}
-
-
-
-
-.mud-popover-top {
-    bottom: 0;
-
-    &.mud-popover-offset-y {
-        bottom: 100%;
-        top: auto;
+    &>*{
+        position:relative;
     }
 }
 
-.mud-popover-bottom {
-    top: 0;
 
-    &.mud-popover-offset-y {
-        top: 100%;
-        bottom: auto;
-    }
-}
 
-.mud-popover-left {
-    left: 0;
-
-    &.mud-popover-offset-x {
-        right: 100%;
-        left: auto;
-    }
-}
-
-.mud-popover-right {
-    right: 0;
-
-    &.mud-popover-offset-x {
-        left: 100%;
-        right: auto;
-    }
-
-    &.mud-popover-offset-y {
-        top: 100%;
-        bottom: auto;
-    }
-}

--- a/src/MudBlazor/Styles/components/_portal.scss
+++ b/src/MudBlazor/Styles/components/_portal.scss
@@ -1,0 +1,6 @@
+﻿.portal{
+    pointer-events:none;
+}
+.portal>*{
+    pointer-events:all;
+}

--- a/src/MudBlazor/Styles/components/_portal.scss
+++ b/src/MudBlazor/Styles/components/_portal.scss
@@ -31,6 +31,7 @@
 }
 
 .portal-fragment-hidden {
+    outline: 5px solid red;
     width: max-content;
     height: max-content;
     &>*{

--- a/src/MudBlazor/Styles/components/_portal.scss
+++ b/src/MudBlazor/Styles/components/_portal.scss
@@ -5,30 +5,16 @@
     top: 0;
     left: 0;
     position: absolute;
-    outline: 5px solid blue;
-   /* visibility:hidden;
+    visibility:hidden;
     opacity:0;
-    overflow:hidden;*/
-
-    /*this is the popover*/
-    & * {
-        background: red !important;
-        visibility: visible !important;
-        opacity: 1 !important;
-    }
+    overflow:hidden;
 }
 
 .portal-anchor {
-    outline: 5px solid green;
     position: absolute;
-    z-index: 11111;
     pointer-events: none;
 
     & * {
         pointer-events: all;
     }
 }
-
-
-
-

--- a/src/MudBlazor/Styles/components/_portal.scss
+++ b/src/MudBlazor/Styles/components/_portal.scss
@@ -12,9 +12,15 @@
 
 .portal-anchor {
     position: absolute;
-    pointer-events: none;
 
     & * {
         pointer-events: all;
     }
+}
+.portal-anchor-hoverable:hover>.mud-popover{
+    visibility:visible;
+    opacity:1;
+    z-index: var(--mud-zindex-popover);
+    pointer-events:all;
+   
 }

--- a/src/MudBlazor/Styles/components/_portal.scss
+++ b/src/MudBlazor/Styles/components/_portal.scss
@@ -12,6 +12,7 @@
 
 .portal-anchor {
     position: absolute;
+    pointer-events:none;
 
     & * {
         pointer-events: all;

--- a/src/MudBlazor/Styles/components/_portal.scss
+++ b/src/MudBlazor/Styles/components/_portal.scss
@@ -6,9 +6,9 @@
     left: 0;
     position: absolute;
     outline: 5px solid blue;
-    visibility:hidden;
+   /* visibility:hidden;
     opacity:0;
-    overflow:hidden;
+    overflow:hidden;*/
 
     /*this is the popover*/
     & * {

--- a/src/MudBlazor/Styles/components/_portal.scss
+++ b/src/MudBlazor/Styles/components/_portal.scss
@@ -1,43 +1,34 @@
-﻿.portal{
-    pointer-events:none;
-    width:100%;
-    height:100%;
-    top:0;
-    left:0;
-    position:absolute;
-}
-
-
-.portal-anchor {
-    outline: 5px solid green;   
-    position: absolute;
-    z-index: 11111;
+﻿.portal {
     pointer-events: none;
-}
-
-.portal-anchor-hidden{
+    width: 100%;
+    height: 100%;
+    top: 0;
+    left: 0;
+    position: absolute;
+    outline: 5px solid blue;
     visibility:hidden;
     opacity:0;
     overflow:hidden;
-}
-.portal-anchor *{
-    pointer-events:all;
-}
 
-.portal-fragment {
-    outline: 5px solid blue;   
-    width: 100%;    
-    position:absolute;
-}
-
-.portal-fragment-hidden {
-    outline: 5px solid red;
-    width: max-content;
-    height: max-content;
-    &>*{
-        position:relative;
+    /*this is the popover*/
+    & * {
+        background: red !important;
+        visibility: visible !important;
+        opacity: 1 !important;
     }
 }
+
+.portal-anchor {
+    outline: 5px solid green;
+    position: absolute;
+    z-index: 11111;
+    pointer-events: none;
+
+    & * {
+        pointer-events: all;
+    }
+}
+
 
 
 

--- a/src/MudBlazor/Styles/components/_tooltip.scss
+++ b/src/MudBlazor/Styles/components/_tooltip.scss
@@ -6,7 +6,7 @@
         display: inline-block;
     }
 
-    }
+}
 .mud-tooltip {
     color: var(--mud-palette-dark-text);
     padding: 4px 8px;
@@ -45,6 +45,3 @@
         transform: translateX(calc(100% + 10px));
     }
 }
-
-    
-

--- a/src/MudBlazor/Styles/components/_tooltip.scss
+++ b/src/MudBlazor/Styles/components/_tooltip.scss
@@ -17,9 +17,11 @@
     width: max-content;
     background-color: var(--mud-palette-grey-darker);
     border-radius: var(--mud-default-borderradius);
-    position: absolute;
+    position: relative;
     z-index: var(--mud-zindex-tooltip);
     transition: opacity .2s;
+    visibility:hidden;
+    opacity:0;
 
     &.mud-tooltip-placement-top {
         top: 0;
@@ -43,5 +45,9 @@
         top: 0;
         right: 0;
         transform: translateX(calc(100% + 10px));
+    }
+    &.mud-tooltip-visible{
+        visibility:visible;
+        opacity:1;
     }
 }

--- a/src/MudBlazor/Styles/components/_tooltip.scss
+++ b/src/MudBlazor/Styles/components/_tooltip.scss
@@ -6,49 +6,45 @@
         display: inline-block;
     }
 
-    & .mud-tooltip {
-        color: var(--mud-palette-dark-text);
-        padding: 4px 8px;
-        text-align: center;
-        font-weight: 500;
-        font-size: 12px;
-        line-height: 1.4em;
-        width: max-content;
-        background-color: var(--mud-palette-grey-darker);
-        border-radius: var(--mud-default-borderradius);
-        position: absolute;
-        z-index: var(--mud-zindex-tooltip);
-        visibility: hidden;
-        opacity: 0;
-        transition: opacity .2s;
+    }
+.mud-tooltip {
+    color: var(--mud-palette-dark-text);
+    padding: 4px 8px;
+    text-align: center;
+    font-weight: 500;
+    font-size: 12px;
+    line-height: 1.4em;
+    width: max-content;
+    background-color: var(--mud-palette-grey-darker);
+    border-radius: var(--mud-default-borderradius);
+    position: absolute;
+    z-index: var(--mud-zindex-tooltip);
+    transition: opacity .2s;
 
-        &.mud-tooltip-placement-top {
-            top: 0;
-            left: 50%;
-            transform: translate(-50%, calc(-100% - 10px));
-        }
-
-        &.mud-tooltip-placement-bottom {
-            bottom: 0;
-            left: 50%;
-            transform: translate(-50%, calc(100% + 10px));
-        }
-
-        &.mud-tooltip-placement-start {
-            top: 0;
-            left: 0;
-            transform: translateX(calc(-100% - 10px));
-        }
-
-        &.mud-tooltip-placement-end {
-            top: 0;
-            right: 0;
-            transform: translateX(calc(100% + 10px));
-        }
+    &.mud-tooltip-placement-top {
+        top: 0;
+        left: 50%;
+        transform: translate(-50%, calc(-100% - 10px));
     }
 
-    &:hover .mud-tooltip {
-        visibility: visible;
-        opacity: 1;
+    &.mud-tooltip-placement-bottom {
+        bottom: 0;
+        left: 50%;
+        transform: translate(-50%, calc(100% + 10px));
+    }
+
+    &.mud-tooltip-placement-start {
+        top: 0;
+        left: 0;
+        transform: translateX(calc(-100% - 10px));
+    }
+
+    &.mud-tooltip-placement-end {
+        top: 0;
+        right: 0;
+        transform: translateX(calc(100% + 10px));
     }
 }
+
+    
+

--- a/src/MudBlazor/Styles/components/_tooltip.scss
+++ b/src/MudBlazor/Styles/components/_tooltip.scss
@@ -17,11 +17,12 @@
     width: max-content;
     background-color: var(--mud-palette-grey-darker);
     border-radius: var(--mud-default-borderradius);
-    position: relative;
+    position: absolute;
     z-index: var(--mud-zindex-tooltip);
     transition: opacity .2s;
-    visibility: hidden;
-    opacity: 0;
+    border:none;
+    /*visibility: hidden;
+    opacity: 0;*/
 
     &.mud-tooltip-visible {
         visibility: visible;

--- a/src/MudBlazor/Styles/components/_tooltip.scss
+++ b/src/MudBlazor/Styles/components/_tooltip.scss
@@ -20,34 +20,35 @@
     position: relative;
     z-index: var(--mud-zindex-tooltip);
     transition: opacity .2s;
-    visibility:hidden;
-    opacity:0;
+    visibility: hidden;
+    opacity: 0;
 
-    &.mud-tooltip-placement-top {
-        top: 0;
-        left: 50%;
-        transform: translate(-50%, calc(-100% - 10px));
-    }
-
-    &.mud-tooltip-placement-bottom {
-        bottom: 0;
-        left: 50%;
-        transform: translate(-50%, calc(100% + 10px));
-    }
-
-    &.mud-tooltip-placement-start {
-        top: 0;
-        left: 0;
-        transform: translateX(calc(-100% - 10px));
-    }
-
-    &.mud-tooltip-placement-end {
-        top: 0;
-        right: 0;
-        transform: translateX(calc(100% + 10px));
-    }
-    &.mud-tooltip-visible{
-        visibility:visible;
-        opacity:1;
+    &.mud-tooltip-visible {
+        visibility: visible;
+        opacity: 1;
     }
 }
+.mud-tooltip-placement-top {
+    top: 0;
+    left: 50%;
+    transform: translate(-50%, calc(-100% - 10px));
+}
+
+.mud-tooltip-placement-bottom {
+    bottom: 0;
+    left: 50%;
+    transform: translate(-50%, calc(100% + 10px));
+}
+
+.mud-tooltip-placement-start {
+    top: 0;
+    left: 0;
+    transform: translateX(calc(-100% - 10px));
+}
+
+.mud-tooltip-placement-end {
+    top: 0;
+    right: 0;
+    transform: translateX(calc(100% + 10px));
+}
+

--- a/src/MudBlazor/TScripts/mudElementReference.js
+++ b/src/MudBlazor/TScripts/mudElementReference.js
@@ -96,7 +96,6 @@
         if (!element) {
             return null;
         }
-
         var absoluteRect = element.getBoundingClientRect();
         let relativeRect = {};
 
@@ -116,6 +115,18 @@
         return relativeRect;
 
     }
+
+    /**
+     * Returns true if element has any ancestor with style position==="fixed"
+     * @param {Element} element
+     */
+    hasFixedAncestors(element) {       
+        for (; element && element !== document; element = element.parentNode) {
+            if (window.getComputedStyle(element).getPropertyValue("position") === "fixed")
+                return true;
+        }
+       return false
+    };
 
 
     changeCss (element, css) {

--- a/src/MudBlazor/TScripts/mudElementReference.js
+++ b/src/MudBlazor/TScripts/mudElementReference.js
@@ -79,42 +79,21 @@
     getBoundingClientRect (element) {
         if (element)
         {
-            return element.getBoundingClientRect();
+            var rect = JSON.parse(JSON.stringify(element.getBoundingClientRect()));
+            
+            rect.scrollY = window.scrollY || document.documentElement.scrollTop;
+            rect.scrollX = window.scrollX || document.documentElement.scrollLeft;
+            rect.windowHeight = window.innerHeight;
+            rect.windowWidth = window.innerWidth;
+            
+        
+            return rect;
         }
-        else
-        {
-            return null;
-        }
+        return null;
     }
 
 
-    /**
-     * returns the client rect relative to the window, not to the viewport
-     * @param {HTMLElement} element
-     */
-    getRelativeClientRect(element) {
-        if (!element) {
-            return null;
-        }
-        var absoluteRect = element.getBoundingClientRect();
-        let relativeRect = {};
-
-        var offsetY = window.scrollY || document.documentElement.scrollTop;
-        var offsetX = window.scrollX || document.documentElement.scrollLeft;
-
-        relativeRect.top = absoluteRect.top + offsetY;
-        relativeRect.left = absoluteRect.left + offsetX;
-        relativeRect.bottom = absoluteRect.bottom + offsetY;
-        relativeRect.right = absoluteRect.right + offsetX;
-
-        relativeRect.x = absoluteRect.left;
-        relativeRect.y = absoluteRect.top;
-        relativeRect.height = absoluteRect.height;
-        relativeRect.width = absoluteRect.width;
-
-        return relativeRect;
-
-    }
+    
 
     /**
      * Returns true if element has any ancestor with style position==="fixed"

--- a/src/MudBlazor/TScripts/mudElementReference.js
+++ b/src/MudBlazor/TScripts/mudElementReference.js
@@ -87,6 +87,37 @@
         }
     }
 
+
+    /**
+     * returns the client rect relative to the window, not to the viewport
+     * @param {HTMLElement} element
+     */
+    getRelativeClientRect(element) {
+        if (!element) {
+            return null;
+        }
+
+        var absoluteRect = element.getBoundingClientRect();
+        let relativeRect = {};
+
+        var offsetY = window.scrollY || document.documentElement.scrollTop;
+        var offsetX = window.scrollX || document.documentElement.scrollLeft;
+
+        relativeRect.top = absoluteRect.top + offsetY;
+        relativeRect.left = absoluteRect.left + offsetX;
+        relativeRect.bottom = absoluteRect.bottom + offsetY;
+        relativeRect.right = absoluteRect.right + offsetX;
+
+        relativeRect.x = absoluteRect.left;
+        relativeRect.y = absoluteRect.top;
+        relativeRect.height = absoluteRect.height;
+        relativeRect.width = absoluteRect.width;
+
+        return relativeRect;
+
+    }
+
+
     changeCss (element, css) {
         if (element)
         {

--- a/src/MudBlazor/TScripts/mudElementReference.js
+++ b/src/MudBlazor/TScripts/mudElementReference.js
@@ -75,7 +75,7 @@
             element.select();
         }
     }
-
+    
     getClientRectFromFirstChild(element) {
         if (!element) return;
         let child = element.children && element.children[0];
@@ -83,18 +83,18 @@
     }
 
     getBoundingClientRect (element) {
-        if (element)
-        {
-            var rect = JSON.parse(JSON.stringify(element.getBoundingClientRect()));
-            
-            rect.scrollY = window.scrollY || document.documentElement.scrollTop;
-            rect.scrollX = window.scrollX || document.documentElement.scrollLeft;
+        if (!element) return;      
 
-            rect.windowHeight = window.innerHeight;
-            rect.windowWidth = window.innerWidth;
-            return rect;
-        }
-        return null;
+        var rect = JSON.parse(JSON.stringify(element.getBoundingClientRect()));
+
+        rect.scrollY = window.scrollY || document.documentElement.scrollTop;
+        rect.scrollX = window.scrollX || document.documentElement.scrollLeft;
+
+        rect.windowHeight = window.innerHeight;
+        rect.windowWidth = window.innerWidth;
+        return rect;
+        
+        
     }
 
 

--- a/src/MudBlazor/TScripts/mudElementReference.js
+++ b/src/MudBlazor/TScripts/mudElementReference.js
@@ -77,7 +77,8 @@
     }
 
     getClientRectFromFirstChild(element) {
-        let child = element.children[0];
+        if (!element) return;
+        let child = element.children && element.children[0];
         return this.getBoundingClientRect(child);
     }
 
@@ -88,10 +89,9 @@
             
             rect.scrollY = window.scrollY || document.documentElement.scrollTop;
             rect.scrollX = window.scrollX || document.documentElement.scrollLeft;
+
             rect.windowHeight = window.innerHeight;
             rect.windowWidth = window.innerWidth;
-            
-        
             return rect;
         }
         return null;

--- a/src/MudBlazor/TScripts/mudElementReference.js
+++ b/src/MudBlazor/TScripts/mudElementReference.js
@@ -76,6 +76,11 @@
         }
     }
 
+    getClientRectFromFirstChild(element) {
+        let child = element.children[0];
+        return this.getBoundingClientRect(child);
+    }
+
     getBoundingClientRect (element) {
         if (element)
         {

--- a/src/MudBlazor/TScripts/mudPortal.js
+++ b/src/MudBlazor/TScripts/mudPortal.js
@@ -1,0 +1,6 @@
+﻿function setStylePositionInParent(element, position) {
+    if (!element) return;
+    if (window.getComputedStyle(element.parentElement).position === "static") {
+        element.parentElement.style.position = position;
+    }
+}


### PR DESCRIPTION
Draft of the feature to move elements outside of normal DOM flow.

- [X] Created Portal and all its services
- [X] Integration with Autocomplete
- [x] Integration with Menu
- [x] Integration with Select
- [x] Integration with Tooltips
- [ ] Tests

With this, you're able to move an element outside of its parent to position it in the top level of the app, ie, in Blazor templates, as a child of `#app` element.