### PR TITLE
MudTextField: Added a setting to control if ValueChanged event should be called for DebouncedInput when OnChange event occurs before DebouncedInterval elapsed

### DIFF
--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -144,6 +144,9 @@ namespace MudBlazor
 
         [Parameter] public EventCallback<FocusEventArgs> OnBlur { get; set; }
 
+        [Parameter]
+        public EventCallback<ChangeEventArgs> OnInternalInputChanged { get; set; }
+
         protected bool _isFocused;
 
         protected bool _shouldRenderBeForced;

--- a/src/MudBlazor/Components/Input/MudDebouncedInput.cs
+++ b/src/MudBlazor/Components/Input/MudDebouncedInput.cs
@@ -40,8 +40,13 @@ namespace MudBlazor
 
         protected Task OnChange()
         {
-            _timer.Stop();
-            return base.UpdateValuePropertyAsync(false);
+            if (DebounceInterval > 0 && _timer != null)
+            {
+                _timer.Stop();
+                return base.UpdateValuePropertyAsync(false);
+            }
+
+            return Task.CompletedTask;
         }
 
         protected override Task UpdateValuePropertyAsync(bool updateText)

--- a/src/MudBlazor/Components/Input/MudDebouncedInput.cs
+++ b/src/MudBlazor/Components/Input/MudDebouncedInput.cs
@@ -33,10 +33,28 @@ namespace MudBlazor
         }
 
         /// <summary>
+        /// If false then updates will happen only on DebounceInterval
+        /// If true then updates will also happen when OnChange happens (blurred, enter pressed, cleared, etc.)
+        /// </summary>
+        [Parameter]
+        public bool UpdateDebouncedWhenChanged { get; set; } = false;
+
+        /// <summary>
         /// callback to be called when the debounce interval has elapsed
         /// receives the Text as a parameter
         /// </summary>
         [Parameter] public EventCallback<string> OnDebounceIntervalElapsed { get; set; }
+
+        protected Task OnChange()
+        {
+            if (UpdateDebouncedWhenChanged)
+            {
+                _timer.Stop();
+                return base.UpdateValuePropertyAsync(false);
+            }
+
+            return Task.CompletedTask;
+        }
 
         protected override Task UpdateValuePropertyAsync(bool updateText)
         {

--- a/src/MudBlazor/Components/Input/MudDebouncedInput.cs
+++ b/src/MudBlazor/Components/Input/MudDebouncedInput.cs
@@ -33,13 +33,6 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// If false then updates will happen only on DebounceInterval
-        /// If true then updates will also happen when OnChange happens (blurred, enter pressed, cleared, etc.)
-        /// </summary>
-        [Parameter]
-        public bool UpdateDebouncedWhenChanged { get; set; } = false;
-
-        /// <summary>
         /// callback to be called when the debounce interval has elapsed
         /// receives the Text as a parameter
         /// </summary>
@@ -47,13 +40,8 @@ namespace MudBlazor
 
         protected Task OnChange()
         {
-            if (UpdateDebouncedWhenChanged)
-            {
-                _timer.Stop();
-                return base.UpdateValuePropertyAsync(false);
-            }
-
-            return Task.CompletedTask;
+            _timer.Stop();
+            return base.UpdateValuePropertyAsync(false);
         }
 
         protected override Task UpdateValuePropertyAsync(bool updateText)

--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -32,9 +32,13 @@ namespace MudBlazor
             return Immediate ? SetTextAsync(args?.Value as string) : Task.CompletedTask;
         }
 
-        protected Task OnChange(ChangeEventArgs args)
+        protected async Task OnChange(ChangeEventArgs args)
         {
-            return Immediate ? Task.CompletedTask : SetTextAsync(args?.Value as string);
+            await OnInternalInputChanged.InvokeAsync(args);
+            if (!Immediate)
+            {
+                await SetTextAsync(args?.Value as string);
+            }
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/TextField/MudTextField.razor
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor
@@ -7,7 +7,7 @@
         <InputContent>
             <MudInput T="string" @ref="_elementReference" @attributes="UserAttributes" InputType="@InputType" Lines="@Lines" Style="@Style" Variant="@Variant" Value="@Text" ValueChanged="(s) => SetTextAsync(s)" Placeholder="@Placeholder" Disabled=@Disabled DisableUnderLine="@DisableUnderLine" ReadOnly="@ReadOnly"
                       Adornment="@Adornment" AdornmentText="@AdornmentText" AdornmentIcon="@AdornmentIcon" AdornmentColor="@AdornmentColor" IconSize="@IconSize" OnAdornmentClick="@OnAdornmentClick" Error="@Error" Immediate="@Immediate" Margin="@Margin"
-                      OnBlur="@OnBlurred" OnKeyDown="@InvokeKeyDown" OnKeyPress="@InvokeKeyPress" OnKeyUp="@InvokeKeyUp"
+                      OnBlur="@OnBlurred" OnKeyDown="@InvokeKeyDown" OnInternalInputChanged="OnChange" OnKeyPress="@InvokeKeyPress" OnKeyUp="@InvokeKeyUp"
                       KeyDownPreventDefault="KeyDownPreventDefault" KeyPressPreventDefault="KeyPressPreventDefault" KeyUpPreventDefault="KeyUpPreventDefault"
                       HideSpinButtons="true" Clearable="@Clearable" OnClearButtonClick="@OnClearButtonClick" />
         </InputContent>


### PR DESCRIPTION
When UpdateDebouncedWhenChanged is false (default) then behavior is as it was before (ValueChanged is called only on DebounceInterval elapsed).
But when setting UpdateDebouncedWhenChanged to true the ValueChanged event will also be called when a user presses enter inside the input field or changes it's focus (blurred) or clears the text.
This is useful for search fields where a DebounceInterval is set to something high (a second or higher) and user already entered the text to search and pressed "Enter" or leaves the field.