### PR TITLE
Fixes #1801 - table padding issue caused by #1725

### DIFF
--- a/src/MudBlazor/Styles/components/_table.scss
+++ b/src/MudBlazor/Styles/components/_table.scss
@@ -129,7 +129,6 @@
         & .mud-table-cell:last-child {
             padding-right: 16px;
             padding-inline-end: 16px;
-            padding-inline-start: unset;
         }
     }
 }


### PR DESCRIPTION
Fixes #1801

Start padding of the last table cell was set to 0 on `dense` tables. This became apparent on tables with  `Dense="true"` and `Bordered="true"`.

Before fix:
![grafik](https://user-images.githubusercontent.com/62108893/121199897-974afb80-c873-11eb-888b-e3b5b2547758.png)


After fix:
![grafik](https://user-images.githubusercontent.com/62108893/121199855-8ef2c080-c873-11eb-8847-96bae4d2d96e.png)
