### PR TITLE
MudTable: when used with server-sorted data, reload on sort label click in mobile view

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableServerSideDataTest4.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableServerSideDataTest4.razor
@@ -1,0 +1,51 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudTable ServerData="@(new Func<TableState, Task<TableData<TestModel>>>(ServerReload))" SortLabel="Sort by">
+    <HeaderContent>
+        <MudTh><MudTableSortLabel SortLabel="a" T="TestModel">a</MudTableSortLabel></MudTh>
+        <MudTh><MudTableSortLabel SortLabel="b" T="TestModel">b</MudTableSortLabel></MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd DataLabel="a">@context.a</MudTd>
+        <MudTd DataLabel="b">@context.b</MudTd>
+    </RowTemplate>
+    <PagerContent>
+        <MudTablePager />
+    </PagerContent>
+</MudTable>
+
+@code {
+#pragma warning disable CS1998 // async without await
+    public static string __description__ = "The server-side loaded table should reload data on mobile sort.";
+
+    public class TestModel
+    {
+        public int a { get; set; }
+        public int b { get; set; }
+    }
+    private int totalItems;
+
+    /// <summary>
+    /// Here we simulate getting the paged, filtered and ordered data from the server
+    /// </summary>
+    private async Task<TableData<TestModel>> ServerReload(TableState state)
+    {
+        IEnumerable<TestModel> data = new List<TestModel>() { new TestModel() { a=1, b=3 },
+                                            new TestModel() { a=2, b=2 },
+                                            new TestModel() { a=3, b=1 } };
+        totalItems = 3;
+        switch (state.SortLabel)
+        {
+            case "a":
+                data = data.OrderByDirection(state.SortDirection, x => x.a);
+                break;
+            case "b":
+                data = data.OrderByDirection(state.SortDirection, x => x.b);
+                break;
+            default:
+                break;
+        }
+        return new TableData<TestModel>() { TotalItems = totalItems, Items = data };
+    }
+
+}

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -688,6 +688,25 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// The server-side loaded table should reload when mobile sort if performed.
+        /// </summary>
+        [Test]
+        public async Task TableServerSideDataTest4()
+        {
+            var comp = ctx.RenderComponent<TableServerSideDataTest4>();
+            Console.WriteLine(comp.Markup);
+            comp.FindAll("tr").Count.Should().Be(4); // three rows + header row
+            comp.FindAll("td")[0].TextContent.Trim().Should().Be("1");
+            comp.FindAll("td")[2].TextContent.Trim().Should().Be("2");
+            comp.FindAll("td")[4].TextContent.Trim().Should().Be("3");
+            comp.FindAll("div.mud-select-input")[0].Click(); // mobile sort drop down
+            comp.FindAll("div.mud-list-item-clickable")[1].Click(); // sort b column
+            comp.FindAll("td")[0].TextContent.Trim().Should().Be("3");
+            comp.FindAll("td")[2].TextContent.Trim().Should().Be("2");
+            comp.FindAll("td")[4].TextContent.Trim().Should().Be("1");
+        }
+
+        /// <summary>
         /// The table should render the classes and style to the tr using the RowStyleFunc and RowClassFunc parameters
         /// </summary>
         [Test]

--- a/src/MudBlazor/Components/Table/TableContext.cs
+++ b/src/MudBlazor/Components/Table/TableContext.cs
@@ -94,6 +94,8 @@ namespace MudBlazor
             SortDirection = label.SortDirection;
             SortBy = label.SortBy;
             UpdateSortLabels(label);
+            if (Table.HasServerData)
+                Table.InvokeServerLoadFunc();
             TableStateHasChanged();
         }
 


### PR DESCRIPTION
Fix for #1293 