### PR TITLE
Line and Bar charts: fixes for RTL

### DIFF
--- a/src/MudBlazor/Components/Chart/Charts/Bar.razor
+++ b/src/MudBlazor/Components/Chart/Charts/Bar.razor
@@ -2,7 +2,7 @@
 @using System.Globalization;
 @inherits MudChartBase
 
-<svg class="mud-chart-line" width="@MudChartParent?.Width" height="@MudChartParent?.Height" viewBox="0 0 650 350">
+<svg class="mud-chart-line mud-ltr" width="@MudChartParent?.Width" height="@MudChartParent?.Height" viewBox="0 0 650 350">
     <g class="mud-charts-grid">
         <g class="mud-charts-gridlines-yaxis">
             @foreach (var horizontalLine in _horizontalLines)

--- a/src/MudBlazor/Components/Chart/Charts/Line.razor
+++ b/src/MudBlazor/Components/Chart/Charts/Line.razor
@@ -2,7 +2,7 @@
 @using System.Globalization;
 @inherits MudChartBase
 
-<svg class="mud-chart-line" width="@MudChartParent?.Width" height="@MudChartParent?.Height" viewBox="0 0 650 350">
+<svg class="mud-chart-line mud-ltr" width="@MudChartParent?.Width" height="@MudChartParent?.Height" viewBox="0 0 650 350">
     <g class="mud-charts-grid">
         <g class="mud-charts-gridlines-yaxis">
             @foreach (var horizontalLine in _horizontalLines)


### PR DESCRIPTION
I read online that line and bar charts should remain ltr because they display the flow of time.
`There doesn't appear to be a global consensus on charts. Line charts are almost always left-to-right.`
https://mapmeld.com/rtl-guide/

Although there are occurrences of rtl line charts. I think keeping them ltr would be the best option.

Before fix (RTL):
![grafik](https://user-images.githubusercontent.com/62108893/120839436-39fc3500-c569-11eb-860c-6b76d3aa2b4b.png)

After fix (RTL):
![grafik](https://user-images.githubusercontent.com/62108893/120839506-4ed8c880-c569-11eb-9a7d-ace992e6b392.png)

