### PR TITLE
RTL: Adds textfield docs example, fixes adornment issue

### DIFF
--- a/src/MudBlazor.Docs/Pages/Features/RTLLanguages/Examples/RTLLanguagesTextfieldExample.razor
+++ b/src/MudBlazor.Docs/Pages/Features/RTLLanguages/Examples/RTLLanguagesTextfieldExample.razor
@@ -1,0 +1,24 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudLayout RightToLeft="true">
+    <MudGrid>
+        <MudItem xs="12" sm="4">
+            <MudText Align="Align.Left">Text</MudText>
+            <MudTextField Label="الاسم الأول" Variant="Variant.Outlined" @bind-Value="@_name" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Person"></MudTextField>
+        </MudItem>
+        <MudItem xs="12" sm="4">
+            <MudText Align="Align.Left">Telephone</MudText>
+            <MudTextField InputType="InputType.Telephone" Label="رقم الهاتف" Variant="Variant.Outlined" @bind-Value="@_telephone" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Smartphone"></MudTextField>
+        </MudItem>
+        <MudItem xs="12" sm="4">
+            <MudText Align="Align.Left">Email</MudText>
+            <MudTextField InputType="InputType.Email" Label="البريد الإلكتروني" Variant="Variant.Outlined" @bind-Value="@_email" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Email"></MudTextField>
+        </MudItem>
+    </MudGrid>
+</MudLayout>
+
+@code {
+    private string _name { get; set; } = "John Smith";
+    private string _email { get; set; } = "mail@example.com";
+    private long? _telephone { get; set; } = 1618033988;
+}

--- a/src/MudBlazor.Docs/Pages/Features/RTLLanguages/RTLLanguagesPage.razor
+++ b/src/MudBlazor.Docs/Pages/Features/RTLLanguages/RTLLanguagesPage.razor
@@ -1,4 +1,4 @@
-﻿@page "/features/rtl-languages"
+@page "/features/rtl-languages"
 
 <DocsPage>
     <DocsPageHeader Title="RTL Languages" SubTitle="Right-to-Left (RTL) specific styling options" />
@@ -28,6 +28,21 @@
                 <RTLLanguagesLayoutExample />
             </SectionContent>
             <SectionSource Code="RTLLanguagesLayoutExample" ShowCode="false"/>
+        </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader>
+                <Title>Text Fields</Title>
+                <Description>
+                    <MudText>
+                        Text Fields with <CodeInline>InputType.Email</CodeInline> or <CodeInline>InputType.Telephone</CodeInline> remain left alligned. The label still remains right alligned on the other hand.
+                    </MudText>
+                </Description>
+            </SectionHeader>
+            <SectionContent Outlined="true">
+                <RTLLanguagesTextfieldExample />
+            </SectionContent>
+            <SectionSource Code="RTLLanguagesTextfieldExample" />
         </DocsPageSection>
 
         <DocsPageSection>

--- a/src/MudBlazor/Components/Input/MudInputCssHelper.cs
+++ b/src/MudBlazor/Components/Input/MudInputCssHelper.cs
@@ -15,6 +15,7 @@ namespace MudBlazor
                 .AddClass("mud-shrink", when: shrinkWhen)
                 .AddClass("mud-disabled", baseInput.Disabled)
                 .AddClass("mud-input-error", baseInput.HasErrors)
+                .AddClass("mud-ltr", baseInput.InputType == InputType.Email || baseInput.InputType == InputType.Telephone)
                 .AddClass(baseInput.Class)
                 .Build();
 

--- a/src/MudBlazor/Styles/components/_inputcontrol.scss
+++ b/src/MudBlazor/Styles/components/_inputcontrol.scss
@@ -167,11 +167,3 @@
     margin-left: 14px;
     margin-right: 14px;
 }
-
-.mud-application-layout-rtl {
-    .mud-input-control .mud-input-control-input-container .mud-input input {
-        &[type="email"], &[type="tel"] {
-            direction: ltr;
-        }
-    }
-}


### PR DESCRIPTION
Implements feature request: https://github.com/Garderoben/MudBlazor/pull/1789#issuecomment-856985091
![grafik](https://user-images.githubusercontent.com/62108893/121361076-3f74c900-c935-11eb-87f8-7df07eb5bf9b.png)

Fixes textfield adornment bug in RTL
