### PR TITLE
AppBar: Add support for adding classes to the nested ToolBar

### DIFF
--- a/src/MudBlazor.UnitTests/Components/AppBarTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AppBarTests.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Bunit;
+using FluentAssertions;
+using NUnit.Framework;
+using static Bunit.ComponentParameterFactory;
+
+namespace MudBlazor.UnitTests.Components
+{
+    [TestFixture]
+    public class AppBarTests
+    {
+        private Bunit.TestContext ctx;
+
+        [SetUp]
+        public void Setup()
+        {
+            ctx = new Bunit.TestContext();
+            ctx.AddTestServices();
+        }
+
+        [TearDown]
+        public void TearDown() => ctx.Dispose();
+
+        /// <summary>
+        /// AppBar with modified Toolbar class
+        /// </summary>
+        [Test]
+        public void AppBarWithModifiedToolBarClass()
+        {
+            var comp = ctx.RenderComponent<MudAppBar>(new[] 
+            {
+                Parameter(nameof(MudAppBar.ToolBarClass), "test-class")
+            });
+
+            // Find the Toolbar inside the AppBar
+            comp.Find("div").ToMarkup()
+                .Should()
+                .Contain("test-class");
+        }
+
+    }
+}

--- a/src/MudBlazor/Components/AppBar/MudAppBar.razor
+++ b/src/MudBlazor/Components/AppBar/MudAppBar.razor
@@ -2,7 +2,7 @@
 @inherits MudComponentBase
 
 <header @attributes="UserAttributes" class="@Classname" style="@Style" >
-    <MudToolBar Dense="@Dense" Class="mud-toolbar-appbar">
+    <MudToolBar Dense="@Dense" Class="@ToolBarClassname">
         @ChildContent
     </MudToolBar>
 </header>

--- a/src/MudBlazor/Components/AppBar/MudAppBar.razor.cs
+++ b/src/MudBlazor/Components/AppBar/MudAppBar.razor.cs
@@ -15,6 +15,11 @@ namespace MudBlazor
                 .AddClass(Class)
                 .Build();
 
+        protected string ToolBarClassname =>
+            new CssBuilder("mud-toolbar-appbar")
+                .AddClass(ToolBarClass)
+                .Build();
+
         /// <summary>
         /// The higher the number, the heavier the drop-shadow. 0 for no shadow.
         /// </summary>
@@ -34,6 +39,11 @@ namespace MudBlazor
         /// If true, appbar will be Fixed.
         /// </summary>
         [Parameter] public bool Fixed { get; set; } = true;
+
+        /// <summary>
+        /// User class names, separated by spaces for the nested toolbar.
+        /// </summary>
+        [Parameter] public string ToolBarClass { get; set; }
 
         /// <summary>
         /// Child content of the component.


### PR DESCRIPTION
Hi,
I've recently been using Mudblazor to write a desktop app using the Blazor Web Control in the .Net 6 preview
One of the things I tried to do was add some icons to the right hand side of the AppBar
for close / minimise / restore window
However I wanted to get rid of the right padding on the ToolBar nested inside the AppBar

I couldn't see a way to do this directly so I've modified the AppBar
to include a ToolBarClass parameter so you can do something like

```
<MudAppBar Dense="true" ToolBarClass="pr-0">
</MudAppBar>
```

I'm not sure if the parameter is ok in terms of the naming, but it's a small change.
