### PR TITLE
MudCardMedia: adapt to changing image

### DIFF
--- a/src/MudBlazor/Components/Card/MudCardMedia.razor.cs
+++ b/src/MudBlazor/Components/Card/MudCardMedia.razor.cs
@@ -6,7 +6,7 @@ namespace MudBlazor
     public partial class MudCardMedia : MudComponentBase
     {
         protected string StyleString =>
-            StyleBuilder.Default($"background-image:url({_imageUrl});{_height};")
+            StyleBuilder.Default($"background-image:url(\"{Image}\");height: {Height}px;")
                 .AddStyle(this.Style)
                 .Build();
 
@@ -16,18 +16,7 @@ namespace MudBlazor
                 .Build();
 
         [Parameter] public string Title { get; set; }
-
         [Parameter] public string Image { get; set; }
-
         [Parameter] public int Height { get; set; } = 300;
-
-        private string _height;
-        private string _imageUrl;
-
-        protected override void OnInitialized()
-        {
-            _height = $"height: {Height}px";
-            _imageUrl = "\"" + Image + "\"";
-        }
     }
 }


### PR DESCRIPTION
If you have a razor page with a MudCardMedia and you exchange the image or the height, the component will not refresh correct.
The reason for that is, that the component is calculating the values within "OnInitialized" which is not getting invoked on any parameter change.

Best solution in this case is to avoid a "state" and not to store the values into a dedicated field.
This PR will inline the parameters of MudCardMedia into the StyleString property directly.