### PR TITLE
Docs, API pages: Add public methods and general improvements

### DIFF
--- a/src/MudBlazor.Docs/Components/DocsApi.razor
+++ b/src/MudBlazor.Docs/Components/DocsApi.razor
@@ -13,61 +13,85 @@
                     Title="@Type.ConvertToCSharpSource()" SubTitle="API documentation">
     </DocsPageHeader>
     <DocsPageContent>
-        <DocsPageSection>
-            <SectionHeader Title="Properties" />
-            <SectionContent Class="docs-content-api" FullWidth="true">
-                <MudTable Items="@Properties" Elevation="0" Class="mx-0" Breakpoint="@Breakpoint.Sm">
-                    <HeaderContent>
-                        <MudTh>Name</MudTh>
-                        <MudTh>Type</MudTh>
-                        <MudTd>Default</MudTd>
-                        <MudTh>Description</MudTh>
-                    </HeaderContent>
-                    <RowTemplate>
-                        <MudTd Class="docs-content-api-cell" DataLabel="Name"><CodeInline>@context.Name</CodeInline></MudTd>
-                        <MudTd Class="docs-content-api-cell" DataLabel="Type"><div style="display: flex; flex-direction: row; align-items: center; white-space: nowrap;">@context.Type<DocsBinding IsTwoWay="@context.IsTwoWay" /></div></MudTd>
-                        <MudTd Class="docs-content-api-cell" DataLabel="Default">@PresentDefaultValue(context.Default)</MudTd>
-                        <MudTd Class="docs-content-api-cell docs-content-api-description" DataLabel="Description"><DocsObsolete PropertyInfo="@context.PropertyInfo" />@(HttpUtility.HtmlDecode(context.Description))</MudTd>
-                    </RowTemplate>
-                </MudTable>
-            </SectionContent>
-        </DocsPageSection>
+
+        @if (Properties?.Count() > 0)
+        {
+            <DocsPageSection>
+                <SectionHeader Title="Properties" />
+                <SectionContent Class="docs-content-api" FullWidth="true">
+                    <MudTable Items="@Properties" Elevation="0" Class="mx-0" Breakpoint="@Breakpoint.Sm">
+                        <HeaderContent>
+                            <MudTh>Name</MudTh>
+                            <MudTh>Type</MudTh>
+                            <MudTd>Default</MudTd>
+                            <MudTh>Description</MudTh>
+                        </HeaderContent>
+                        <RowTemplate>
+                            <MudTd Class="docs-content-api-cell" DataLabel="Name"><CodeInline>@context.Name</CodeInline></MudTd>
+                            <MudTd Class="docs-content-api-cell" DataLabel="Type"><div style="display: flex; flex-direction: row; align-items: center; white-space: nowrap;">@context.Type<DocsBinding IsTwoWay="@context.IsTwoWay" /></div></MudTd>
+                            <MudTd Class="docs-content-api-cell" DataLabel="Default">@PresentDefaultValue(context.Default)</MudTd>
+                            <MudTd Class="docs-content-api-cell docs-content-api-description" DataLabel="Description">@(HttpUtility.HtmlDecode(context.Description))</MudTd>
+                        </RowTemplate>
+                    </MudTable>
+                </SectionContent>
+            </DocsPageSection>
+        }
+
+        @if (EventCallbacks?.Count() > 0)
+        {
+            <DocsPageSection>
+                <SectionHeader Title="EventCallbacks" />
+                <SectionContent Class="docs-content-api" FullWidth="true">
+                    <MudTable Items="@EventCallbacks" Elevation="0" Class="mx-0" Breakpoint="@Breakpoint.Sm">
+                        <HeaderContent>
+                            <MudTh>Name</MudTh>
+                            <MudTh>Type</MudTh>
+                            <MudTh>Description</MudTh>
+                        </HeaderContent>
+                        <RowTemplate>
+                            <MudTd Class="docs-content-api-cell" DataLabel="Name"><CodeInline>@context.Name</CodeInline></MudTd>
+                            <MudTd Class="docs-content-api-cell" DataLabel="Type"><div style="display: flex; flex-direction: row; align-items: center; white-space: nowrap;">@context.Type<DocsBinding IsTwoWay="@context.IsTwoWay" /></div></MudTd>
+                            <MudTd Class="docs-content-api-cell docs-content-api-description" DataLabel="Description">@(HttpUtility.HtmlDecode(context.Description))</MudTd>
+                        </RowTemplate>
+                    </MudTable>
+                </SectionContent>
+            </DocsPageSection>
+        }
+
         @if (Methods?.Count() > 0)
         {
-        <DocsPageSection>
-            <SectionHeader>
-                <Title>Methods</Title>
-            </SectionHeader>
-            <SectionContent Class="docs-content-api" FullWidth="true">
-                <MudTable Items="@Methods" Elevation="0" Class="mx-0" Breakpoint="@Breakpoint.Sm">
-                    <HeaderContent>
-                        <MudTh>Name</MudTh>
-                        <MudTd>Parameters</MudTd>
-                        <MudTh>Return</MudTh>
-                        <MudTh>Description</MudTh>
-                    </HeaderContent>
-                    <RowTemplate>
-                        <MudTd Class="docs-content-api-cell" DataLabel="Name"><CodeInline>@context.MethodInfo.Name</CodeInline></MudTd>
-                        <MudTd Class="docs-content-api-cell" DataLabel="Parameters">
-                         @if (context.Parameters != null)
-                         {
-                             foreach (var parameterInfo in context.Parameters)
-                             {
-                                <div style="display: flex; flex-direction: row; align-items: center; white-space: nowrap;">@($"{parameterInfo.ParameterType.ConvertToCSharpSource()} {parameterInfo.Name}{AnalyseMethodDocumentation(context.Documentation, "param", parameterInfo.Name)}")</div>
-                             }
-                         }
-                         </MudTd>
-                        <MudTd Class="docs-content-api-cell" DataLabel="Return">
-                        @if (@context.Return != null && context.Return.ParameterType.ConvertToCSharpSource() != "Void")
-                        {
-                            <div style="display: flex; flex-direction: row; align-items: center; white-space: nowrap;">@($"{context.Return.ParameterType.ConvertToCSharpSource()}{AnalyseMethodDocumentation(context.Documentation, "returns")}")</div>
-                        }
-                        </MudTd>
-                        <MudTd Class="docs-content-api-cell docs-content-api-description" DataLabel="Description"><DocsObsolete MethodInfo="@context.MethodInfo" />@(HttpUtility.HtmlDecode(AnalyseMethodDocumentation(context.Documentation, "summary")))</MudTd>
-                    </RowTemplate>
-                </MudTable>
-            </SectionContent>
-        </DocsPageSection>
+            <DocsPageSection>
+                <SectionHeader Title="Methods" />>
+                <SectionContent Class="docs-content-api" FullWidth="true">
+                    <MudTable Items="@Methods" Elevation="0" Class="mx-0" Breakpoint="@Breakpoint.Sm">
+                        <HeaderContent>
+                            <MudTh>Name</MudTh>
+                            <MudTd>Parameters</MudTd>
+                            <MudTh>Return</MudTh>
+                            <MudTh>Description</MudTh>
+                        </HeaderContent>
+                        <RowTemplate>
+                            <MudTd Class="docs-content-api-cell" DataLabel="Name"><CodeInline>@context.MethodInfo.Name</CodeInline></MudTd>
+                            <MudTd Class="docs-content-api-cell" DataLabel="Parameters">
+                            @if (context.Parameters != null)
+                            {
+                                foreach (var parameterInfo in context.Parameters)
+                                {
+                                    <div style="display: flex; flex-direction: row; align-items: center; white-space: nowrap;">@($"{parameterInfo.ParameterType.ConvertToCSharpSource()} {parameterInfo.Name}{AnalyseMethodDocumentation(context.Documentation, "param", parameterInfo.Name)}")</div>
+                                }
+                            }
+                            </MudTd>
+                            <MudTd Class="docs-content-api-cell" DataLabel="Return">
+                            @if (@context.Return != null && context.Return.ParameterType.ConvertToCSharpSource() != "Void")
+                            {
+                                <div style="display: flex; flex-direction: row; align-items: center; white-space: nowrap;">@($"{context.Return.ParameterType.ConvertToCSharpSource()}{AnalyseMethodDocumentation(context.Documentation, "returns")}")</div>
+                            }
+                            </MudTd>
+                            <MudTd Class="docs-content-api-cell docs-content-api-description" DataLabel="Description">@(HttpUtility.HtmlDecode(AnalyseMethodDocumentation(context.Documentation, "summary")))</MudTd>
+                        </RowTemplate>
+                    </MudTable>
+                </SectionContent>
+            </DocsPageSection>
         }
     </DocsPageContent>
 </DocsPage>
@@ -88,6 +112,28 @@
     };
     [Parameter] public Type Type { get; set; }
 
+    private IEnumerable<ApiProperty> EventCallbacks
+    {
+        get
+        {
+            foreach (var info in Type.GetPropertyInfosWithAttribute<ParameterAttribute>().OrderBy(x => x.Name))
+            {
+                if (info.GetCustomAttributes(typeof(System.ObsoleteAttribute), true).Length == 0 && info.PropertyType.Name.Contains("EventCallback"))
+                {
+                    yield return new ApiProperty()
+                    {
+                        Name = info.Name,
+                        PropertyInfo = info,
+                        Default = string.Empty,
+                        IsTwoWay = CheckIsTwoWay(info),
+                        Description = GetDescription(Type, info),
+                        Type = info.PropertyType.ConvertToCSharpSource(),
+                    };
+                }
+            }
+        }
+    }
+
     private IEnumerable<ApiMethod> Methods
     {
         get
@@ -96,13 +142,16 @@
             {
                 if (!hiddenMethods.Any(x => x.Contains(info.Name)) && !info.Name.StartsWith("get_") && !info.Name.StartsWith("set_"))
                 {
-                    yield return new ApiMethod()
+                    if (info.GetCustomAttributes(typeof(System.ObsoleteAttribute), true).Length == 0)
                     {
-                        MethodInfo = info,
-                        Return = info.ReturnParameter,
-                        Parameters = info.GetParameters(),
-                        Documentation = info.GetDocumentation()
-                    };
+                        yield return new ApiMethod()
+                        {
+                            MethodInfo = info,
+                            Return = info.ReturnParameter,
+                            Parameters = info.GetParameters(),
+                            Documentation = info.GetDocumentation()
+                        };
+                    }
                 }
             }
         }
@@ -114,18 +163,22 @@
         {
             foreach (var info in Type.GetPropertyInfosWithAttribute<ParameterAttribute>().OrderBy(x => x.Name))
             {
-                yield return new ApiProperty()
+                if (info.GetCustomAttributes(typeof(System.ObsoleteAttribute), true).Length == 0 && !info.PropertyType.Name.Contains("EventCallback"))
                 {
-                    Name = info.Name,
-                    PropertyInfo = info,
-                    IsTwoWay = CheckIsTwoWay(info),
-                    Description = GetDescription(Type, info),
-                    Type = info.PropertyType.ConvertToCSharpSource(),
-                    Default = GetDefaultValue(info) == null ? null : GetDefaultValue(info).ToString().Contains("EventCallback") ? "" : GetDefaultValue(info),
-                };
+                    yield return new ApiProperty()
+                    {
+                        Name = info.Name,
+                        PropertyInfo = info,
+                        IsTwoWay = CheckIsTwoWay(info),
+                        Description = GetDescription(Type, info),
+                        Type = info.PropertyType.ConvertToCSharpSource(),
+                        Default = GetDefaultValue(info) == null ? null : GetDefaultValue(info).ToString().Contains("EventCallback") ? "" : GetDefaultValue(info),
+                    };
+                }
             }
         }
     }
+
 
     private string AnalyseMethodDocumentation(string documentation, string occurence, string parameter = "")
     {
@@ -210,7 +263,7 @@
         return null;
     }
 
-     DefaultConverter<object> _converter = new DefaultConverter<object>() { Culture= CultureInfo.InvariantCulture };
+    DefaultConverter<object> _converter = new DefaultConverter<object>() { Culture= CultureInfo.InvariantCulture };
 
     private string PresentDefaultValue(object @default)
     {

--- a/src/MudBlazor.Docs/Components/DocsApi.razor
+++ b/src/MudBlazor.Docs/Components/DocsApi.razor
@@ -172,7 +172,7 @@
                         IsTwoWay = CheckIsTwoWay(info),
                         Description = GetDescription(Type, info),
                         Type = info.PropertyType.ConvertToCSharpSource(),
-                        Default = GetDefaultValue(info) == null ? null : GetDefaultValue(info).ToString().Contains("EventCallback") ? "" : GetDefaultValue(info),
+                        Default = GetDefaultValue(info)
                     };
                 }
             }

--- a/src/MudBlazor.Docs/Components/DocsApi.razor
+++ b/src/MudBlazor.Docs/Components/DocsApi.razor
@@ -25,13 +25,50 @@
                     </HeaderContent>
                     <RowTemplate>
                         <MudTd Class="docs-content-api-cell" DataLabel="Name"><CodeInline>@context.Name</CodeInline></MudTd>
-                        <MudTd Class="docs-content-api-cell" DataLabel="Type">@context.Type</MudTd>
+                        <MudTd Class="docs-content-api-cell" DataLabel="Type"><div style="display: flex; flex-direction: row; align-items: center; white-space: nowrap;">@context.Type<DocsBinding IsTwoWay="@context.IsTwoWay" /></div></MudTd>
                         <MudTd Class="docs-content-api-cell" DataLabel="Default">@PresentDefaultValue(context.Default)</MudTd>
-                        <MudTd Class="docs-content-api-cell docs-content-api-description" DataLabel="Description">@(HttpUtility.HtmlDecode(context.Description))</MudTd>
+                        <MudTd Class="docs-content-api-cell docs-content-api-description" DataLabel="Description"><DocsObsolete PropertyInfo="@context.PropertyInfo" />@(HttpUtility.HtmlDecode(context.Description))</MudTd>
                     </RowTemplate>
                 </MudTable>
             </SectionContent>
         </DocsPageSection>
+        @if (Methods?.Count() > 0)
+        {
+        <DocsPageSection>
+            <SectionHeader>
+                <Title>Methods</Title>
+            </SectionHeader>
+            <SectionContent Class="docs-content-api" FullWidth="true">
+                <MudTable Items="@Methods" Elevation="0" Class="mx-0" Breakpoint="@Breakpoint.Sm">
+                    <HeaderContent>
+                        <MudTh>Name</MudTh>
+                        <MudTd>Parameters</MudTd>
+                        <MudTh>Return</MudTh>
+                        <MudTh>Description</MudTh>
+                    </HeaderContent>
+                    <RowTemplate>
+                        <MudTd Class="docs-content-api-cell" DataLabel="Name"><CodeInline>@context.MethodInfo.Name</CodeInline></MudTd>
+                        <MudTd Class="docs-content-api-cell" DataLabel="Parameters">
+                         @if (context.Parameters != null)
+                         {
+                             foreach (var parameterInfo in context.Parameters)
+                             {
+                                <div style="display: flex; flex-direction: row; align-items: center; white-space: nowrap;">@($"{parameterInfo.ParameterType.ConvertToCSharpSource()} {parameterInfo.Name}{AnalyseMethodDocumentation(context.Documentation, "param", parameterInfo.Name)}")</div>
+                             }
+                         }
+                         </MudTd>
+                        <MudTd Class="docs-content-api-cell" DataLabel="Return">
+                        @if (@context.Return != null && context.Return.ParameterType.ConvertToCSharpSource() != "Void")
+                        {
+                            <div style="display: flex; flex-direction: row; align-items: center; white-space: nowrap;">@($"{context.Return.ParameterType.ConvertToCSharpSource()}{AnalyseMethodDocumentation(context.Documentation, "returns")}")</div>
+                        }
+                        </MudTd>
+                        <MudTd Class="docs-content-api-cell docs-content-api-description" DataLabel="Description"><DocsObsolete MethodInfo="@context.MethodInfo" />@(HttpUtility.HtmlDecode(AnalyseMethodDocumentation(context.Documentation, "summary")))</MudTd>
+                    </RowTemplate>
+                </MudTable>
+            </SectionContent>
+        </DocsPageSection>
+        }
     </DocsPageContent>
 </DocsPage>
 
@@ -40,27 +77,102 @@
 </div>
 
 @code {
-
+    private List<string> hiddenMethods = new List<string>()
+    {
+        "ToString",
+        "GetType",
+        "GetHashCode",
+        "Equals",
+        "SetParametersAsync",
+        "ReferenceEquals"
+    };
     [Parameter] public Type Type { get; set; }
+
+    private IEnumerable<ApiMethod> Methods
+    {
+        get
+        {
+            foreach (var info in Type.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.FlattenHierarchy | BindingFlags.Static).OrderBy(x => x.Name))
+            {
+                if (!hiddenMethods.Any(x => x.Contains(info.Name)) && !info.Name.StartsWith("get_") && !info.Name.StartsWith("set_"))
+                {
+                    yield return new ApiMethod()
+                    {
+                        MethodInfo = info,
+                        Return = info.ReturnParameter,
+                        Parameters = info.GetParameters(),
+                        Documentation = info.GetDocumentation()
+                    };
+                }
+            }
+        }
+    }
 
     private IEnumerable<ApiProperty> Properties
     {
         get
         {
-            foreach (var info in Type.GetPropertyInfosWithAttribute<ParameterAttribute>())
+            foreach (var info in Type.GetPropertyInfosWithAttribute<ParameterAttribute>().OrderBy(x => x.Name))
             {
-                if (info.GetCustomAttributes(typeof(System.ObsoleteAttribute), true).Length == 0)
+                yield return new ApiProperty()
                 {
-                    yield return new ApiProperty()
-                    {
-                        Name=info.Name,
-                        Type = info.PropertyType.ConvertToCSharpSource(),
-                        Description = GetDescription(Type, info),
-                        Default = GetDefaultValue(info),
-                    };
+                    Name = info.Name,
+                    PropertyInfo = info,
+                    IsTwoWay = CheckIsTwoWay(info),
+                    Description = GetDescription(Type, info),
+                    Type = info.PropertyType.ConvertToCSharpSource(),
+                    Default = GetDefaultValue(info) == null ? null : GetDefaultValue(info).ToString().Contains("EventCallback") ? "" : GetDefaultValue(info),
+                };
+            }
+        }
+    }
+
+    private string AnalyseMethodDocumentation(string documentation, string occurence, string parameter = "")
+    {
+        try
+        {
+            // Define local variable
+            string doublequotes = @"""";
+
+            // Define the start tag and the end tag
+            string endTag = $"</{occurence}>";
+            string startTag = $"<{occurence}{(parameter == string.Empty ? "" : " name=" + doublequotes + parameter + doublequotes)}>";
+
+            // Check if the documentation is valid and contains the start tag
+            if (documentation != null && documentation.Contains(startTag))
+            {
+                // Remove the beginnig of the documentation until the start tag
+                documentation = documentation.Substring(documentation.IndexOf(startTag), documentation.Length - documentation.IndexOf(startTag));
+
+                // Check if the documentation contains the end tag
+                if (documentation.Contains(endTag))
+                {
+                    // Return the extracted information
+                    // If the information is not for summary, ' : ' is only added if there is a non-empty information to be returned
+                    return (occurence != "summary" && documentation.Substring(startTag.Length, documentation.IndexOf(endTag) - startTag.Length).Trim() != "" ? " : " : "") +
+                        documentation.Substring(startTag.Length, documentation.IndexOf(endTag) - startTag.Length).Trim();
                 }
             }
         }
+        catch
+        {
+            // ignored
+        }
+
+        return string.Empty;
+    }
+
+    private bool CheckIsTwoWay(PropertyInfo propertyInfo)
+    {
+        foreach (MethodInfo methodInfo in propertyInfo.GetAccessors())
+        {
+            if (methodInfo.Name.StartsWith("set") && methodInfo.IsPublic)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private string GetDescription(Type type, PropertyInfo info)
@@ -98,30 +210,23 @@
         return null;
     }
 
-    // TODO: document public methods later
-    //IEnumerable<ApiMethod> Methods {
-    //    get {
-    //        foreach (var info in Type.GetMethods(BindingFlags.Instance|BindingFlags.Public))
-    //        {
-    //            var doc=info.GetDocumentation();
-    //            doc = Regex.Replace(doc??"", @"</?.+?>", "");
-    //            yield return new ApiItem()
-    //            {
-    //                Name=info.Name, 
-    //                ReturnType = info.PropertyType.ConvertToCSharpSource(), 
-    //                Description = doc
-    //            };
-    //        }
-    //    }
-    //}
-    DefaultConverter<object> _converter = new DefaultConverter<object>() { Culture= CultureInfo.InvariantCulture };
+     DefaultConverter<object> _converter = new DefaultConverter<object>() { Culture= CultureInfo.InvariantCulture };
 
     private string PresentDefaultValue(object @default)
     {
         if (@default == null)
             return "null";
-        if (@default.GetType()==typeof(string))
-            return $"\"{@default}\"";
+        if (@default.GetType() == typeof(string))
+        {
+            if (@default.ToString() == string.Empty)
+            {
+                return "";
+            }
+            else
+            {
+                return $"\"{@default}\"";
+            }
+        }
         if (@default.GetType().IsEnum)
             return $"{@default.GetType().Name}.{@default}";
         if (Nullable.GetUnderlyingType(@default.GetType())!=null)
@@ -132,5 +237,4 @@
             return _converter.Set( @default);
         return "";
     }
-
 }

--- a/src/MudBlazor.Docs/Components/DocsApi.razor
+++ b/src/MudBlazor.Docs/Components/DocsApi.razor
@@ -4,6 +4,7 @@
 @using System.Web
 @using Microsoft.Extensions.DependencyInjection
 @using System.Globalization
+@using MudBlazor.Docs.Extensions
 @namespace MudBlazor.Docs.Components
 
 
@@ -71,20 +72,20 @@
                             <MudTh>Description</MudTh>
                         </HeaderContent>
                         <RowTemplate>
-                            <MudTd Class="docs-content-api-cell" DataLabel="Name"><CodeInline>@context.MethodInfo.Name</CodeInline></MudTd>
+                            <MudTd Class="docs-content-api-cell" DataLabel="Name"><CodeInline>@context.Signature</CodeInline></MudTd>
                             <MudTd Class="docs-content-api-cell" DataLabel="Parameters">
                             @if (context.Parameters != null)
                             {
                                 foreach (var parameterInfo in context.Parameters)
                                 {
-                                    <div style="display: flex; flex-direction: row; align-items: center; white-space: nowrap;">@($"{parameterInfo.ParameterType.ConvertToCSharpSource()} {parameterInfo.Name}{AnalyseMethodDocumentation(context.Documentation, "param", parameterInfo.Name)}")</div>
+                                    <div style="display: flex; flex-direction: row; align-items: center; white-space: nowrap;">@($"{GetGenericTypeName(parameterInfo.ParameterType.ConvertToCSharpSource())} {parameterInfo.Name}{AnalyseMethodDocumentation(context.Documentation, "param", parameterInfo.Name)}")</div>
                                 }
                             }
                             </MudTd>
                             <MudTd Class="docs-content-api-cell" DataLabel="Return">
                             @if (@context.Return != null && context.Return.ParameterType.ConvertToCSharpSource() != "Void")
                             {
-                                <div style="display: flex; flex-direction: row; align-items: center; white-space: nowrap;">@($"{context.Return.ParameterType.ConvertToCSharpSource()}{AnalyseMethodDocumentation(context.Documentation, "returns")}")</div>
+                                <div style="display: flex; flex-direction: row; align-items: center; white-space: nowrap;">@($"{GetGenericTypeName(context.Return.ParameterType.ConvertToCSharpSource())}{AnalyseMethodDocumentation(context.Documentation, "returns")}")</div>
                             }
                             </MudTd>
                             <MudTd Class="docs-content-api-cell docs-content-api-description" DataLabel="Description">@(HttpUtility.HtmlDecode(AnalyseMethodDocumentation(context.Documentation, "summary")))</MudTd>
@@ -101,6 +102,16 @@
 </div>
 
 @code {
+
+    private string GetGenericTypeName(string value)
+    {
+        switch (value)
+        {
+            case "Int32": return "Int";
+            case "Int16": return "Int";
+            default: return value;
+        }
+    }
     private List<string> hiddenMethods = new List<string>()
     {
         "ToString",
@@ -148,6 +159,7 @@
                         {
                             MethodInfo = info,
                             Return = info.ReturnParameter,
+                            Signature = info.GetSignature(),
                             Parameters = info.GetParameters(),
                             Documentation = info.GetDocumentation()
                         };

--- a/src/MudBlazor.Docs/Components/DocsBinding.razor
+++ b/src/MudBlazor.Docs/Components/DocsBinding.razor
@@ -1,0 +1,17 @@
+﻿@if (IsTwoWay)
+{
+    <MudTooltip Text="Binding TwoWay" Placement="Placement.Top">
+        <MudIcon Icon="@Icons.Material.Filled.SyncAlt" Color="Color.Default" Class="ml-2 mt-2" />
+    </MudTooltip>
+}
+else
+{
+    <MudTooltip Text="Binding OneWay" Placement="Placement.Top">
+        <MudIcon Icon="@Icons.Material.Filled.TrendingFlat" Color="Color.Default" Class="ml-2 mt-2" />
+    </MudTooltip>
+}
+
+
+@code {
+    [Parameter] public bool IsTwoWay { get; set;}
+}

--- a/src/MudBlazor.Docs/Components/DocsObsolete.razor
+++ b/src/MudBlazor.Docs/Components/DocsObsolete.razor
@@ -1,0 +1,51 @@
+﻿@using System.Reflection
+
+@if (foundObsoleteMethod)
+{
+    <CodeInline SecondaryColor="true">Obsolete</CodeInline> @descriptionObsoleteMethod
+}
+@if (foundObsoleteProperty)
+{
+    <CodeInline SecondaryColor="true">Obsolete</CodeInline> @descriptionObsoleteProperty
+}
+
+@code {
+    private bool foundObsoleteMethod;
+    private bool foundObsoleteProperty;
+    private string descriptionObsoleteMethod = string.Empty;
+    private string descriptionObsoleteProperty = string.Empty;
+    [Parameter] public MethodInfo MethodInfo { get; set; }
+    [Parameter] public PropertyInfo PropertyInfo { get; set; }
+
+    protected override void OnInitialized()
+    {
+        SearchObsoleteMethod();
+        SearchObsoleteProperty();
+    }
+
+    private void SearchObsoleteMethod()
+    {
+        if (MethodInfo != null)
+        {
+            // Define object attributes associated to the method
+            object[] attributes = MethodInfo.GetCustomAttributes(false);
+
+            // Parse all obsolete attributes
+            foreach (ObsoleteAttribute attribute in attributes.OfType<ObsoleteAttribute>())
+            {
+                foundObsoleteMethod = true;
+                descriptionObsoleteMethod += attribute.Message + " ";
+            }
+        }
+    }
+
+    private void SearchObsoleteProperty()
+    {
+        if (PropertyInfo != null && PropertyInfo.GetCustomAttribute(typeof(ObsoleteAttribute), false) != null)
+        {
+            foundObsoleteProperty = true;
+            ObsoleteAttribute attribute = (ObsoleteAttribute)PropertyInfo.GetCustomAttribute(typeof(ObsoleteAttribute), false);
+            descriptionObsoleteProperty += attribute.Message + " ";
+        }
+    }
+}

--- a/src/MudBlazor.Docs/Extensions/MethodInfoExtensions.cs
+++ b/src/MudBlazor.Docs/Extensions/MethodInfoExtensions.cs
@@ -1,0 +1,165 @@
+﻿using System;
+using System.Reflection;
+using System.Text;
+
+namespace MudBlazor.Docs.Extensions
+{
+    // Adaptation from : https://stackoverflow.com/questions/1312166/print-full-signature-of-a-method-from-a-methodinfo/1312321
+    public static class MethodInfoExtensions
+    {
+        /// <summary>
+        /// Return the method signature as a string.
+        /// </summary>
+        /// <param name="method">The Method</param>
+        /// <param name="callable">Return as an callable string(public void a(string b) would return a(b))</param>
+        /// <returns>Method signature</returns>
+        public static string GetSignature(this MethodInfo method, bool callable = false)
+        {
+            // Define local variables
+            var firstParameter = true;
+            var secondParameter = false;
+            var stringBuilder = new StringBuilder();
+
+            // Define the method access
+            if (callable == false)
+            {
+                // Append return type
+                stringBuilder.Append(TypeName(method.ReturnType));
+                stringBuilder.Append(' ');
+            }
+
+            // Add the name of the method
+            stringBuilder.Append(method.Name);
+
+            // Add generics method
+            if (method.IsGenericMethod)
+            {
+                stringBuilder.Append('<');
+
+                foreach (var genericArgument in method.GetGenericArguments())
+                {
+                    if (firstParameter)
+                    {
+                        firstParameter = false;
+                    }
+                    else
+                    {
+                        stringBuilder.Append(", ");
+                    }
+
+                    stringBuilder.Append(TypeName(genericArgument));
+                }
+
+                stringBuilder.Append('>');
+            }
+
+            stringBuilder.Append('(');
+            firstParameter = true;
+
+            foreach (var parameter in method.GetParameters())
+            {
+                if (firstParameter)
+                {
+                    firstParameter = false;
+
+                    if (method.IsDefined(typeof(System.Runtime.CompilerServices.ExtensionAttribute), false))
+                    {
+                        if (callable)
+                        {
+                            secondParameter = true;
+                            continue;
+                        }
+                        stringBuilder.Append("this ");
+                    }
+                }
+                else if (secondParameter == true)
+                {
+                    secondParameter = false;
+                }
+                else
+                {
+                    stringBuilder.Append(", ");
+                }
+
+                if (parameter.ParameterType.IsByRef)
+                {
+                    stringBuilder.Append("ref ");
+                }
+                else if (parameter.IsOut)
+                {
+                    stringBuilder.Append("out ");
+                }
+
+                if (!callable)
+                {
+                    stringBuilder.Append(TypeName(parameter.ParameterType));
+                    stringBuilder.Append(' ');
+                }
+
+                stringBuilder.Append(parameter.Name);
+            }
+
+            stringBuilder.Append(')');
+
+            // Return final result
+            return stringBuilder.ToString();
+        }
+
+        /// <summary>
+        /// Get full type name with full namespace names
+        /// </summary>
+        /// <param name="type">Type. May be generic or nullable</param>
+        /// <returns>Full type name, fully qualified namespaces</returns>
+        private static string TypeName(Type type)
+        {
+            var first = true;
+            var nullableType = Nullable.GetUnderlyingType(type);
+
+            if (nullableType != null)
+            {
+                return Cleaning(nullableType.Name + "?");
+            }
+
+            if (!(type.IsGenericType && type.Name.Contains('`')))
+            {
+                switch (type.Name)
+                {
+                    case "String": return "string";
+                    case "Int32": return "int";
+                    case "Int16": return "int";
+                    case "Double": return "double";
+                    case "Decimal": return "decimal";
+                    case "Object": return "object";
+                    case "Void": return "";
+                    case "Boolean": return "bool";
+                    default:
+                        {
+                            return Cleaning(string.IsNullOrWhiteSpace(type.FullName) ? type.Name : type.FullName);
+                        }
+                }
+            }
+
+            var stringBuilder = new StringBuilder(type.Name.Substring(0, type.Name.IndexOf('`')));
+            stringBuilder.Append('<');
+
+            foreach (var t in type.GetGenericArguments())
+            {
+                if (!first)
+                {
+                    stringBuilder.Append(',');
+                }
+                stringBuilder.Append(TypeName(t));
+                first = false;
+            }
+            stringBuilder.Append('>');
+
+            // Return result
+            return Cleaning(stringBuilder.ToString());
+        }
+
+        private static string Cleaning(string value)
+        {
+            return value.Replace("System.Threading.Tasks.", "").Replace("System.", "").Replace("MudBlazor.", "");
+        }
+    }
+}

--- a/src/MudBlazor.Docs/Models/ApiMethod.cs
+++ b/src/MudBlazor.Docs/Models/ApiMethod.cs
@@ -5,6 +5,7 @@ namespace MudBlazor.Docs.Models
 {
     public class ApiMethod
     {
+        public string Signature { get; set; }
         public ParameterInfo Return { get; set; }
         public string Documentation { get; set; }
         public MethodInfo MethodInfo { get; set; }

--- a/src/MudBlazor.Docs/Models/ApiMethod.cs
+++ b/src/MudBlazor.Docs/Models/ApiMethod.cs
@@ -1,0 +1,13 @@
+﻿using System.Reflection;
+
+
+namespace MudBlazor.Docs.Models
+{
+    public class ApiMethod
+    {
+        public ParameterInfo Return { get; set; }
+        public string Documentation { get; set; }
+        public MethodInfo MethodInfo { get; set; }
+        public ParameterInfo[] Parameters { get; set; }
+    }
+}

--- a/src/MudBlazor.Docs/Models/ApiProperty.cs
+++ b/src/MudBlazor.Docs/Models/ApiProperty.cs
@@ -1,10 +1,14 @@
-﻿namespace MudBlazor.Docs.Models
+﻿using System.Reflection;
+
+namespace MudBlazor.Docs.Models
 {
     public class ApiProperty
     {
         public string Name { get; set; }
         public string Type { get; set; }
+        public PropertyInfo PropertyInfo { get; set; }
         public string Description { get; set; }
         public object Default { get; set; }
+        public bool IsTwoWay { get; set; }
     }
 }


### PR DESCRIPTION
Implementation of the  [API documentation improvements](https://github.com/Garderoben/MudBlazor/issues/1805) issue.

**Changes**

* A _Method_ section has been added.
* _Obsolete_ methods are displayed.
* _Obsolete_ properties are displayed.
* If the component does not have a method, the _Methods_ section is not displayed.
* An icon is shown when the property is bindable in both directions.
* An icon is shown when the property is unidirectional.
* Simple _EventCallbacks_ are displayed as an empty string in the _Default_ column.

**Notes**

* All API pages have been tested without failure.
* The following methods are not displayed. Should they be present in the Methods section?
```C#
* ToString
* GetType
* GetHashCode
* Equals
* SetParametersAsync
* ReferenceEquals
```
* The list of properties is only with type ```[Parameter]```. Should it be modified?

![Example](https://user-images.githubusercontent.com/16502423/121240566-c4f76b00-c89a-11eb-9347-8494380eebff.png)