### PR TITLE
Add MudPicker.AdornmentIcon to replace MudPicker.InputIcon 

### DIFF
--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor
@@ -11,7 +11,7 @@
                           @onclick="() => { if (!Editable) ToggleState(); }">
                <InputContent>
                    <MudRangeInput @ref="_rangeInput" @attributes="UserAttributes" InputType="@InputType.Text" Class="@PickerInputClass" Style="@Style" Variant="@InputVariant" ReadOnly="@(!Editable)"
-                                   @bind-Value="@RangeText" Disabled=@Disabled Adornment="@Adornment" AdornmentIcon="@InputIcon" IconSize="@IconSize" OnAdornmentClick="ToggleState"
+                                   @bind-Value="@RangeText" Disabled=@Disabled Adornment="@Adornment" AdornmentIcon="@AdornmentIcon" IconSize="@IconSize" OnAdornmentClick="ToggleState"
                                    Required="@Required" RequiredError="@RequiredError" Error="@Error" ErrorText="@ErrorText" Margin="@Margin"/>
                </InputContent>
            </MudInputControl>;

--- a/src/MudBlazor/Components/Picker/MudPicker.razor
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor
@@ -10,7 +10,7 @@
     protected virtual RenderFragment InputContent =>
         @<MudTextField @ref="_inputReference" @attributes="UserAttributes" Label="@Label" @bind-Text="@Text" HelperText="@HelperText" Variant="@InputVariant" ReadOnly="@(!Editable)" T="string" Style="@Style"
                     @onclick="(() => { if (!Editable) ToggleState(); })" OnAdornmentClick="ToggleState" Disabled="@Disabled" Adornment="@Adornment"
-                    AdornmentIcon="@InputIcon" IconSize="@IconSize" Margin="@Margin"
+                    AdornmentIcon="@AdornmentIcon" IconSize="@IconSize" Margin="@Margin"
                     Required="@Required" RequiredError="@RequiredError" Error="@Error" ErrorText="@ErrorText"/>;
 
     protected virtual RenderFragment PickerContent => null;

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -1,8 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
-using MudBlazor.Extensions;
-using MudBlazor.Interfaces;
-using MudBlazor.Services;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
@@ -78,7 +76,18 @@ namespace MudBlazor
         /// <summary>
         /// Sets the icon of the input text field
         /// </summary>
-        [Parameter] public string InputIcon { get; set; } = Icons.Filled.Event;
+        [Parameter]
+        [Obsolete("Obsolete, use AdornmentIcon")]
+        public string InputIcon
+        {
+            get { return AdornmentIcon; }
+            set { AdornmentIcon = value; }
+        }
+
+        /// <summary>
+        /// Sets the icon of the input text field
+        /// </summary>
+        [Parameter] public string AdornmentIcon { get; set; } = Icons.Filled.Event;
 
         /// <summary>
         /// Fired when the dropdown / dialog opens

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -19,7 +19,7 @@ namespace MudBlazor
             Converter.GetFunc = OnGet;
             Converter.SetFunc = OnSet;
             (Converter as DefaultConverter<TimeSpan?>).Format = format24Hours;
-            InputIcon = Icons.Material.Filled.AccessTime;
+            AdornmentIcon = Icons.Material.Filled.AccessTime;
         }
 
         private string OnSet(TimeSpan? timespan)


### PR DESCRIPTION
`MudDatePicker` and `MudTimePicker` have the `InputIcon` property.

These pickers are the only ones that have this property, all others have `AdornmentIcon`.

For MudBlazor consistency, this PR adds the `MudPicker.AdornmentIcon` property
and marks the `MudPicker.InputIcon` as `[Obsolete]` so that it can safely be removed in the future.
