### PR TITLE
NumericInput: fix manual input boundaries check

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/NumericField/NumericFieldTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/NumericField/NumericFieldTest.razor
@@ -20,7 +20,8 @@
 				 Step="1.3"
 				 Max="9.9"
 				 Min="-5.0"
-				Format="F3"/>
+				Format="F3"
+				 Immediate="true"/>
 
 <br />
 <MudNumericField @bind-Value="_valueDec"
@@ -28,7 +29,8 @@
 				 Variant="Variant.Outlined"
 				 Step=".3333M"
 				 Max="6.6M"
-				 Min=".2M" />
+				 Min=".2M"
+				 Immediate="true"/>
 
 <br />
 <MudNumericField @bind-Value="_valueDbl"
@@ -36,7 +38,8 @@
 				 Variant="Variant.Filled"
 				 Margin="Margin.Dense"
 				 Max="9.9"
-				 Min="-5.0" />
+				 Min="-5.0" 
+				 Immediate="true"/>
 <br/><br/>
 <MudNumericField @bind-Value="_nullable"
 				 Label="int? max 10"

--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -89,21 +89,22 @@ namespace MudBlazor.UnitTests
             comp.FindAll("div.mud-input-error").Count.Should().Be(0);
         }
 
-        /// <summary>
-        /// Setting an invalid number should show the conversion error message
-        /// </summary>
-        [Test]
-        public async Task NumericFieldConversionError()
-        {
-            var comp = ctx.RenderComponent<MudNumericField<int?>>();
-            // print the generated html
-            //Console.WriteLine(comp.Markup);
-            comp.Find("input").Change("seventeen");
-            comp.Find("input").Blur();
-            Console.WriteLine(comp.Markup);
-            comp.FindAll("p.mud-input-error").Count.Should().Be(1);
-            comp.Find("p.mud-input-error").TextContent.Trim().Should().Be("Not a valid number");
-        }
+        //This doesn't make any sense because you cannot set anything that's not a number
+        ///// <summary>
+        ///// Setting an invalid number should show the conversion error message
+        ///// </summary>
+        //[Test]
+        //public async Task NumericFieldConversionError()
+        //{
+        //    var comp = ctx.RenderComponent<MudNumericField<int?>>();
+        //    // print the generated html
+        //    //Console.WriteLine(comp.Markup);
+        //    comp.Find("input").Change("seventeen");
+        //    comp.Find("input").Blur();
+        //    Console.WriteLine(comp.Markup);
+        //    comp.FindAll("p.mud-input-error").Count.Should().Be(1);
+        //    comp.Find("p.mud-input-error").TextContent.Trim().Should().Be("Not a valid number");
+        //}
 
         /// <summary>
         /// If Debounce Interval is null or 0, Value should change immediately
@@ -272,22 +273,24 @@ namespace MudBlazor.UnitTests
             changed_text.Should().Be("4");
         }
 
-        /// <summary>
-        /// Instead of RequiredError it should show the conversion error, because typing something (even if not a number) should
-        /// already fulfill the requirement of Required="true". If it is a valid value is a different question.
-        /// </summary>
-        /// <returns></returns>
-        [Test]
-        public async Task NumericField_ShouldNot_ShowRequiredErrorWhenThereIsAConversionError()
-        {
-            var comp = ctx.RenderComponent<MudNumericField<int?>>(ComponentParameter.CreateParameter("Required", true));
-            var numericField = comp.Instance;
-            comp.Find("input").Change("A");
-            comp.Find("input").Blur();
-            numericField.Value.Should().BeNull();
-            numericField.HasErrors.Should().Be(true);
-            numericField.ErrorText.Should().Be("Not a valid number");
-        }
+
+        //This doesn't make any sense because you cannot set anything that's not a number
+        ///// <summary>
+        ///// Instead of RequiredError it should show the conversion error, because typing something (even if not a number) should
+        ///// already fulfill the requirement of Required="true". If it is a valid value is a different question.
+        ///// </summary>
+        ///// <returns></returns>
+        //[Test]
+        //public async Task NumericField_ShouldNot_ShowRequiredErrorWhenThereIsAConversionError()
+        //{
+        //    var comp = ctx.RenderComponent<MudNumericField<int?>>(ComponentParameter.CreateParameter("Required", true));
+        //    var numericField = comp.Instance;
+        //    comp.Find("input").Change("A");
+        //    comp.Find("input").Blur();
+        //    numericField.Value.Should().BeNull();
+        //    numericField.HasErrors.Should().Be(true);
+        //    numericField.ErrorText.Should().Be("Not a valid number");
+        //}
 
         /// <summary>
         /// Instead of RequiredError it should show the conversion error, because typing something (even if not a number) should

--- a/src/MudBlazor.UnitTests/Utilities/BindingConverterTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/BindingConverterTests.cs
@@ -529,12 +529,111 @@ namespace MudBlazor.UnitTests.Utilities
         [Test]
         public void NumericBoundariesConverter_FunctionTest()
         {
-            //Note: Set doesn't do anything. The Get can change the value
-            var c1 = new NumericBoundariesConverter<double>((i) => -i) { Culture = CultureInfo.InvariantCulture };
+            var c10 = new NumericBoundariesConverter<sbyte>((i) => (sbyte)-i) { Culture = CultureInfo.InvariantCulture };
+            c10.Set("123").Should().Be("123");
+            c10.Get("123").Should().Be("-123");
+            var c11 = new NumericBoundariesConverter<sbyte?>((i) => (sbyte?)-i) { Culture = CultureInfo.InvariantCulture };
+            c11.Set("123").Should().Be("123");
+            c11.Get("123").Should().Be("-123");
+            c11.Set(null).Should().Be(null);
+            c11.Get(null).Should().Be(null);
+            var c12 = new NumericBoundariesConverter<byte>((i) => (byte)(i - 1)) { Culture = CultureInfo.InvariantCulture };
+            c12.Set("234").Should().Be("234");
+            c12.Get("234").Should().Be("233");
+            var c13 = new NumericBoundariesConverter<byte?>((i) => (byte?)(i - 1)) { Culture = CultureInfo.InvariantCulture };
+            c13.Set("234").Should().Be("234");
+            c13.Get("234").Should().Be("233");
+            c13.Set(null).Should().Be(null);
+            c13.Get(null).Should().Be(null);
+            var c14 = new NumericBoundariesConverter<short>((i) => (short)-i) { Culture = CultureInfo.InvariantCulture };
+            c14.Set("1234").Should().Be("1234");
+            c14.Get("1234").Should().Be("-1234");
+            var c15 = new NumericBoundariesConverter<short?>((i) => (short?)-i) { Culture = CultureInfo.InvariantCulture };
+            c15.Set("1234").Should().Be("1234");
+            c15.Get("1234").Should().Be("-1234");
+            c15.Set(null).Should().Be(null);
+            c15.Get(null).Should().Be(null);
+            var c16 = new NumericBoundariesConverter<ushort>((i) => (ushort)(i - 1)) { Culture = CultureInfo.InvariantCulture };
+            c16.Set("12345").Should().Be("12345");
+            c16.Get("12345").Should().Be("12344");
+            var c17 = new NumericBoundariesConverter<ushort?>((i) => (ushort?)(i - 1)) { Culture = CultureInfo.InvariantCulture };
+            c17.Set("12345").Should().Be("12345");
+            c17.Get("12345").Should().Be("12344");
+            c17.Set(null).Should().Be(null);
+            c17.Get(null).Should().Be(null);
+            var c18 = new NumericBoundariesConverter<int>((i) => -i) { Culture = CultureInfo.InvariantCulture };
+            c18.Set("34567").Should().Be("34567");
+            c18.Get("34567").Should().Be("-34567");
+            var c19 = new NumericBoundariesConverter<int?>((i) => -i) { Culture = CultureInfo.InvariantCulture };
+            c19.Set("34567").Should().Be("34567");
+            c19.Get("34567").Should().Be("-34567");
+            c19.Set(null).Should().Be(null);
+            c19.Get(null).Should().Be(null);
+            var c20 = new NumericBoundariesConverter<uint>((i) => i - 1) { Culture = CultureInfo.InvariantCulture };
+            c20.Set("45678").Should().Be("45678");
+            c20.Get("45678").Should().Be("45677");
+            var c21 = new NumericBoundariesConverter<uint?>((i) => i - 1) { Culture = CultureInfo.InvariantCulture };
+            c21.Set("45678").Should().Be("45678");
+            c21.Get("45678").Should().Be("45677");
+            c21.Set(null).Should().Be(null);
+            c21.Get(null).Should().Be(null);
+            var c22 = new NumericBoundariesConverter<long>((i) => -i) { Culture = CultureInfo.InvariantCulture };
+            c22.Set("456789").Should().Be("456789");
+            c22.Get("456789").Should().Be("-456789");
+            var c23 = new NumericBoundariesConverter<long?>((i) => -i) { Culture = CultureInfo.InvariantCulture };
+            c23.Set("456789").Should().Be("456789");
+            c23.Get("456789").Should().Be("-456789");
+            c23.Set(null).Should().Be(null);
+            c23.Get(null).Should().Be(null);
+            var c24 = new NumericBoundariesConverter<ulong>((i) => i - 1) { Culture = CultureInfo.InvariantCulture };
+            c24.Set("4567890").Should().Be("4567890");
+            c24.Get("4567890").Should().Be("4567889");
+            var c25 = new NumericBoundariesConverter<ulong?>((i) => i - 1) { Culture = CultureInfo.InvariantCulture };
+            c25.Set("4567890").Should().Be("4567890");
+            c25.Get("4567890").Should().Be("4567889");
+            c25.Set(null).Should().Be(null);
+            c25.Get(null).Should().Be(null);
+            var c26 = new NumericBoundariesConverter<float>((i) => -i) { Culture = CultureInfo.InvariantCulture };
+            c26.Set("456789").Should().Be("456789");
+            c26.Get("456789").Should().Be("-456789");
+            var c27 = new NumericBoundariesConverter<float?>((i) => -i) { Culture = CultureInfo.InvariantCulture };
+            c27.Set("45,678.9").Should().Be("45,678.9");
+            c27.Get("45,678.9").Should().Be("-45678.9");
+            c27.Set(null).Should().Be(null);
+            c27.Get(null).Should().Be(null);
+            var c28 = new NumericBoundariesConverter<double>((i) => -i) { Culture = CultureInfo.InvariantCulture };
+            c28.Set("45,678.9").Should().Be("45,678.9");
+            c28.Get("45678.9").Should().Be("-45678.9");
+            var c29 = new NumericBoundariesConverter<double?>((i) => -i) { Culture = CultureInfo.InvariantCulture };
+            c29.Set("45,678.9").Should().Be("45,678.9");
+            c29.Get("45,678.9").Should().Be("-45678.9");
+            c29.Set(null).Should().Be(null);
+            c29.Get(null).Should().Be(null);
+            var c30 = new NumericBoundariesConverter<decimal>((i) => -i) { Culture = CultureInfo.InvariantCulture };
+            c30.Set("45,678.9").Should().Be("45,678.9");
+            c30.Get("45678.9").Should().Be("-45678.9");
+            var c31 = new NumericBoundariesConverter<decimal?>((i) => -i) { Culture = CultureInfo.InvariantCulture };
+            c31.Set("45,678.9").Should().Be("45,678.9");
+            c31.Get("45,678.9").Should().Be("-45678.9");
+            c31.Set(null).Should().Be(null);
+            c31.Get(null).Should().Be(null);
+        }
+
+        [Test]
+        public void NumericBoundariesConverter_FormatTest()
+        {
+            var c1 = new NumericBoundariesConverter<double>((i) => i)
+            {
+                Culture = CultureInfo.InvariantCulture,
+                Format = "F3"
+            };
             c1.Set("1,234,567.15").Should().Be("1,234,567.15");
             c1.GetError.Should().Be(false);
             c1.GetErrorMessage.Should().BeNull();
-            c1.Get("1,234,567.15").Should().Be("-1234567.15");
+            c1.Get("1,234,567.15").Should().Be("1234567.150");
+            c1.GetError.Should().Be(false);
+            c1.GetErrorMessage.Should().BeNull();
+            c1.Get(Math.PI.ToString(c1.Culture)).Should().Be(Math.PI.ToString("F3", c1.Culture));
             c1.GetError.Should().Be(false);
             c1.GetErrorMessage.Should().BeNull();
         }

--- a/src/MudBlazor.UnitTests/Utilities/BindingConverterTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/BindingConverterTests.cs
@@ -444,5 +444,99 @@ namespace MudBlazor.UnitTests.Utilities
             c16.Format = "dd/mm/yy";
             c16.Get(c16.Set(22)).Should().Be(null);
         }
+
+        [Test]
+        public void NumericBoundariesConverterTest()
+        {
+            Func<int, int> functInt = (int i) => i;//Not testing test the function, return the parameter
+            Func<double?, double?> functDbl = (double? d) => d;//Not testing test the function, return the parameter
+
+            //Note: Set doesn't do anything. The Get can change the value
+            var c1 = new NumericBoundariesConverter<int>(functInt);
+            c1.Set("hello").Should().Be("hello");
+            c1.Get("hello").Should().Be(null);
+            c1.GetError.Should().Be(true);
+            c1.GetErrorMessage.Should().Be("Not a valid number");
+            c1.Set("").Should().Be("");
+            c1.Get("").Should().Be(null);
+            c1.GetError.Should().Be(false);
+            c1.GetErrorMessage.Should().BeNull();
+            c1.Get(null).Should().Be(null);
+            c1.Set(null).Should().Be(null);
+            c1.GetError.Should().Be(false);
+            c1.GetErrorMessage.Should().BeNull();
+            c1.Get("0").Should().Be("0");
+            c1.Set("0").Should().Be("0");
+            c1.GetError.Should().Be(false);
+            c1.GetErrorMessage.Should().BeNull();
+            c1.Get("-2").Should().Be("-2");
+            c1.Set("-2").Should().Be("-2");
+            c1.GetError.Should().Be(false);
+            c1.GetErrorMessage.Should().BeNull();
+            c1.Set("1.5").Should().Be("1.5");
+            c1.GetError.Should().Be(false);
+            c1.GetErrorMessage.Should().BeNull();
+            c1.Get("1.5").Should().Be(null);
+            c1.GetError.Should().Be(true);
+            c1.GetErrorMessage.Should().Be("Not a valid number");
+            var c3 = new NumericBoundariesConverter<double?>(functDbl) { Culture = CultureInfo.InvariantCulture };
+            c3.Set("1.7").Should().Be("1.7");
+            c3.Get("1.7").Should().Be("1.7");
+            c3.GetError.Should().Be(false);
+            c3.GetErrorMessage.Should().BeNull();
+            c3.Get("1234567.15").Should().Be("1234567.15");
+            c3.Set("1234567.15").Should().Be("1234567.15");
+            c3.GetError.Should().Be(false);
+            c3.GetErrorMessage.Should().BeNull();
+            c3.Set(c3.Get("1,234,567.15")).Should().Be("1234567.15");
+            c3.GetError.Should().Be(false);
+            c3.GetErrorMessage.Should().BeNull();
+            c3.Get(c3.Set("1,234,567.15")).Should().Be("1234567.15");
+            c3.GetError.Should().Be(false);
+            c3.GetErrorMessage.Should().BeNull();
+            c3.Set(".5").Should().Be(".5");
+            c3.Get(".5").Should().Be("0.5");
+            c3.GetError.Should().Be(false);
+            c3.GetErrorMessage.Should().BeNull();
+            c3.Set("1.").Should().Be("1.");
+            c3.GetError.Should().Be(false);
+            c3.GetErrorMessage.Should().BeNull();
+            c3.Get("1.").Should().Be("1");
+            c3.GetError.Should().Be(false);
+            c3.GetErrorMessage.Should().BeNull();
+            c3.Culture = CultureInfo.GetCultureInfo("de-AT");
+            c3.Set("1,7").Should().Be("1,7");
+            c3.Get("1,7").Should().Be("1,7");
+            c3.GetError.Should().Be(false);
+            c3.GetErrorMessage.Should().BeNull();
+            c3.Set("1.7").Should().Be("1.7");
+            c3.Get("1.7").Should().Be("17");//Changes from 1.7 to 17 because the dot is a valid grouping symbol
+            c3.GetError.Should().Be(false);
+            c3.GetErrorMessage.Should().BeNull();
+            c3.Get("1,").Should().Be("1");
+            c3.GetError.Should().Be(false);
+            c3.GetErrorMessage.Should().BeNull();
+            c3.Get(c3.Set("1.234.567,15")).Should().Be("1234567,15");
+            c3.GetError.Should().Be(false);
+            c3.GetErrorMessage.Should().BeNull();
+            var c4 = new NumericBoundariesConverter<bool>((b) => b);
+            c4.Set("true").Should().Be("true");
+            c4.Get("true").Should().Be(null);
+            c4.GetError.Should().Be(true);
+            c4.GetErrorMessage.Should().Be($"Conversion to type {typeof(bool)} not implemented");
+        }
+
+        [Test]
+        public void NumericBoundariesConverter_FunctionTest()
+        {
+            //Note: Set doesn't do anything. The Get can change the value
+            var c1 = new NumericBoundariesConverter<double>((i) => -i) { Culture = CultureInfo.InvariantCulture };
+            c1.Set("1,234,567.15").Should().Be("1,234,567.15");
+            c1.GetError.Should().Be(false);
+            c1.GetErrorMessage.Should().BeNull();
+            c1.Get("1,234,567.15").Should().Be("-1234567.15");
+            c1.GetError.Should().Be(false);
+            c1.GetErrorMessage.Should().BeNull();
+        }
     }
 }

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor
@@ -9,7 +9,7 @@
 					 Error="@HasErrors" ErrorText="@GetErrorText()" Disabled="@Disabled" Margin="@Margin" Required="@Required">
 		<InputContent>
 			<MudInput T="string" @ref="_elementReference" @attributes="UserAttributes" InputType="InputType.Number" Style="@Style" Variant="@Variant"
-					  Value="@Text" ValueChanged="(v) => SetTextAsync(v)" Converter="s_inputConverter" Placeholder="@Placeholder"
+					  Value="@Text" ValueChanged="(v) => SetTextAsync(v)" Converter="_inputConverter" Placeholder="@Placeholder"
 					  Disabled=@Disabled DisableUnderLine="@DisableUnderLine" ReadOnly="@ReadOnly" Adornment="@Adornment"
 					  AdornmentText="@AdornmentText" AdornmentIcon="@AdornmentIcon" AdornmentColor="@AdornmentColor" IconSize="@IconSize"
 					  OnAdornmentClick="@OnAdornmentClick" Error="@Error" Immediate="@Immediate" Margin="@Margin"

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -3,7 +3,6 @@ using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
-using MudBlazor.Components.NumericField;
 using MudBlazor.Utilities;
 
 namespace MudBlazor

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using MudBlazor.Components.NumericField;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
@@ -16,6 +17,7 @@ namespace MudBlazor
             SetConverter(new DefaultConverter<T> { Culture = CultureInfo.InvariantCulture });
 
             _validateInstance = new Func<T, Task<bool>>(ValidateInput);
+            _inputConverter = new NumericBoundariesConverter<T>((val) => ConstrainBoundaries(val).value) { Culture = CultureInfo.InvariantCulture };
 
             #region parameters default depending on T
             //sbyte
@@ -107,7 +109,7 @@ namespace MudBlazor
 
         private MudInput<string> _elementReference;
 
-        private static Converter<string> s_inputConverter = new DefaultConverter<string> { Culture = CultureInfo.InvariantCulture };
+        private Converter<string> _inputConverter;
 
         public override ValueTask FocusAsync()
         {
@@ -128,7 +130,7 @@ namespace MudBlazor
         {
             bool valueChanged;
             (value, valueChanged) = ConstrainBoundaries(value);
-            await base.SetValueAsync(ConstrainBoundaries(value).value, valueChanged || updateText);
+            await base.SetValueAsync(value, valueChanged || updateText);
         }
 
         protected async Task<bool> ValidateInput(T value)

--- a/src/MudBlazor/Components/NumericField/NumericBoundariesConverter.cs
+++ b/src/MudBlazor/Components/NumericField/NumericBoundariesConverter.cs
@@ -20,6 +20,9 @@ namespace MudBlazor.Components.NumericField
 
         private string OnGet(string value)
         {
+            if (String.IsNullOrEmpty(value))
+                return null;
+
             try
             {
                 // sbyte

--- a/src/MudBlazor/Components/NumericField/NumericBoundariesConverter.cs
+++ b/src/MudBlazor/Components/NumericField/NumericBoundariesConverter.cs
@@ -1,0 +1,116 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Globalization;
+
+namespace MudBlazor.Components.NumericField
+{
+    public class NumericBoundariesConverter<T> : Converter<string>
+    {
+        public Func<T, T> BoundariesFunc { get; set; }
+
+        public NumericBoundariesConverter(Func<T, T> boundariesFunc)
+        {
+            BoundariesFunc = boundariesFunc;
+            SetFunc = (value) => value;
+            GetFunc = OnGet;
+        }
+
+        private string OnGet(string value)
+        {
+            try
+            {
+                // sbyte
+                if (typeof(T) == typeof(sbyte) || typeof(T) == typeof(sbyte?))
+                {
+                    if (sbyte.TryParse(value, NumberStyles.Integer, Culture, out var parsedValue))
+                        return CheckBoundaries((T)(object)parsedValue);
+                }
+                // byte
+                else if (typeof(T) == typeof(byte) || typeof(T) == typeof(byte?))
+                {
+                    if (byte.TryParse(value, NumberStyles.Integer, Culture, out var parsedValue))
+                        return CheckBoundaries((T)(object)parsedValue);
+                    UpdateGetError("Not a valid number");
+                }
+                // short
+                else if (typeof(T) == typeof(short) || typeof(T) == typeof(short?))
+                {
+                    if (short.TryParse(value, NumberStyles.Integer, Culture, out var parsedValue))
+                        return CheckBoundaries((T)(object)parsedValue);
+                    UpdateGetError("Not a valid number");
+                }
+                // ushort
+                else if (typeof(T) == typeof(ushort) || typeof(T) == typeof(ushort?))
+                {
+                    if (ushort.TryParse(value, NumberStyles.Integer, Culture, out var parsedValue))
+                        return CheckBoundaries((T)(object)parsedValue);
+                    UpdateGetError("Not a valid number");
+                }
+                // int
+                else if (typeof(T) == typeof(int) || typeof(T) == typeof(int?))
+                {
+                    if (int.TryParse(value, NumberStyles.Integer, Culture, out var parsedValue))
+                        return CheckBoundaries((T)(object)parsedValue);
+                    UpdateGetError("Not a valid number");
+                }
+                // uint
+                else if (typeof(T) == typeof(uint) || typeof(T) == typeof(uint?))
+                {
+                    if (uint.TryParse(value, NumberStyles.Integer, Culture, out var parsedValue))
+                        return CheckBoundaries((T)(object)parsedValue);
+                    UpdateGetError("Not a valid number");
+                }
+                // long
+                else if (typeof(T) == typeof(long) || typeof(T) == typeof(long?))
+                {
+                    if (long.TryParse(value, NumberStyles.Integer, Culture, out var parsedValue))
+                        return CheckBoundaries((T)(object)parsedValue);
+                    UpdateGetError("Not a valid number");
+                }
+                // ulong
+                else if (typeof(T) == typeof(ulong) || typeof(T) == typeof(ulong?))
+                {
+                    if (ulong.TryParse(value, NumberStyles.Integer, Culture, out var parsedValue))
+                        return CheckBoundaries((T)(object)parsedValue);
+                    UpdateGetError("Not a valid number");
+                }
+                // float
+                else if (typeof(T) == typeof(float) || typeof(T) == typeof(float?))
+                {
+                    if (float.TryParse(value, NumberStyles.Any, Culture, out var parsedValue))
+                        return CheckBoundaries((T)(object)parsedValue);
+                    UpdateGetError("Not a valid number");
+                }
+                // double
+                else if (typeof(T) == typeof(double) || typeof(T) == typeof(double?))
+                {
+                    if (double.TryParse(value, NumberStyles.Any, Culture, out var parsedValue))
+                        return CheckBoundaries((T)(object)parsedValue);
+                    UpdateGetError("Not a valid number");
+                }
+                // decimal
+                else if (typeof(T) == typeof(decimal) || typeof(T) == typeof(decimal?))
+                {
+                    if (decimal.TryParse(value, NumberStyles.Any, Culture, out var parsedValue))
+                        return CheckBoundaries((T)(object)parsedValue);
+                    UpdateGetError("Not a valid number");
+                }
+                else
+                {
+                    UpdateGetError($"Conversion to type {typeof(T)} not implemented");
+                }
+            }
+            catch (Exception e)
+            {
+                UpdateGetError("Conversion error: " + e.Message);
+            }
+
+            return null;
+        }
+
+        private string CheckBoundaries(T value) => Convert.ToString(BoundariesFunc.Invoke(value), Culture);
+    }
+}

--- a/src/MudBlazor/Utilities/BindingConverters/NumericBoundariesConverter.cs
+++ b/src/MudBlazor/Utilities/BindingConverters/NumericBoundariesConverter.cs
@@ -36,76 +36,76 @@ namespace MudBlazor
                 if (typeof(T) == typeof(sbyte) || typeof(T) == typeof(sbyte?))
                 {
                     if (sbyte.TryParse(value, NumberStyles.Integer, Culture, out var parsedValue))
-                        return CheckBoundaries((T)(object)parsedValue);
+                        return ((sbyte)(object)CheckBoundaries((T)(object)parsedValue)).ToString(Format, Culture);
                 }
                 // byte
                 else if (typeof(T) == typeof(byte) || typeof(T) == typeof(byte?))
                 {
                     if (byte.TryParse(value, NumberStyles.Integer, Culture, out var parsedValue))
-                        return CheckBoundaries((T)(object)parsedValue);
+                        return ((byte)(object)CheckBoundaries((T)(object)parsedValue)).ToString(Format, Culture);
                     UpdateGetError("Not a valid number");
                 }
                 // short
                 else if (typeof(T) == typeof(short) || typeof(T) == typeof(short?))
                 {
                     if (short.TryParse(value, NumberStyles.Integer, Culture, out var parsedValue))
-                        return CheckBoundaries((T)(object)parsedValue);
+                        return ((short)(object)CheckBoundaries((T)(object)parsedValue)).ToString(Format, Culture);
                     UpdateGetError("Not a valid number");
                 }
                 // ushort
                 else if (typeof(T) == typeof(ushort) || typeof(T) == typeof(ushort?))
                 {
                     if (ushort.TryParse(value, NumberStyles.Integer, Culture, out var parsedValue))
-                        return CheckBoundaries((T)(object)parsedValue);
+                        return ((ushort)(object)CheckBoundaries((T)(object)parsedValue)).ToString(Format, Culture);
                     UpdateGetError("Not a valid number");
                 }
                 // int
                 else if (typeof(T) == typeof(int) || typeof(T) == typeof(int?))
                 {
                     if (int.TryParse(value, NumberStyles.Integer, Culture, out var parsedValue))
-                        return CheckBoundaries((T)(object)parsedValue);
+                        return ((int)(object)CheckBoundaries((T)(object)parsedValue)).ToString(Format, Culture);
                     UpdateGetError("Not a valid number");
                 }
                 // uint
                 else if (typeof(T) == typeof(uint) || typeof(T) == typeof(uint?))
                 {
                     if (uint.TryParse(value, NumberStyles.Integer, Culture, out var parsedValue))
-                        return CheckBoundaries((T)(object)parsedValue);
+                        return ((uint)(object)CheckBoundaries((T)(object)parsedValue)).ToString(Format, Culture);
                     UpdateGetError("Not a valid number");
                 }
                 // long
                 else if (typeof(T) == typeof(long) || typeof(T) == typeof(long?))
                 {
                     if (long.TryParse(value, NumberStyles.Integer, Culture, out var parsedValue))
-                        return CheckBoundaries((T)(object)parsedValue);
+                        return ((long)(object)CheckBoundaries((T)(object)parsedValue)).ToString(Format, Culture);
                     UpdateGetError("Not a valid number");
                 }
                 // ulong
                 else if (typeof(T) == typeof(ulong) || typeof(T) == typeof(ulong?))
                 {
                     if (ulong.TryParse(value, NumberStyles.Integer, Culture, out var parsedValue))
-                        return CheckBoundaries((T)(object)parsedValue);
+                        return ((ulong)(object)CheckBoundaries((T)(object)parsedValue)).ToString(Format, Culture);
                     UpdateGetError("Not a valid number");
                 }
                 // float
                 else if (typeof(T) == typeof(float) || typeof(T) == typeof(float?))
                 {
                     if (float.TryParse(value, NumberStyles.Any, Culture, out var parsedValue))
-                        return CheckBoundaries((T)(object)parsedValue);
+                        return ((float)(object)CheckBoundaries((T)(object)parsedValue)).ToString(Format, Culture);
                     UpdateGetError("Not a valid number");
                 }
                 // double
                 else if (typeof(T) == typeof(double) || typeof(T) == typeof(double?))
                 {
                     if (double.TryParse(value, NumberStyles.Any, Culture, out var parsedValue))
-                        return CheckBoundaries((T)(object)parsedValue);
+                        return ((double)(object)CheckBoundaries((T)(object)parsedValue)).ToString(Format, Culture);
                     UpdateGetError("Not a valid number");
                 }
                 // decimal
                 else if (typeof(T) == typeof(decimal) || typeof(T) == typeof(decimal?))
                 {
                     if (decimal.TryParse(value, NumberStyles.Any, Culture, out var parsedValue))
-                        return CheckBoundaries((T)(object)parsedValue);
+                        return ((decimal)(object)CheckBoundaries((T)(object)parsedValue)).ToString(Format, Culture);
                     UpdateGetError("Not a valid number");
                 }
                 else
@@ -121,6 +121,6 @@ namespace MudBlazor
             return null;
         }
 
-        private string CheckBoundaries(T value) => Convert.ToString(EvaluationFunc.Invoke(value), Culture);
+        private T CheckBoundaries(T value) => EvaluationFunc.Invoke(value);
     }
 }

--- a/src/MudBlazor/Utilities/BindingConverters/NumericBoundariesConverter.cs
+++ b/src/MudBlazor/Utilities/BindingConverters/NumericBoundariesConverter.cs
@@ -5,15 +5,22 @@
 using System;
 using System.Globalization;
 
-namespace MudBlazor.Components.NumericField
+namespace MudBlazor
 {
+    /// <summary>
+    /// This converter is used by MudNumericInput to enforce the Min/Max boundaries on the textbox.
+    /// It's a string => string converter, the number it's only to enforce the limits.
+    /// </summary>
+    /// <typeparam name="T">Must be a numeric type</typeparam>
     public class NumericBoundariesConverter<T> : Converter<string>
     {
-        public Func<T, T> BoundariesFunc { get; set; }
+#nullable enable
+        public Func<T, T> EvaluationFunc { get; set; }
+#nullable disable
 
-        public NumericBoundariesConverter(Func<T, T> boundariesFunc)
+        public NumericBoundariesConverter(Func<T, T> evaluationFunc)
         {
-            BoundariesFunc = boundariesFunc;
+            EvaluationFunc = evaluationFunc;
             SetFunc = (value) => value;
             GetFunc = OnGet;
         }
@@ -114,6 +121,6 @@ namespace MudBlazor.Components.NumericField
             return null;
         }
 
-        private string CheckBoundaries(T value) => Convert.ToString(BoundariesFunc.Invoke(value), Culture);
+        private string CheckBoundaries(T value) => Convert.ToString(EvaluationFunc.Invoke(value), Culture);
     }
 }

--- a/src/MudBlazor/Utilities/BindingConverters/NumericBoundariesConverter.cs
+++ b/src/MudBlazor/Utilities/BindingConverters/NumericBoundariesConverter.cs
@@ -21,7 +21,7 @@ namespace MudBlazor
         public NumericBoundariesConverter(Func<T, T> evaluationFunc)
         {
             EvaluationFunc = evaluationFunc;
-            SetFunc = (value) => value;
+            SetFunc = (value) => value; //Set doesn't do anything, awaits the Get to commit changes (IE: typing the decimal separator shouldn't trigger changes)
             GetFunc = OnGet;
         }
 


### PR DESCRIPTION
This PR fixes an issue with NumericField, an out of bound value doesn't change on the interface when manually typed in, but it's bound value is costrained.

**How to reproduce**
https://try.mudblazor.com/snippet/wYQlOKOlWPefTgtG
This fiddler replicates the "Normal vs Immediate vs Debounced" example in the docs, but with `Min=0 Max=10` parameters.
It's easier seen on immediate, but it happens on debounced and normal (in some cases).
If you type a valid number (IE: 4) you can see change immediately both on the textbox and in the control below. If you make it invalid (IE: 40) the control value changes to 10 (maximum valid value) but the text is still 40.


**Why it happens**
NumericField declared a `DefaultConverter<string>` (forcing `InvariantCulture` to work with HTML standard specifications) on the internal `MudInput` component, that deals with the number but it doesn't care if the number is valid so it isn't changed.

**How it's fixed**
Created a `NumericBoundariesConverter<T>` where T must be a number format, but it's a string => string converter. It holds a reference to a function that returns `T` given a parsed `T`.
The `OnGet` function parses the input string, evaluates the value before converting it back to a string, allowing to make evaluations on the numeric value beyond the simple "is valid".
Inside NumericField constructor, it binds the evaluation function to `MudNumericField.ConstrainBoundaries` in order to check the boundaries with the current Min/Max values.