### PR TITLE
MudSwitch: flipped in RTL

### DIFF
--- a/src/MudBlazor.Docs/Pages/Features/RTLLanguages/Examples/RTLLanguagesLayoutExample.razor
+++ b/src/MudBlazor.Docs/Pages/Features/RTLLanguages/Examples/RTLLanguagesLayoutExample.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudLayout RightToLeft="@_rightToLeft">
-    <MudCard Style="width: 400px">
+    <MudCard Class="mb-2" Style="width: 400px">
         <MudCardHeader>
             <CardHeaderAvatar>
                 <MudAvatar Color="Color.Secondary">@Localizer("CardAvatarLetter")</MudAvatar>
@@ -23,8 +23,8 @@
             <MudIconButton Icon="@Icons.Material.Filled.Share" Color="Color.Default" />
         </MudCardActions>
     </MudCard>
-    <MudSwitch @bind-Checked="@_rightToLeft" Label="Toggle Right to Left" Color="Color.Primary" Class="mud-float-left mud-ltr"/>
 </MudLayout>
+<MudSwitch @bind-Checked="@_rightToLeft" Label="Toggle Right to Left" Color="Color.Primary" Class="mud-float-left mt-n5"/>
 
 @code {
     private bool _rightToLeft = true;

--- a/src/MudBlazor/Components/Switch/MudSwitch.razor
+++ b/src/MudBlazor/Components/Switch/MudSwitch.razor
@@ -3,7 +3,7 @@
 @typeparam T
 
 <label class="@Classname" style="@Style">
-    <span class="mud-switch-span">
+    <span class="mud-switch-span mud-flip-x-rtl">
         <span class="@SwitchClassname">
             <span class="mud-switch-button">
                 <input @attributes="UserAttributes" type="checkbox" class="mud-switch-input" checked="@BoolValue" @onchange="@OnChange" disabled="@Disabled" @onclick:preventDefault="@ReadOnly"/>


### PR DESCRIPTION
As mentioned in https://github.com/Garderoben/MudBlazor/issues/92#issuecomment-857573814

Before fix (RTL):
![grafik](https://user-images.githubusercontent.com/62108893/122047608-a0424c80-cde0-11eb-8571-8f34b202ae1d.png)

After fix (RTL):
![grafik](https://user-images.githubusercontent.com/62108893/122047533-8ef94000-cde0-11eb-874e-033586e870c4.png)

Fixes small problem caused in `RTLLanguages` docs page due to this PR.
