### PR TITLE
MudBadge: fixes alignment in RTL

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Badge/Examples/BadgeInteractiveExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Badge/Examples/BadgeInteractiveExample.razor
@@ -4,7 +4,7 @@
 
 <MudGrid>
     <MudItem md="8" Class="mud-text-align-center my-auto">
-        <MudBadge Content="@BadgeContent" Color="Color.Primary" Overlap="@Overlap" Bottom="@Bottom" Left="@Left" Dot="@Dot" Bordered="@Bordered" Icon="@BadgeIcon">
+        <MudBadge Content="@BadgeContent" Color="Color.Primary" Overlap="@Overlap" Bottom="@Bottom" Start="@Start" Dot="@Dot" Bordered="@Bordered" Icon="@BadgeIcon">
             @if (SelectedTestComponent == "MudIcon")
             {
                 <MudIcon Icon="@Icons.Custom.Brands.MudBlazor" Color="Color.Default" Size="Size.Large" />
@@ -35,7 +35,7 @@
                 <MudText Typo="Typo.subtitle2" GutterBottom="true">Badge Options</MudText>
                 <MudCheckBox @bind-Checked="@Bottom" Label="Bottom" Color="Color.Primary" Style="width:100%;" />
                 <MudCheckBox @bind-Checked="@Dot" Label="Dot" Color="Color.Primary" Style="width:100%;" />
-                <MudCheckBox @bind-Checked="@Left" Label="Left" Color="Color.Primary" Style="width:100%;" />
+                <MudCheckBox @bind-Checked="@Start" Label="Start" Color="Color.Primary" Style="width:100%;" />
                 <MudCheckBox @bind-Checked="@Overlap" Label="Overlap" Color="Color.Primary" Style="width:100%;" />
                 <MudCheckBox @bind-Checked="@Bordered" Label="Bordered" Color="Color.Primary" Style="width:100%;" />
                 <MudCheckBox T="bool" CheckedChanged="AddIcon" Label="Icon" Color="Color.Primary" Style="width:100%;" />
@@ -52,7 +52,7 @@
 @code {
     public bool Bottom { get; set; }
     public bool Dot { get; set; }
-    public bool Left { get; set; }
+    public bool Start { get; set; }
     public bool Overlap { get; set; }
     public bool Bordered { get; set; }
     public string BadgeIcon { get; set; }

--- a/src/MudBlazor/Components/Badge/MudBadge.razor.cs
+++ b/src/MudBlazor/Components/Badge/MudBadge.razor.cs
@@ -20,11 +20,13 @@ namespace MudBlazor
             .AddClass("mud-theme-" + Color.ToDescriptionString())
             .AddClass("mud-badge-top", !Bottom)
             .AddClass("mud-badge-bottom", Bottom)
-            .AddClass("mud-badge-right", !Left)
-            .AddClass("mud-badge-left", Left)
+            .AddClass("mud-badge-right", Start == RightToLeft)
+            .AddClass("mud-badge-left", Start != RightToLeft)
             .AddClass("mud-badge-overlap", Overlap)
         .Build();
 
+        [CascadingParameter] public bool RightToLeft { get; set; }
+        
         /// <summary>
         /// The color of the badge.
         /// </summary>
@@ -38,7 +40,13 @@ namespace MudBlazor
         /// <summary>
         /// Aligns the badge to left.
         /// </summary>
-        [Parameter] public bool Left { get; set; }
+        [ObsoleteAttribute("Left is obsolete. Use Start instead!", false)]
+        [Parameter] public bool Left { get => Start; set { Start = value; } }
+
+        /// <summary>
+        /// Aligns the badge to the start (Left in LTR and right in RTL).
+        /// </summary>
+        [Parameter] public bool Start { get; set; }
 
         /// <summary>
         /// Reduces the size of the badge and hide any of its content.


### PR DESCRIPTION
Fixes `Badge position` in #92
This PR obsoletes the `Left` property.

Before fix (RTL):
![grafik](https://user-images.githubusercontent.com/62108893/121910232-f6ef4e00-cd2e-11eb-973e-e352d3878e1d.png)

After fix (RTL):
![grafik](https://user-images.githubusercontent.com/62108893/121910312-079fc400-cd2f-11eb-83c4-c6d129ff9d80.png)
