### PR TITLE
Dialog: Fixed dialog parameters re-set on each StateHasChanged overwriting current values

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogWithParameters.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogWithParameters.razor
@@ -1,0 +1,23 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudDialog>
+    <DialogContent>
+        <MudInput @bind-Value="TestValue" />
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="OnTest" Variant="Variant.Filled" Color="Color.Primary" Class="mr-auto">Test</MudButton>
+        <MudButton OnClick="() => MudDialog.Close()">Close</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] MudDialogInstance MudDialog { get; set; }
+    [Parameter] public string TestValue { get; set; }
+    [Parameter] public Color Color_Test { get; set; }
+
+    private void OnTest()
+    {
+        MudDialog.ForceRender();
+        StateHasChanged();
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/DialogTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DialogTests.cs
@@ -147,6 +147,43 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// A test that ensures parameters are not overwritten when dialog is updated
+        /// </summary>
+        [Test]
+        public async Task DialogShouldNotOverwriteParameters()
+        {
+            var comp = ctx.RenderComponent<MudDialogProvider>();
+            comp.Markup.Trim().Should().BeEmpty();
+            var service = ctx.Services.GetService<IDialogService>() as DialogService;
+            service.Should().NotBe(null);
+            IDialogReference dialogReference = null;
+
+            var parameters = new DialogParameters();
+            parameters.Add("TestValue", "test");
+            parameters.Add("Color_Test", Color.Error); // !! comment me !!
+
+            await comp.InvokeAsync(() => dialogReference = service?.Show<DialogWithParameters>(string.Empty, parameters));
+            dialogReference.Should().NotBe(null);
+
+            Console.WriteLine("----------------------------------------");
+            Console.WriteLine(comp.Markup);
+
+            var textField = comp.FindComponent<MudInput<string>>().Instance;
+            textField.Text.Should().Be("test");
+
+            comp.Find("input").Change("new_test");
+            comp.Find("input").Blur();
+            textField.Text.Should().Be("new_test");
+
+            comp.FindAll("button")[0].Click();
+            Console.WriteLine("----------------------------------------");
+            Console.WriteLine(comp.Markup);
+
+            (dialogReference.Dialog as DialogWithParameters).TestValue.Should().Be("new_test");
+            textField.Text.Should().Be("new_test");
+        }
+
+        /// <summary>
         /// Based on bug report #1385
         /// Dialog Class and Style parameters should be honored
         /// </summary>

--- a/src/MudBlazor/Components/Dialog/DialogParameters.cs
+++ b/src/MudBlazor/Components/Dialog/DialogParameters.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 
 namespace MudBlazor
 {
-    public class DialogParameters : IEnumerable
+    public class DialogParameters : IEnumerable<KeyValuePair<string, object>>
     {
         internal Dictionary<string, object> _parameters;
 
@@ -40,10 +40,18 @@ namespace MudBlazor
             return default;
         }
 
+        public int Count =>
+            _parameters.Count;
+
         public object this[string parameterName]
         {
             get => Get<object>(parameterName);
             set => _parameters[parameterName] = value;
+        }
+
+        public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
+        {
+            return _parameters.GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()

--- a/src/MudBlazor/Components/Dialog/DialogReference.cs
+++ b/src/MudBlazor/Components/Dialog/DialogReference.cs
@@ -44,6 +44,8 @@ namespace MudBlazor
 
         public Task<DialogResult> Result => _resultCompletion.Task;
 
+        public bool AreParametersRendered { get; set; }
+
         internal void InjectDialog(object inst)
         {
             Dialog = inst;

--- a/src/MudBlazor/Components/Dialog/IDialogReference.cs
+++ b/src/MudBlazor/Components/Dialog/IDialogReference.cs
@@ -10,6 +10,8 @@ namespace MudBlazor
 {
     public interface IDialogReference
     {
+        public bool AreParametersRendered { get; }
+
         Task<DialogResult> Result { get; }
 
         void Close();

--- a/src/MudBlazor/Services/DialogService.cs
+++ b/src/MudBlazor/Services/DialogService.cs
@@ -74,10 +74,17 @@ namespace MudBlazor
             {
                 var i = 0;
                 builder.OpenComponent(i++, contentComponent);
-                foreach (var parameter in parameters._parameters)
+
+                if (!dialogReference.AreParametersRendered)
                 {
-                    builder.AddAttribute(i++, parameter.Key, parameter.Value);
+                    foreach (var parameter in parameters._parameters)
+                    {
+                        builder.AddAttribute(i++, parameter.Key, parameter.Value);
+                    }
+
+                    dialogReference.AreParametersRendered = true;
                 }
+
                 builder.AddComponentReferenceCapture(1, inst => { dialogReference.InjectDialog(inst); });
                 builder.CloseComponent();
             });

--- a/src/MudBlazor/Services/DialogService.cs
+++ b/src/MudBlazor/Services/DialogService.cs
@@ -68,8 +68,7 @@ namespace MudBlazor
                 throw new ArgumentException($"{contentComponent.FullName} must be a Blazor Component");
             }
             var dialogInstanceId = Guid.NewGuid();
-            DialogReference dialogReference = null;
-            dialogReference = new DialogReference(dialogInstanceId, this);
+            var dialogReference = new DialogReference(dialogInstanceId, this);
             var dialogContent = new RenderFragment(builder =>
             {
                 var i = 0;
@@ -77,15 +76,19 @@ namespace MudBlazor
 
                 if (!dialogReference.AreParametersRendered)
                 {
-                    foreach (var parameter in parameters._parameters)
+                    foreach (var parameter in parameters)
                     {
                         builder.AddAttribute(i++, parameter.Key, parameter.Value);
                     }
 
                     dialogReference.AreParametersRendered = true;
                 }
+                else
+                {
+                    i += parameters.Count;
+                }
 
-                builder.AddComponentReferenceCapture(1, inst => { dialogReference.InjectDialog(inst); });
+                builder.AddComponentReferenceCapture(i++, inst => { dialogReference.InjectDialog(inst); });
                 builder.CloseComponent();
             });
             var dialogInstance = new RenderFragment(builder =>


### PR DESCRIPTION
When using parameters for dialog like this:
```c#
public partial class PackLockDialog : ComponentBase
{
    // ...
    [Parameter]
    public DateTime? LockedDate { get; set; }

    // ...
}

// ...

var parameters = new DialogParameters
{
    { nameof(PackLockDialog.LockedDate), DateTime.Today },
};

var dialogRef = dialogService.Show<PackLockDialog>(string.Empty, parameters);
```

They get re-set every time a StateHasChanged is called for the components, which use these parameters.
This PR adds a AreParametersRendered property for a DialogReference to restrict parameters setting only for the first time when the component is created.