### PR TITLE
MudSelect and MudAutocomplete Adornment improvements

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Autocomplete/AutocompletePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Autocomplete/AutocompletePage.razor
@@ -3,7 +3,7 @@
 
 <DocsPage>
     <DocsPageHeader Title="Autocomplete"
-        SubTitle="The autocomplete component offers simple and flexible type-ahead functionality.">
+        SubTitle="The Autocomplete component offers simple and flexible type-ahead functionality.">
         <Description>
             It is great for searching a value from a long list of options. In comparison to a Select, the Autocomplete doesn't need to know the complete item list, 
             it only calls a search function which will return matching items. The search function can even run asynchronously, i.e. for database queries.

--- a/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompleteUsageExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompleteUsageExample.razor
@@ -9,7 +9,8 @@
     <MudItem xs="12" sm="6" md="4">
         <MudAutocomplete T="string" Label="US States" @bind-Value="value2" SearchFunc="@Search2" 
                          ResetValueOnEmptyText="@resetValueOnEmptyText" 
-                         CoerceText="@coerceText"  CoerceValue="@coerceValue"/>
+                         CoerceText="@coerceText"  CoerceValue="@coerceValue"
+                         AdornmentIcon="@Icons.Material.Filled.Search" AdornmentColor="Color.Primary" />
     </MudItem>
     <MudItem xs="12" md="12">
         <MudText Class="mb-n3" Typo="Typo.body2">

--- a/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompleteValidationExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompleteValidationExample.razor
@@ -6,6 +6,7 @@
         <EditForm EditContext="editContext1">
         <DataAnnotationsValidator />
             <MudAutocomplete Label="US States" @bind-Value="choice1.State" 
+             AdornmentIcon="@Icons.Material.Filled.Search" AdornmentColor="Color.Primary"
              SearchFunc="@SearchAsync" Immediate="true" CoerceValue="@coerceValue"
              For="@(() => choice1.State)"/>
             <MudButton ButtonType="ButtonType.Button" Variant="Variant.Filled" Color="Color.Primary" 
@@ -30,6 +31,7 @@
         <EditForm EditContext="editContext2">
         <DataAnnotationsValidator />
             <MudAutocomplete Label="US States" @bind-Value="choice2.State" 
+             OpenIcon="@Icons.Material.Filled.Search" AdornmentColor="Color.Secondary"
              SearchFunc="@SearchAsync" Immediate="true" CoerceValue="@coerceValue"
              Validation="@(new Func<string, IEnumerable<string>>(Validate))" />
             <MudButton ButtonType="ButtonType.Button" Variant="Variant.Filled" Color="Color.Primary" 
@@ -53,6 +55,7 @@
     <MudItem xs="12" sm="6" md="4">
         <MudForm @ref="form" @bind-Errors="@errors">
             <MudAutocomplete T="string" Label="US States" @bind-Value="choice3.State" 
+             CloseIcon="@Icons.Material.Filled.Search" AdornmentColor="Color.Tertiary"
              SearchFunc="@SearchAsync" Immediate="true" CoerceValue="@coerceValue"
              Validation="@(new Func<string, IEnumerable<string>>(Validate))" />
             <MudButton Variant="Variant.Filled" Color="Color.Primary" Class="ml-auto mt-3 mb-3" 

--- a/src/MudBlazor.Docs/Pages/Components/Select/Examples/MultiSelectCustomizedExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Select/Examples/MultiSelectCustomizedExample.razor
@@ -3,8 +3,9 @@
 
 <MudGrid>
     <MudItem xs="12" md="12">
-        <MudSelect T="string" Label="US States" HelperText="Pick your favorite states" MultiSelection="true" 
-         @bind-Value="value" @bind-SelectedValues="options"
+        <MudSelect T="string" Label="US States" HelperText="Pick your favorite states"
+         MultiSelection="true" OffsetY="true"
+         @bind-Value="value" @bind-SelectedValues="options" AdornmentIcon="@Icons.Material.Filled.Search"
          MultiSelectionTextFunc="@(new Func<List<string>, string>(GetMultiSelectionText))">
             @foreach (var state in states)
             {

--- a/src/MudBlazor.Docs/Pages/Components/Select/Examples/SelectDenseExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Select/Examples/SelectDenseExample.razor
@@ -1,8 +1,9 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 
-<MudSelect T="string" Label="Dense" Dense="true">
-    <MudSelectItem T="string" Value="@("Tyrannosaur")"/>
-    <MudSelectItem T="string" Value="@("Triceratops")"/>
-    <MudSelectItem T="string" Value="@("Oviraptor")"/>
+<MudSelect T="string" Label="Dense" Dense="true"
+           AdornmentIcon="@Icons.Material.Filled.Search">
+    <MudSelectItem Value="@("Tyrannosaur")"/>
+    <MudSelectItem Value="@("Triceratops")"/>
+    <MudSelectItem Value="@("Oviraptor")"/>
 </MudSelect>

--- a/src/MudBlazor.Docs/Pages/Components/Select/Examples/SelectDisabledExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Select/Examples/SelectDisabledExample.razor
@@ -1,7 +1,8 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 
-<MudSelect T="string" Label="Disabled" Disabled="true">
-    <MudSelectItem T="string" Value="@("foo")">Foo</MudSelectItem>
-    <MudSelectItem T="string" Value="@("bar")">Bar</MudSelectItem>
+<MudSelect T="string" Label="Disabled" Disabled="true"
+           AdornmentIcon="@Icons.Material.Filled.SearchOff" AdornmentColor="Color.Primary">
+    <MudSelectItem Value="@("foo")">Foo</MudSelectItem>
+    <MudSelectItem Value="@("bar")">Bar</MudSelectItem>
 </MudSelect>

--- a/src/MudBlazor.Docs/Pages/Components/Select/Examples/SelectUsageExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Select/Examples/SelectUsageExample.razor
@@ -4,14 +4,16 @@
 
 <MudGrid>
     <MudItem xs="12" sm="6" md="4">
-        <MudSelect Label="Select fast-food" @bind-Value="stringValue" HelperText="String">
+        <MudSelect Label="Select fast-food" @bind-Value="stringValue" HelperText="String"
+                   OffsetY="true" AdornmentIcon="@Icons.Material.Filled.Fastfood" AdornmentColor="Color.Primary">
             <MudSelectItem Value="@("Pizza")" Disabled="true">Pizza (Disabled)</MudSelectItem>
             <MudSelectItem Value="@("Burger")">Burger</MudSelectItem>
             <MudSelectItem Value="@("Hotdog")">Hot Dog</MudSelectItem>
         </MudSelect>
     </MudItem>
     <MudItem xs="12" sm="6" md="4">
-        <MudSelect Label="Select drink" @bind-Value="enumValue" HelperText="Enum">
+        <MudSelect Label="Select drink" @bind-Value="enumValue" HelperText="Enum"
+                   OffsetY="true" OpenIcon="@Icons.Material.Filled.LocalDrink" AdornmentColor="Color.Secondary">
             @foreach (Drink item in Enum.GetValues(typeof(Drink)))
             {
                 <MudSelectItem Value="@item">@item</MudSelectItem>
@@ -19,7 +21,8 @@
         </MudSelect>
     </MudItem>
     <MudItem xs="12" sm="6" md="4">
-        <MudSelect Placeholder="Select culture" @bind-Value="cultureValue" HelperText="CultureInfo" ToStringFunc="@convertFunc">
+        <MudSelect Placeholder="Select culture" @bind-Value="cultureValue" HelperText="CultureInfo" ToStringFunc="@convertFunc"
+                   OffsetY="true" CloseIcon="@Icons.Material.Filled.Flag" AdornmentColor="Color.Tertiary">
             <MudSelectItem Value="@(CultureInfo.GetCultureInfo("en-US"))"></MudSelectItem>
             <MudSelectItem Value="@(CultureInfo.GetCultureInfo("de-AT"))"></MudSelectItem>
             <MudSelectItem Value="@(CultureInfo.GetCultureInfo("pt-BR"))"></MudSelectItem>

--- a/src/MudBlazor.Docs/Pages/Components/Select/SelectPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Select/SelectPage.razor
@@ -14,7 +14,7 @@
                     <SelectVariantsExample />
                 </MudContainer>
             </SectionContent>
-            <SectionSource ShowCode="true" Code="SelectVariantsExample" GitHubFolderName="Select" />
+            <SectionSource ShowCode="false" Code="SelectVariantsExample" GitHubFolderName="Select" />
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>

--- a/src/MudBlazor.sln
+++ b/src/MudBlazor.sln
@@ -24,8 +24,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MudBlazor.Examples.Data", "MudBlazor.Examples.Data\MudBlazor.Examples.Data.csproj", "{D9290286-6DD8-478C-A902-23660C554A1C}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MudBlazorTestApp", "..\..\MudBlazorTestApp\MudBlazorTestApp\MudBlazorTestApp.csproj", "{BE2D48C9-8E7E-4937-BB10-B351660A498B}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -64,10 +62,6 @@ Global
 		{D9290286-6DD8-478C-A902-23660C554A1C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D9290286-6DD8-478C-A902-23660C554A1C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D9290286-6DD8-478C-A902-23660C554A1C}.Release|Any CPU.Build.0 = Release|Any CPU
-		{BE2D48C9-8E7E-4937-BB10-B351660A498B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{BE2D48C9-8E7E-4937-BB10-B351660A498B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{BE2D48C9-8E7E-4937-BB10-B351660A498B}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{BE2D48C9-8E7E-4937-BB10-B351660A498B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/MudBlazor.sln
+++ b/src/MudBlazor.sln
@@ -24,8 +24,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MudBlazor.Examples.Data", "MudBlazor.Examples.Data\MudBlazor.Examples.Data.csproj", "{D9290286-6DD8-478C-A902-23660C554A1C}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MudBlazorTestApp", "..\..\MudBlazorTestApp\MudBlazorTestApp\MudBlazorTestApp.csproj", "{5F79EB04-21DB-4150-BCFA-A307A7930ED9}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -64,10 +62,6 @@ Global
 		{D9290286-6DD8-478C-A902-23660C554A1C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D9290286-6DD8-478C-A902-23660C554A1C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D9290286-6DD8-478C-A902-23660C554A1C}.Release|Any CPU.Build.0 = Release|Any CPU
-		{5F79EB04-21DB-4150-BCFA-A307A7930ED9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{5F79EB04-21DB-4150-BCFA-A307A7930ED9}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{5F79EB04-21DB-4150-BCFA-A307A7930ED9}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{5F79EB04-21DB-4150-BCFA-A307A7930ED9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/MudBlazor.sln
+++ b/src/MudBlazor.sln
@@ -24,7 +24,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MudBlazor.Examples.Data", "MudBlazor.Examples.Data\MudBlazor.Examples.Data.csproj", "{D9290286-6DD8-478C-A902-23660C554A1C}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MudBlazorTestApp", "..\..\MudBlazorTestApp\MudBlazorTestApp\MudBlazorTestApp.csproj", "{1627AE2E-B7DF-4F78-A470-EF9FDDA74306}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MudBlazorTestApp", "..\..\MudBlazorTestApp\MudBlazorTestApp\MudBlazorTestApp.csproj", "{BE2D48C9-8E7E-4937-BB10-B351660A498B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -64,10 +64,10 @@ Global
 		{D9290286-6DD8-478C-A902-23660C554A1C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D9290286-6DD8-478C-A902-23660C554A1C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D9290286-6DD8-478C-A902-23660C554A1C}.Release|Any CPU.Build.0 = Release|Any CPU
-		{1627AE2E-B7DF-4F78-A470-EF9FDDA74306}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{1627AE2E-B7DF-4F78-A470-EF9FDDA74306}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{1627AE2E-B7DF-4F78-A470-EF9FDDA74306}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{1627AE2E-B7DF-4F78-A470-EF9FDDA74306}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BE2D48C9-8E7E-4937-BB10-B351660A498B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BE2D48C9-8E7E-4937-BB10-B351660A498B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BE2D48C9-8E7E-4937-BB10-B351660A498B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BE2D48C9-8E7E-4937-BB10-B351660A498B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/MudBlazor.sln
+++ b/src/MudBlazor.sln
@@ -24,6 +24,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MudBlazor.Examples.Data", "MudBlazor.Examples.Data\MudBlazor.Examples.Data.csproj", "{D9290286-6DD8-478C-A902-23660C554A1C}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MudBlazorTestApp", "..\..\MudBlazorTestApp\MudBlazorTestApp\MudBlazorTestApp.csproj", "{5F79EB04-21DB-4150-BCFA-A307A7930ED9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -62,6 +64,10 @@ Global
 		{D9290286-6DD8-478C-A902-23660C554A1C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D9290286-6DD8-478C-A902-23660C554A1C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D9290286-6DD8-478C-A902-23660C554A1C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5F79EB04-21DB-4150-BCFA-A307A7930ED9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5F79EB04-21DB-4150-BCFA-A307A7930ED9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5F79EB04-21DB-4150-BCFA-A307A7930ED9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5F79EB04-21DB-4150-BCFA-A307A7930ED9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/MudBlazor.sln
+++ b/src/MudBlazor.sln
@@ -24,8 +24,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MudBlazor.Examples.Data", "MudBlazor.Examples.Data\MudBlazor.Examples.Data.csproj", "{D9290286-6DD8-478C-A902-23660C554A1C}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MyMudBlazorApp", "..\..\..\MyMudBlazorApp\MyMudBlazorApp\MyMudBlazorApp.csproj", "{7EDA9BE3-D3BD-4109-9669-01AA74794699}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -64,10 +62,6 @@ Global
 		{D9290286-6DD8-478C-A902-23660C554A1C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D9290286-6DD8-478C-A902-23660C554A1C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D9290286-6DD8-478C-A902-23660C554A1C}.Release|Any CPU.Build.0 = Release|Any CPU
-		{7EDA9BE3-D3BD-4109-9669-01AA74794699}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{7EDA9BE3-D3BD-4109-9669-01AA74794699}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{7EDA9BE3-D3BD-4109-9669-01AA74794699}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{7EDA9BE3-D3BD-4109-9669-01AA74794699}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/MudBlazor.sln
+++ b/src/MudBlazor.sln
@@ -24,6 +24,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MudBlazor.Examples.Data", "MudBlazor.Examples.Data\MudBlazor.Examples.Data.csproj", "{D9290286-6DD8-478C-A902-23660C554A1C}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MyMudBlazorApp", "..\..\..\MyMudBlazorApp\MyMudBlazorApp\MyMudBlazorApp.csproj", "{7EDA9BE3-D3BD-4109-9669-01AA74794699}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -62,6 +64,10 @@ Global
 		{D9290286-6DD8-478C-A902-23660C554A1C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D9290286-6DD8-478C-A902-23660C554A1C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D9290286-6DD8-478C-A902-23660C554A1C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7EDA9BE3-D3BD-4109-9669-01AA74794699}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7EDA9BE3-D3BD-4109-9669-01AA74794699}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7EDA9BE3-D3BD-4109-9669-01AA74794699}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7EDA9BE3-D3BD-4109-9669-01AA74794699}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/MudBlazor.sln
+++ b/src/MudBlazor.sln
@@ -24,6 +24,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MudBlazor.Examples.Data", "MudBlazor.Examples.Data\MudBlazor.Examples.Data.csproj", "{D9290286-6DD8-478C-A902-23660C554A1C}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MudBlazorTestApp", "..\..\MudBlazorTestApp\MudBlazorTestApp\MudBlazorTestApp.csproj", "{1627AE2E-B7DF-4F78-A470-EF9FDDA74306}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -62,6 +64,10 @@ Global
 		{D9290286-6DD8-478C-A902-23660C554A1C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D9290286-6DD8-478C-A902-23660C554A1C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D9290286-6DD8-478C-A902-23660C554A1C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1627AE2E-B7DF-4F78-A470-EF9FDDA74306}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1627AE2E-B7DF-4F78-A470-EF9FDDA74306}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1627AE2E-B7DF-4F78-A470-EF9FDDA74306}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1627AE2E-B7DF-4F78-A470-EF9FDDA74306}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -7,10 +7,17 @@
         <MudInputControl Label="@Label" Variant="@Variant" HelperText="@HelperText" FullWidth="@FullWidth" Margin="@Margin" Class="@Classname" Style="@Style"
                          Error="@Error" ErrorText="@ErrorText" Disabled="@Disabled" @onclick="@ToggleMenu">
             <InputContent>
-                <MudInput T="string" @ref="_elementReference" InputType="InputType.Text" Variant="@Variant" @attributes="UserAttributes" Value="@Text" TextChanged="OnTextChanged" DisableUnderLine="@DisableUnderLine" Placeholder="@Placeholder" Disabled=@Disabled ReadOnly="@ReadOnly"
-                          Immediate="true" Margin="@Margin" Class="mud-select-input" Error="@Error" AdornmentIcon="@CurrentIcon" Adornment="@Adornment" AdornmentColor="@AdornmentColor" IconSize="@IconSize"
-                          OnBlur="@OnInputBlurred" OnKeyUp="@this.OnInputKeyUp"  autocomplete=@("mud-disabled-"+Guid.NewGuid()) KeyUpPreventDefault="KeyUpPreventDefault"
+                <MudInput @ref="_elementReference" InputType="InputType.Text"
+                          Class="mud-select-input" Margin="@Margin" 
+                          Variant="@Variant" Value="@Text" DisableUnderLine="@DisableUnderLine"
+                          Disabled="@Disabled" ReadOnly="@ReadOnly" Error="@Error"
+                          AdornmentIcon="@CurrentIcon" Adornment="@Adornment" AdornmentColor="@AdornmentColor" IconSize="@IconSize"
                           Clearable="@Clearable" OnClearButtonClick="@OnClearButtonClick"
+
+                          TextChanged="OnTextChanged" OnBlur="OnInputBlurred"
+                          OnKeyUp="@this.OnInputKeyUp" autocomplete=@("mud-disabled-"+Guid.NewGuid()) KeyUpPreventDefault="KeyUpPreventDefault"
+                          @attributes="UserAttributes" Placeholder="@Placeholder" Immediate="true"
+                          T="string"
                           />
                 @if (_items!=null && _items.Length!=0)
                 {

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -13,10 +13,11 @@
                           Disabled="@Disabled" ReadOnly="@ReadOnly" Error="@Error"
                           AdornmentIcon="@CurrentIcon" Adornment="@Adornment" AdornmentColor="@AdornmentColor" IconSize="@IconSize"
                           Clearable="@Clearable" OnClearButtonClick="@OnClearButtonClick"
+                          @attributes="UserAttributes" 
 
                           TextChanged="OnTextChanged" OnBlur="OnInputBlurred"
                           OnKeyUp="@this.OnInputKeyUp" autocomplete=@("mud-disabled-"+Guid.NewGuid()) KeyUpPreventDefault="KeyUpPreventDefault"
-                          @attributes="UserAttributes" Placeholder="@Placeholder" Immediate="true"
+                          Placeholder="@Placeholder" Immediate="true"
                           T="string"
                           />
                 @if (_items!=null && _items.Length!=0)

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -11,7 +11,7 @@
                           Class="mud-select-input" Margin="@Margin" 
                           Variant="@Variant" Value="@Text" DisableUnderLine="@DisableUnderLine"
                           Disabled="@Disabled" ReadOnly="@ReadOnly" Error="@Error"
-                          AdornmentIcon="@CurrentIcon" Adornment="@Adornment" AdornmentColor="@AdornmentColor" IconSize="@IconSize"
+                          AdornmentIcon="@_currentIcon" Adornment="@Adornment" AdornmentColor="@AdornmentColor" IconSize="@IconSize"
                           Clearable="@Clearable" OnClearButtonClick="@OnClearButtonClick"
                           @attributes="UserAttributes" 
 

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -64,12 +64,12 @@ namespace MudBlazor
         /// <summary>
         /// The Open Autocomplete Icon
         /// </summary>
-        [Parameter] public string OpenIcon { get; set; } = Icons.Material.Filled.ArrowDropUp;
+        [Parameter] public string OpenIcon { get; set; } = Icons.Material.Filled.ArrowDropDown;
 
         /// <summary>
         /// The Close Autocomplete Icon
         /// </summary>
-        [Parameter] public string CloseIcon { get; set; } = Icons.Material.Filled.ArrowDropDown;
+        [Parameter] public string CloseIcon { get; set; } = Icons.Material.Filled.ArrowDropUp;
 
         //internal event Action<HashSet<T>> SelectionChangedFromOutside;
 

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -177,7 +177,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public EventCallback<bool> IsOpenChanged { get; set; }
 
-        public string CurrentIcon { get; set; }
+        private string _currentIcon;
 
         private MudInput<string> _elementReference;
 
@@ -219,7 +219,7 @@ namespace MudBlazor
 
         public void UpdateIcon()
         {
-            CurrentIcon = !string.IsNullOrWhiteSpace(AdornmentIcon) ? AdornmentIcon : _isOpen ? CloseIcon : OpenIcon;
+            _currentIcon = !string.IsNullOrWhiteSpace(AdornmentIcon) ? AdornmentIcon : _isOpen ? CloseIcon : OpenIcon;
         }
 
         protected override void OnInitialized()

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -181,8 +181,8 @@ namespace MudBlazor
 
         public MudAutocomplete()
         {
-            IconSize = Size.Medium;
             Adornment = Adornment.End;
+            IconSize = Size.Medium;
         }
 
         public async Task SelectOption(T value)
@@ -219,14 +219,7 @@ namespace MudBlazor
 
         public void UpdateIcon()
         {
-            if (IsOpen)
-            {
-                CurrentIcon = OpenIcon;
-            }
-            else
-            {
-                CurrentIcon = CloseIcon;
-            }
+            CurrentIcon = !string.IsNullOrWhiteSpace(AdornmentIcon) ? AdornmentIcon : _isOpen ? OpenIcon : CloseIcon;
         }
 
         protected override void OnInitialized()

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -165,7 +165,9 @@ namespace MudBlazor
             {
                 if (value == _isOpen)
                     return;
+
                 _isOpen = value;
+                UpdateIcon();
                 IsOpenChanged.InvokeAsync(_isOpen).AndForget();
             }
         }
@@ -193,7 +195,6 @@ namespace MudBlazor
             await SetTextAsync(GetItemString(value), false);
             _timer?.Dispose();
             IsOpen = false;
-            UpdateIcon();
             BeginValidate();
             StateHasChanged();
         }
@@ -213,7 +214,6 @@ namespace MudBlazor
                 RestoreScrollPosition();
                 await CoerceTextToValue();
             }
-            UpdateIcon();
             StateHasChanged();
         }
 
@@ -279,13 +279,11 @@ namespace MudBlazor
             {
                 await CoerceValueToText();
                 IsOpen = false;
-                UpdateIcon();
                 StateHasChanged();
                 return;
             }
 
             IsOpen = true;
-            UpdateIcon();
             StateHasChanged();
         }
 

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -219,7 +219,7 @@ namespace MudBlazor
 
         public void UpdateIcon()
         {
-            CurrentIcon = !string.IsNullOrWhiteSpace(AdornmentIcon) ? AdornmentIcon : _isOpen ? OpenIcon : CloseIcon;
+            CurrentIcon = !string.IsNullOrWhiteSpace(AdornmentIcon) ? AdornmentIcon : _isOpen ? CloseIcon : OpenIcon;
         }
 
         protected override void OnInitialized()

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -217,7 +217,7 @@ namespace MudBlazor
             StateHasChanged();
         }
 
-        public void UpdateIcon()
+        private void UpdateIcon()
         {
             _currentIcon = !string.IsNullOrWhiteSpace(AdornmentIcon) ? AdornmentIcon : _isOpen ? CloseIcon : OpenIcon;
         }

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -7,10 +7,12 @@
         <MudInputControl Label="@Label" Variant="@Variant" HelperText="@HelperText" FullWidth="@FullWidth" Margin="@Margin" Class="@Classname" Style="@Style"
                          Error="@Error" ErrorText="@ErrorText" Disabled="@Disabled" @onclick="@ToggleMenu" Required="@Required">
             <InputContent>
-                <MudInput @ref="_elementReference" @attributes="UserAttributes" Variant="@Variant" Value="@(Strict && !IsValueInList ? null : Text)" DisableUnderLine="@DisableUnderLine" Disabled=@Disabled ReadOnly="true"
-                          Class="mud-select-input" Error="@Error" AdornmentIcon="@CurrentIcon" Adornment="Adornment.End" AdornmentColor="@AdornmentColor" IconSize="@IconSize" Margin="@Margin"
-                          InputType="@(CanRenderValue || (Strict && !IsValueInList) ? InputType.Hidden : InputType.Text)"
-                          Clearable="@Clearable" OnClearButtonClick="@SelectClearButtonClickHandlerAsync"
+                <MudInput @ref="_elementReference" InputType="@(CanRenderValue || (Strict && !IsValueInList) ? InputType.Hidden : InputType.Text)"
+                          Class="mud-select-input" Margin="@Margin" 
+                          Variant="@Variant" Value="@(Strict && !IsValueInList ? null : Text)" DisableUnderLine="@DisableUnderLine"
+                          Disabled="@Disabled" ReadOnly="true" Error="@Error"
+                          AdornmentIcon="@CurrentIcon" Adornment="@Adornment" AdornmentColor="@AdornmentColor" IconSize="@IconSize"
+                          Clearable="@Clearable" OnClearButtonClick="(async (e) => await SelectClearButtonClickHandlerAsync(e))"
                           >
                     @if (CanRenderValue)
                     {

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -13,6 +13,7 @@
                           Disabled="@Disabled" ReadOnly="true" Error="@Error"
                           AdornmentIcon="@CurrentIcon" Adornment="@Adornment" AdornmentColor="@AdornmentColor" IconSize="@IconSize"
                           Clearable="@Clearable" OnClearButtonClick="(async (e) => await SelectClearButtonClickHandlerAsync(e))"
+                          @attributes="UserAttributes" 
                           >
                     @if (CanRenderValue)
                     {

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -11,7 +11,7 @@
                           Class="mud-select-input" Margin="@Margin" 
                           Variant="@Variant" Value="@(Strict && !IsValueInList ? null : Text)" DisableUnderLine="@DisableUnderLine"
                           Disabled="@Disabled" ReadOnly="true" Error="@Error"
-                          AdornmentIcon="@CurrentIcon" Adornment="@Adornment" AdornmentColor="@AdornmentColor" IconSize="@IconSize"
+                          AdornmentIcon="@_currentIcon" Adornment="@Adornment" AdornmentColor="@AdornmentColor" IconSize="@IconSize"
                           Clearable="@Clearable" OnClearButtonClick="(async (e) => await SelectClearButtonClickHandlerAsync(e))"
                           @attributes="UserAttributes" 
                           >

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -130,6 +130,7 @@ namespace MudBlazor
 
         public MudSelect()
         {
+            Adornment = Adornment.End;
             IconSize = Size.Medium;
         }
 
@@ -334,14 +335,7 @@ namespace MudBlazor
 
         public void UpdateIcon()
         {
-            if (_isOpen)
-            {
-                CurrentIcon = OpenIcon;
-            }
-            else
-            {
-                CurrentIcon = CloseIcon;
-            }
+            CurrentIcon = !string.IsNullOrWhiteSpace(AdornmentIcon) ? AdornmentIcon : _isOpen ? OpenIcon : CloseIcon;
         }
 
         protected override void OnInitialized()
@@ -381,7 +375,7 @@ namespace MudBlazor
         /// <summary>
         /// Extra handler for clearing selection.
         /// </summary>
-        protected async Task SelectClearButtonClickHandlerAsync(MouseEventArgs e)
+        protected async ValueTask SelectClearButtonClickHandlerAsync(MouseEventArgs e)
         {
             await SetValueAsync(default, false);
             await SetTextAsync(default, false);
@@ -389,7 +383,7 @@ namespace MudBlazor
             BeginValidate();
             StateHasChanged();
             await SelectedValuesChanged.InvokeAsync(SelectedValues);
-            await OnClearButtonClick.InvokeAsync();
+            await OnClearButtonClick.InvokeAsync(e);
         }
 
         protected async Task SetCustomizedTextAsync(string text, bool updateValue = true,

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -260,7 +260,7 @@ namespace MudBlazor
 
         internal bool _isOpen;
 
-        public string CurrentIcon { get; set; }
+        public string _currentIcon { get; set; }
 
         public async Task SelectOption(object obj)
         {
@@ -333,9 +333,9 @@ namespace MudBlazor
             await OnBlur.InvokeAsync(new FocusEventArgs());
         }
 
-        public void UpdateIcon()
+        private void UpdateIcon()
         {
-            CurrentIcon = !string.IsNullOrWhiteSpace(AdornmentIcon) ? AdornmentIcon : _isOpen ? CloseIcon : OpenIcon;
+            _currentIcon = !string.IsNullOrWhiteSpace(AdornmentIcon) ? AdornmentIcon : _isOpen ? CloseIcon : OpenIcon;
         }
 
         protected override void OnInitialized()

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -48,12 +48,12 @@ namespace MudBlazor
         /// <summary>
         /// The Open Select Icon
         /// </summary>
-        [Parameter] public string OpenIcon { get; set; } = Icons.Material.Filled.ArrowDropUp;
+        [Parameter] public string OpenIcon { get; set; } = Icons.Material.Filled.ArrowDropDown;
 
         /// <summary>
         /// The Close Select Icon
         /// </summary>
-        [Parameter] public string CloseIcon { get; set; } = Icons.Material.Filled.ArrowDropDown;
+        [Parameter] public string CloseIcon { get; set; } = Icons.Material.Filled.ArrowDropUp;
 
         /// <summary>
         /// Fires when SelectedValues changes.

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -335,7 +335,7 @@ namespace MudBlazor
 
         public void UpdateIcon()
         {
-            CurrentIcon = !string.IsNullOrWhiteSpace(AdornmentIcon) ? AdornmentIcon : _isOpen ? OpenIcon : CloseIcon;
+            CurrentIcon = !string.IsNullOrWhiteSpace(AdornmentIcon) ? AdornmentIcon : _isOpen ? CloseIcon : OpenIcon;
         }
 
         protected override void OnInitialized()


### PR DESCRIPTION
This PR changes the following:

- MudAutocomplete: The `AdornmentIcon` attribute sets both the `OpenIcon` and `CloseIcon` attributes;
- MudAutocomplete: Switched property `CloseIcon` <> `OpenIcon` values;
- MudAutocomplete: Reversed `UpdateIcon()` state;
- MudAutocomplete: Added docs examples for `AdornmentIcon`, `OpenIcon` and `CloseIcon` attributes;
- MudAutocomplete: Removed calls to `UpdateIcon()` and added a call to `IsOpen` setter so that the icon always reflects the correct `IsOpen` state;
- MudAutocomplete: Property `CurrentIcon` is now private (**breaking**);
- MudAutocomplete: Method `UpdateIcon()` is now private (**breaking**);
- MudSelect: The `Adornment` attribute is now applied;
- MudSelect: The `AdornmentIcon` attribute sets both the `OpenIcon` and `CloseIcon` attributes;
- MudSelect: Switched property `CloseIcon` <> `OpenIcon` values;
- MudSelect: Reversed `UpdateIcon()` state;
- MudSelect: Added docs examples for `AdornmentIcon`, `OpenIcon` and `CloseIcon` attributes;
- MudSelect: Changed `Task SelectClearButtonClickHandlerAsync(MouseEventArgs e)` to return a `ValueTask` instead;
- MudSelect: Added `@attributes="UserAttributes"` to satisfy unit test.
- MudSelect: Property `CurrentIcon` is now private (**breaking**);
- MudSelect: Method `UpdateIcon()` is now private (**breaking**);

Related issues: #804, #912, #1659