### PR TITLE
MudTextField: adds missing right margin to adornment start icon (#1838)

### DIFF
--- a/src/MudBlazor/Styles/components/_input.scss
+++ b/src/MudBlazor/Styles/components/_input.scss
@@ -455,14 +455,9 @@
 }
 
 .mud-input-adornment-start {
-  &.mud-text {
     margin-right: 8px;
     margin-inline-end: 8px;
     margin-inline-start: unset;
-  }
-
-  &.mud-icon {
-  }
 }
 
 .mud-input-adornment-end {


### PR DESCRIPTION
Fixes #1838

Before fix:
![grafik](https://user-images.githubusercontent.com/62108893/121780856-80bde080-cba2-11eb-83b1-e26787f57775.png)

After fix:
![grafik](https://user-images.githubusercontent.com/62108893/121780861-84516780-cba2-11eb-8ec3-a201ec9a12ea.png)