### PR TITLE
MudTabs: Using Equals instead operator for activating tabpanel by ID

### DIFF
--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -287,7 +287,7 @@ namespace MudBlazor
 
         public void ActivatePanel(object id, bool ignoreDisabledState = false)
         {
-            var panel = _panels.Where((p) => p.ID == id).FirstOrDefault();
+            var panel = _panels.Where((p) => Equals(p.ID, id)).FirstOrDefault();
             if (panel != null)
                 ActivatePanel(panel, null, ignoreDisabledState);
         }


### PR DESCRIPTION
I think Equals() should be used instead operator for activating panel by ID.

For example now it is not possible to use strings as Ids.