### PR TITLE
Overlay: improved documentation

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Overlay/Examples/OverlayAbsoluteExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Overlay/Examples/OverlayAbsoluteExample.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudPaper Class="pa-8" Style="height: 300px;">
+<MudPaper Class="pa-8" Style="height: 300px; position: relative;">
     <MudButton Variant="Variant.Filled" Color="Color.Secondary" OnClick="@(e => ToggleOverlay(true))">Show Overlay</MudButton>
 
     <MudOverlay Visible="isVisible" DarkBackground="true" Absolute="true">

--- a/src/MudBlazor.Docs/Pages/Components/Overlay/OverlayPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Overlay/OverlayPage.razor
@@ -1,7 +1,7 @@
 ﻿@page "/components/overlay"
 
 <DocsPage>
-    <DocsPageHeader Title="Overlay" SubTitle="A short description of the component." />
+    <DocsPageHeader Title="Overlay" SubTitle="Provides a window which can have an arbitrary number of overlay views that will sit above the root view of the window." />
     <DocsPageContent>
         <DocsPageSection>
             <SectionHeader>
@@ -16,7 +16,7 @@
         <DocsPageSection>
             <SectionHeader>
                 <Title>Absolute</Title>
-                <Description>You can contain the overlay inside its parent with the <CodeInline>Absolute</CodeInline> property.</Description>
+                <Description>The overlay can be contained inside its parent using the <CodeInline>Absolute</CodeInline> property and css <CodeInline>Style="position: relative;"</CodeInline></Description>
             </SectionHeader>
             <SectionContent Outlined="true" AutoMarginContent="false">
                 <OverlayAbsoluteExample />


### PR DESCRIPTION
Fixes #1670
For the SubTitle, I used the [first line](https://material.io/develop/ios/supporting/overlay-window).

