### PR TITLE
MudAutocomplete: Forward PopOver attributes OffsetX, OffsetY and Direction

### DIFF
--- a/src/MudBlazor.sln
+++ b/src/MudBlazor.sln
@@ -24,6 +24,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MudBlazor.Examples.Data", "MudBlazor.Examples.Data\MudBlazor.Examples.Data.csproj", "{D9290286-6DD8-478C-A902-23660C554A1C}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MyMudBlazorApp", "..\..\..\MyMudBlazorApp\MyMudBlazorApp\MyMudBlazorApp.csproj", "{370D75CE-DDA8-4ED3-87A8-BEB415E4DF9F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -62,6 +64,10 @@ Global
 		{D9290286-6DD8-478C-A902-23660C554A1C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D9290286-6DD8-478C-A902-23660C554A1C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D9290286-6DD8-478C-A902-23660C554A1C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{370D75CE-DDA8-4ED3-87A8-BEB415E4DF9F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{370D75CE-DDA8-4ED3-87A8-BEB415E4DF9F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{370D75CE-DDA8-4ED3-87A8-BEB415E4DF9F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{370D75CE-DDA8-4ED3-87A8-BEB415E4DF9F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/MudBlazor.sln
+++ b/src/MudBlazor.sln
@@ -24,8 +24,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MudBlazor.Examples.Data", "MudBlazor.Examples.Data\MudBlazor.Examples.Data.csproj", "{D9290286-6DD8-478C-A902-23660C554A1C}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MyMudBlazorApp", "..\..\..\MyMudBlazorApp\MyMudBlazorApp\MyMudBlazorApp.csproj", "{370D75CE-DDA8-4ED3-87A8-BEB415E4DF9F}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -64,10 +62,6 @@ Global
 		{D9290286-6DD8-478C-A902-23660C554A1C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D9290286-6DD8-478C-A902-23660C554A1C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D9290286-6DD8-478C-A902-23660C554A1C}.Release|Any CPU.Build.0 = Release|Any CPU
-		{370D75CE-DDA8-4ED3-87A8-BEB415E4DF9F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{370D75CE-DDA8-4ED3-87A8-BEB415E4DF9F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{370D75CE-DDA8-4ED3-87A8-BEB415E4DF9F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{370D75CE-DDA8-4ED3-87A8-BEB415E4DF9F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -14,7 +14,7 @@
                           />
                 @if (_items!=null && _items.Length!=0)
                 {
-                    <MudPopover Open="@IsOpen" MaxHeight="@MaxHeight" OffsetY="true">
+                    <MudPopover Open="@IsOpen" MaxHeight="@MaxHeight" Direction="@Direction" OffsetX="@OffsetX" OffsetY="@OffsetY">
                             @*this must be the real scroll container, not the Popover, hence the maxheight*@
                         <MudList Clickable="true" Dense="@Dense" Style=@($"max-height: {MaxHeight}px; overflow-y:auto;")>
                             @for (var index= 0; index < _items.Length;index++ )

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -32,22 +32,22 @@ namespace MudBlazor
 
 
         /// <summary>
-        /// Sets the direction the select menu should open.
+        /// Sets the direction the Autocomplete menu should open.
         /// </summary>
         [Parameter] public Direction Direction { get; set; } = Direction.Bottom;
 
         /// <summary>
-        /// If true, the select menu will open either before or after the input (left/right).
+        /// If true, the Autocomplete menu will open either before or after the input (left/right).
         /// </summary>
         [Parameter] public bool OffsetX { get; set; }
 
         /// <summary>
-        /// If true, the select menu will open either before or after the input (top/bottom).
+        /// If true, the Autocomplete menu will open either before or after the input (top/bottom).
         /// </summary>
         [Parameter] public bool OffsetY { get; set; } = true;
 
         /// <summary>
-        /// If true, compact vertical padding will be applied to all select items.
+        /// If true, compact vertical padding will be applied to all Autocomplete items.
         /// </summary>
         [Parameter] 
         public bool Dense 
@@ -62,19 +62,19 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// The Open Select Icon
+        /// The Open Autocomplete Icon
         /// </summary>
         [Parameter] public string OpenIcon { get; set; } = Icons.Material.Filled.ArrowDropUp;
 
         /// <summary>
-        /// The Close Select Icon
+        /// The Close Autocomplete Icon
         /// </summary>
         [Parameter] public string CloseIcon { get; set; } = Icons.Material.Filled.ArrowDropDown;
 
         //internal event Action<HashSet<T>> SelectionChangedFromOutside;
 
         /// <summary>
-        /// Sets the maxheight the select can have when open.
+        /// Sets the maxheight the Autocomplete can have when open.
         /// </summary>
         [Parameter] public int MaxHeight { get; set; } = 300;
 

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -32,17 +32,19 @@ namespace MudBlazor
 
 
         /// <summary>
-        /// Sets the direction the select menu should be.
+        /// Sets the direction the select menu should open.
         /// </summary>
         [Parameter] public Direction Direction { get; set; } = Direction.Bottom;
 
         /// <summary>
-        /// If true, the select menu will open either before or after the input.
+        /// If true, the select menu will open either before or after the input (left/right).
         /// </summary>
-        [Parameter] public bool OffsetY { get; set; }
-
         [Parameter] public bool OffsetX { get; set; }
 
+        /// <summary>
+        /// If true, the select menu will open either before or after the input (top/bottom).
+        /// </summary>
+        [Parameter] public bool OffsetY { get; set; } = true;
 
         /// <summary>
         /// If true, compact vertical padding will be applied to all select items.
@@ -65,7 +67,7 @@ namespace MudBlazor
         [Parameter] public string OpenIcon { get; set; } = Icons.Material.Filled.ArrowDropUp;
 
         /// <summary>
-        /// The Open Select Icon
+        /// The Close Select Icon
         /// </summary>
         [Parameter] public string CloseIcon { get; set; } = Icons.Material.Filled.ArrowDropDown;
 

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -30,6 +30,20 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public string Placeholder { get; set; }
 
+
+        /// <summary>
+        /// Sets the direction the select menu should be.
+        /// </summary>
+        [Parameter] public Direction Direction { get; set; } = Direction.Bottom;
+
+        /// <summary>
+        /// If true, the select menu will open either before or after the input.
+        /// </summary>
+        [Parameter] public bool OffsetY { get; set; }
+
+        [Parameter] public bool OffsetX { get; set; }
+
+
         /// <summary>
         /// If true, compact vertical padding will be applied to all select items.
         /// </summary>

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -50,7 +50,7 @@ namespace MudBlazor
         [Parameter] public string OpenIcon { get; set; } = Icons.Material.Filled.ArrowDropUp;
 
         /// <summary>
-        /// The Open Select Icon
+        /// The Close Select Icon
         /// </summary>
         [Parameter] public string CloseIcon { get; set; } = Icons.Material.Filled.ArrowDropDown;
 
@@ -207,16 +207,20 @@ namespace MudBlazor
         [Parameter] public int MaxHeight { get; set; } = 300;
 
         /// <summary>
-        /// Sets the direction the select menu should be.
+        /// Sets the direction the select menu should open.
         /// </summary>
         [Parameter] public Direction Direction { get; set; } = Direction.Bottom;
 
         /// <summary>
-        /// If true, the select menu will open either before or after the input.
+        /// If true, the select menu will open either before or after the input (left/right).
+        /// </summary>
+        [Parameter] public bool OffsetX { get; set; }
+
+        /// <summary>
+        /// If true, the select menu will open either before or after the input (top/bottom).
         /// </summary>
         [Parameter] public bool OffsetY { get; set; }
 
-        [Parameter] public bool OffsetX { get; set; }
 
         /// <summary>
         /// If true, the select's input will not show any values that are not defined in the dropdown.

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -30,7 +30,7 @@ namespace MudBlazor
         [Parameter] public string Label { get; set; }
 
         /// <summary>
-        /// If true, compact vertical padding will be applied to all select items.
+        /// If true, compact vertical padding will be applied to all Select items.
         /// </summary>
         [Parameter]
         public bool Dense
@@ -202,30 +202,30 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// Sets the maxheight the select can have when open.
+        /// Sets the maxheight the Select can have when open.
         /// </summary>
         [Parameter] public int MaxHeight { get; set; } = 300;
 
         /// <summary>
-        /// Sets the direction the select menu should open.
+        /// Sets the direction the Select menu should open.
         /// </summary>
         [Parameter] public Direction Direction { get; set; } = Direction.Bottom;
 
         /// <summary>
-        /// If true, the select menu will open either before or after the input (left/right).
+        /// If true, the Select menu will open either before or after the input (left/right).
         /// </summary>
         [Parameter] public bool OffsetX { get; set; }
 
         /// <summary>
-        /// If true, the select menu will open either before or after the input (top/bottom).
+        /// If true, the Select menu will open either before or after the input (top/bottom).
         /// </summary>
         [Parameter] public bool OffsetY { get; set; }
 
 
         /// <summary>
-        /// If true, the select's input will not show any values that are not defined in the dropdown.
+        /// If true, the Select's input will not show any values that are not defined in the dropdown.
         /// This can be useful if Value is bound to a variable which is initialized to a value which is not in the list
-        /// and you want the select to show the label / placeholder instead.
+        /// and you want the Select to show the label / placeholder instead.
         /// </summary>
         [Parameter] public bool Strict { get; set; }
 


### PR DESCRIPTION
This PR is an attempt to enable the `MudSelect` and `MudAutocomplete` components
to behave more alike by forwarding the `OffsetX`, `OffsetY` and `Direction` attributes for `MudAutocomplete`.

`MudSelect`, `MudAutocomplete`
![0](https://user-images.githubusercontent.com/10358198/121351718-9b325880-c91b-11eb-92c1-69c4cea2de61.png)

 `<MudSelect OffsetX="true" Direction="Direction.Right" ...`
![1](https://user-images.githubusercontent.com/10358198/121351788-aab1a180-c91b-11eb-8c44-585b4a39ab3c.png)


 `<MudAutocomplete OffsetX="true" Direction="Direction.Right" ...`
![2](https://user-images.githubusercontent.com/10358198/121351801-ae452880-c91b-11eb-913d-ada8fd515c06.png)

