### PR TITLE
MudDatePicker: added AutoClose to close on date selection

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/DatePicker/DatePickerPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DatePicker/DatePickerPage.razor
@@ -11,6 +11,7 @@
                 <Title>Basic Usage</Title>
                 <Description>
                     <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">Note: Always use the two-way binding <CodeInline>@@bind-Date</CodeInline> to bind to a field of type <CodeInline>DateTime?</CodeInline></MudAlert>
+                    <MudText Class="py-6">If <CodeInline>AutoClose</CodeInline> is set to true and PickerActions are defined, selecting the day will close the MudDatePicker.</MudText>
                 </Description>
             </SectionHeader>
             <SectionContent Outlined="true">

--- a/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerBasicUsageExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerBasicUsageExample.razor
@@ -23,17 +23,19 @@
 </MudGrid>
 <MudGrid>
     <MudItem xs="12" sm="6" md="4">
-        <MudDatePicker @ref="_picker" Label="With action buttons" @bind-Date="date">
+        <MudDatePicker @ref="_picker" Label="With action buttons" @bind-Date="date" AutoClose="@autoClose">
             <PickerActions>
                 <MudButton Class="mr-auto align-self-start" OnClick="@(() => _picker.Clear())">Clear</MudButton>
                 <MudButton OnClick="@(() => _picker.Close(false))">Cancel</MudButton>
                 <MudButton Color="Color.Primary" OnClick="@(() => _picker.Close())">Ok</MudButton>
             </PickerActions>
         </MudDatePicker>
+        <MudSwitch @bind-Checked="@autoClose" Color="Color.Secondary">AutoClose</MudSwitch>
     </MudItem>
 </MudGrid>
 
 @code {
     MudDatePicker _picker;
     DateTime? date = DateTime.Today;
+    private bool autoClose;
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/AutoCompleteDatePickerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/AutoCompleteDatePickerTest.razor
@@ -1,0 +1,12 @@
+﻿<MudDatePicker id="picker" @ref="_picker" Label="With action buttons" @bind-Date="date">
+    <PickerActions>
+        <MudButton Class="mr-auto align-self-start" OnClick="@(() => _picker.Clear())">Clear</MudButton>
+        <MudButton OnClick="@(() => _picker.Close(false))">Cancel</MudButton>
+        <MudButton Color="Color.Primary" OnClick="@(() => _picker.Close())">Ok</MudButton>
+    </PickerActions>
+</MudDatePicker>
+
+@code {
+    MudDatePicker _picker;
+    DateTime? date = DateTime.Today;
+}

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -12,6 +12,7 @@ using Bunit;
 using FluentAssertions;
 using MudBlazor.Extensions;
 using MudBlazor.UnitTests.TestComponents;
+using MudBlazor.UnitTests.TestComponents.DatePicker;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
 using static Bunit.ComponentParameterFactory;
@@ -375,6 +376,70 @@ namespace MudBlazor.UnitTests.Components
 
             picker.Text.Should().Be(text);
             (comp.FindAll("input")[0] as IHtmlInputElement).Value.Should().Be(text);
+        }
+
+        [Test]
+        public async Task CheckAutoCloseDatePickerTest()
+        {
+            // Define a date for comparison
+            DateTime now = new DateTime(DateTime.Now.Year, DateTime.Now.Month, DateTime.Now.Day);
+
+            // Get access to the datepicker of the instance
+            var comp = ctx.RenderComponent<AutoCompleteDatePickerTest>();
+            var datePicker = comp.FindComponent<MudDatePicker>();
+
+            // Open the datepicker
+            await comp.InvokeAsync(() => datePicker.Instance.Open());
+
+            // Clicking a day button to select a date
+            // It must be a different day than the day of now!
+            // So the test is working when the day is 20
+            if (now.Day != 20)
+            {
+                comp.FindAll("button.mud-picker-calendar-day")
+                    .Where(x => x.TrimmedText().Equals("20")).First().Click();
+            }
+            else
+            {
+                comp.FindAll("button.mud-picker-calendar-day")
+                    .Where(x => x.TrimmedText().Equals("19")).First().Click();
+            }
+
+            // Check that the date should remain the same because autoclose is false
+            // and there are actions which are defined
+            datePicker.Instance.Date.Should().Be(now);
+
+            // Close the datepicker without submitting the date
+            // The date of the datepicker remains equal to now 
+            await comp.InvokeAsync(() => datePicker.Instance.Close(false));
+
+            // Change the value of autoclose
+            datePicker.Instance.AutoClose = true;
+            
+            // Open the datepicker
+            await comp.InvokeAsync(() => datePicker.Instance.Open());
+
+            // Clicking a day button to select a date
+            if (now.Day != 20)
+            {
+                comp.FindAll("button.mud-picker-calendar-day")
+                    .Where(x => x.TrimmedText().Equals("20")).First().Click();
+            }
+            else
+            {
+                comp.FindAll("button.mud-picker-calendar-day")
+                    .Where(x => x.TrimmedText().Equals("19")).First().Click();
+            }
+
+            // Check that the date should be equal to the new date 19 or 20
+            if (now.Day != 20)
+            {
+                datePicker.Instance.Date.Should().Be(new DateTime(now.Year, now.Month, 20));
+            }
+            else
+            {
+                datePicker.Instance.Date.Should().Be(new DateTime(now.Year, now.Month, 19));
+            }
         }
     }
 }

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -26,6 +26,11 @@ namespace MudBlazor
             set => SetDateAsync(value, true).AndForget();
         }
 
+        /// <summary>
+        /// If RequiredAction is set to false and PickerActions are defined, selecting the day will close the MudDatePicker.
+        /// </summary>
+        [Parameter] public bool RequiredAction { get; set; } = true;
+
         protected async Task SetDateAsync(DateTime? date, bool updateValue)
         {
             if (_value != date)
@@ -69,7 +74,7 @@ namespace MudBlazor
         protected override async void OnDayClicked(DateTime dateTime)
         {
             _selectedDate = dateTime;
-            if (PickerActions == null)
+            if (PickerActions == null || !RequiredAction)
             {
                 Submit();
 

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -27,9 +27,9 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// If RequiredAction is set to false and PickerActions are defined, selecting the day will close the MudDatePicker.
+        /// If AutoClose is set to true and PickerActions are defined, selecting the day will close the MudDatePicker.
         /// </summary>
-        [Parameter] public bool RequiredAction { get; set; } = true;
+        [Parameter] public bool AutoClose { get; set; }
 
         protected async Task SetDateAsync(DateTime? date, bool updateValue)
         {
@@ -74,7 +74,7 @@ namespace MudBlazor
         protected override async void OnDayClicked(DateTime dateTime)
         {
             _selectedDate = dateTime;
-            if (PickerActions == null || !RequiredAction)
+            if (PickerActions == null || AutoClose)
             {
                 Submit();
 


### PR DESCRIPTION
Implementation of the [On the Date Picker have a today button to select today](https://github.com/Garderoben/MudBlazor/issues/1243) issue.

The ```RequiredAction``` parameter has been added to _MudDatePicker_.

If ```RequiredAction``` is set to ```false``` and _PickerActions_ are defined, selecting the day will close the _MudDatePicker_.