### PR TITLE
Autocomplete, Select and Textfield: Fixes for RTL

### DIFF
--- a/src/MudBlazor/Styles/components/_inputcontrol.scss
+++ b/src/MudBlazor/Styles/components/_inputcontrol.scss
@@ -167,3 +167,11 @@
     margin-left: 14px;
     margin-right: 14px;
 }
+
+.mud-application-layout-rtl {
+    .mud-input-control .mud-input-control-input-container .mud-input input {
+        &[type="email"], &[type="tel"] {
+            direction: ltr;
+        }
+    }
+}

--- a/src/MudBlazor/Styles/components/_inputlabel.scss
+++ b/src/MudBlazor/Styles/components/_inputlabel.scss
@@ -1,4 +1,4 @@
-﻿.mud-input-label {
+.mud-input-label {
     display: block;
     transform-origin: top left;
 }
@@ -75,5 +75,53 @@ label.mud-input-label.mud-input-label-inputcontrol {
 
     .mud-input:focus-within ~ &.mud-input-error {
         color: var(--mud-palette-error);
+    }
+}
+.mud-application-layout-rtl {
+    .mud-input-label {
+        transform-origin: top right;
+    }
+
+    .mud-input-label-inputcontrol {
+        left: unset;
+        right: 0;
+    }
+
+    .mud-input-label-shrink {
+        transform-origin: top right;
+    }
+
+    .mud-input-label-filled {
+        transform: translate(-12px, 20px) scale(1);
+
+        &.mud-input-label-margin-dense {
+            transform: translate(-12px, 17px) scale(1);
+        }
+    }
+
+    .mud-input-label-outlined {
+        transform: translate(-14px, 20px) scale(1);
+
+        &.mud-input-label-margin-dense {
+            transform: translate(-14px, 12px) scale(1);
+        }
+    }
+
+    .mud-shrink, .mud-input:focus-within {
+        ~ label.mud-input-label.mud-input-label-inputcontrol {
+            transform-origin: top right;
+
+            &.mud-input-label-filled {
+                transform: translate(-12px, 10px) scale(0.75);
+
+                &.mud-input-label-margin-dense {
+                    transform: translate(-12px, 7px) scale(0.75);
+                }
+            }
+
+            &.mud-input-label-outlined {
+                transform: translate(-14px, -6px) scale(0.75);
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes in https://github.com/Garderoben/MudBlazor/issues/92#issuecomment-724748845:
`Autocomplete text and position of arrow`
`Select text and arrow position` + `Select items in dropdown`
`Textfield helper text and label text`

![textfield](https://user-images.githubusercontent.com/62108893/120891239-c8bf8f00-c607-11eb-8560-b13311aed111.gif)

When the `InputTpye` of `MudTextFields` is set to `InputType.Email` or `InputType.Telephone` the orientation of the textfield automatically changes to ltr. As described here: https://rtlstyling.com/posts/rtl-styling/#form-inputs
![grafik](https://user-images.githubusercontent.com/62108893/120891300-189e5600-c608-11eb-9b82-94da9b6023e3.png)
![grafik](https://user-images.githubusercontent.com/62108893/120891317-35d32480-c608-11eb-8b62-a6c2775e4a31.png)

