### PR TITLE
Table: improve loading bar and add parameters for loading-text and no-rows-text

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableServerSidePaginateExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableServerSidePaginateExample.razor
@@ -26,10 +26,10 @@
         <MudTd DataLabel="Molar mass">@context.Molar</MudTd>
     </RowTemplate>
     <NoRecordsContent>
-        No matching records found
+        <MudText>No matching records found</MudText>
     </NoRecordsContent>
     <LoadingContent>
-        Loading...
+        <MudText>Loading...</MudText>
     </LoadingContent>
     <PagerContent>
         <MudTablePager />

--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableServerSidePaginateExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableServerSidePaginateExample.razor
@@ -3,13 +3,13 @@
 @namespace MudBlazor.Docs.Examples
 @inject HttpClient httpClient
 
-<MudTable ServerData="@(new Func<TableState, Task<TableData<Element>>>(ServerReload))"  
-                        Dense="true" Hover="true" @ref="table">
+<MudTable ServerData="@(new Func<TableState, Task<TableData<Element>>>(ServerReload))"
+          Dense="true" Hover="true" @ref="table">
     <ToolBarContent>
         <MudText Typo="Typo.h6">Periodic Elements</MudText>
         <MudSpacer />
-        <MudTextField T="string" ValueChanged="@(s=>OnSearch(s))" Placeholder="Search" Adornment="Adornment.Start" 
-                        AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium" Class="mt-0"></MudTextField>
+        <MudTextField T="string" ValueChanged="@(s=>OnSearch(s))" Placeholder="Search" Adornment="Adornment.Start"
+                      AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium" Class="mt-0"></MudTextField>
     </ToolBarContent>
     <HeaderContent>
         <MudTh><MudTableSortLabel SortLabel="nr_field" T="Element">Nr</MudTableSortLabel></MudTh>
@@ -25,6 +25,12 @@
         <MudTd DataLabel="Position">@context.Position</MudTd>
         <MudTd DataLabel="Molar mass">@context.Molar</MudTd>
     </RowTemplate>
+    <NoRecordsContent>
+        No matching records found
+    </NoRecordsContent>
+    <LoadingContent>
+        Loading...
+    </LoadingContent>
     <PagerContent>
         <MudTablePager />
     </PagerContent>
@@ -43,6 +49,7 @@
     private async Task<TableData<Element>> ServerReload(TableState state)
     {
         IEnumerable<Element> data = await httpClient.GetFromJsonAsync<List<Element>>("webapi/periodictable");
+        await Task.Delay(300);
         data = data.Where(element =>
         {
             if (string.IsNullOrWhiteSpace(searchString))

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableLoadingTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableLoadingTest.razor
@@ -1,6 +1,9 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents
 
-<MudTable Items="@Elements" Hover="true" Breakpoint="Breakpoint.Sm" Loading="@_loading">
+<MudTable Items="@Elements" Hover="true" Breakpoint="Breakpoint.Sm" Loading="@_loading" Filter="new Func<Element, bool>(FilterFunc)">
+    <ToolBarContent>
+        <MudTextField id="searchString" @bind-Value="searchString" Placeholder="Search"></MudTextField>
+    </ToolBarContent>
     <HeaderContent>
         <MudTh>Nr</MudTh>
         <MudTh>Sign</MudTh>
@@ -22,6 +25,7 @@
 @code {
     private bool _loading = false;
     private IEnumerable<Element> Elements = new List<Element>();
+    private string searchString;
 
     protected override void OnInitialized()
     {
@@ -30,6 +34,23 @@
             new Element() { Molar = "A", Sign = "A", Name = "A", Number = "A", Position = "A"},
             new Element() { Molar = "B", Sign = "B", Name = "B", Number = "B", Position = "B"},
         };
+    }
+
+    private bool FilterFunc(Element element)
+    {
+        if (string.IsNullOrWhiteSpace(searchString))
+            return true;
+        if (element.Number.Contains(searchString, StringComparison.OrdinalIgnoreCase))
+            return true;
+        if (element.Sign.Contains(searchString, StringComparison.OrdinalIgnoreCase))
+            return true;
+        if (element.Name.Contains(searchString, StringComparison.OrdinalIgnoreCase))
+            return true;
+        if (element.Position.Contains(searchString, StringComparison.OrdinalIgnoreCase))
+            return true;
+        if (element.Molar.Contains(searchString, StringComparison.OrdinalIgnoreCase))
+            return true;
+        return false;
     }
 
     public class Element

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableLoadingTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableLoadingTest.razor
@@ -18,11 +18,15 @@
         <MudTd DataLabel="Position">@context.Position</MudTd>
         <MudTd DataLabel="Molar mass">@context.Molar</MudTd>
     </RowTemplate>
+    <NoRecordsContent>No matching records found</NoRecordsContent>
+    <LoadingContent>Loading...</LoadingContent>
 </MudTable>
 
 <MudSwitch id="switch" @bind-Checked="_loading">Show Loading</MudSwitch>
 
 @code {
+    public static string __description__ = "When loading is true a progress bar should appear";
+
     private bool _loading = false;
     private IEnumerable<Element> Elements = new List<Element>();
     private string searchString;

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -128,6 +128,31 @@ namespace MudBlazor.UnitTests.Components
             trs.Count.Should().Be(4);
         }
 
+        /// Check if if empty row text is correct
+        /// </summary>
+        [Test]
+        public void TableEmptyRowTest()
+        {
+            var comp = ctx.RenderComponent<TableLoadingTest>();
+            var searchString = comp.Find("#searchString");
+            var switchElement = comp.Find("#switch");
+
+            // It should be equal to 3 = two rows + header row
+            comp.FindAll("tr").Count.Should().Be(3);
+
+            // Filter out all table rows
+            searchString.Change("ZZZ");
+
+            // It should be equal to 2 = two rows + header row
+            comp.FindAll("tr").Count.Should().Be(2);
+            comp.FindAll("tr")[1].TextContent.Should().Be("No matching records found");
+
+            // It should be equal to 3 = empty row string + header row + loading row
+            switchElement.Change(true); 
+            comp.FindAll("tr").Count.Should().Be(3);
+            comp.FindAll("tr")[2].TextContent.Should().Be("Loading...");
+        }
+
         /// <summary>
         /// should only be able to select one item and selecteditems.count should never exceed 1
         /// </summary>
@@ -175,7 +200,8 @@ namespace MudBlazor.UnitTests.Components
             searchString.Change("ZZZ");
             table.GetFilteredItemsCount().Should().Be(0);
             table.FilteredItems.Count().Should().Be(0);
-            comp.FindAll("tr").Count.Should().Be(0);
+            comp.FindAll("tr").Count.Should().Be(1);
+            comp.FindAll("tr").First().TextContent.Should().Be("No matching records found");
             // should return 1 item
             searchString.Change("Alaska");
             table.GetFilteredItemsCount().Should().Be(1);

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -131,7 +131,7 @@ namespace MudBlazor.UnitTests.Components
         /// Check if if empty row text is correct
         /// </summary>
         [Test]
-        public void TableEmptyRowTest()
+        public void TableHeadContentTest()
         {
             var comp = ctx.RenderComponent<TableLoadingTest>();
             var searchString = comp.Find("#searchString");
@@ -200,8 +200,7 @@ namespace MudBlazor.UnitTests.Components
             searchString.Change("ZZZ");
             table.GetFilteredItemsCount().Should().Be(0);
             table.FilteredItems.Count().Should().Be(0);
-            comp.FindAll("tr").Count.Should().Be(1);
-            comp.FindAll("tr").First().TextContent.Should().Be("No matching records found");
+            comp.FindAll("tr").Count.Should().Be(0);
             // should return 1 item
             searchString.Change("Alaska");
             table.GetFilteredItemsCount().Should().Be(1);

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -51,12 +51,12 @@
                     @if (Loading)
                     {
                         <tr>
-                            <td colspan="1000">
-                                <MudProgressLinear Color="@LoadingProgressColor" Indeterminate="true" />
+                            <td colspan="1000" class="mud-table-loading">
+                                <MudProgressLinear Color="@LoadingProgressColor" Class="mud-table-loading-progress" Indeterminate="true" />
                             </td>
                         </tr>
                     }
-                    @if (CurrentPageItems != null)
+                    @if (CurrentPageItems != null && CurrentPageItems.Count() > 0)
                     {
                         var rowIndex = 0;
                         @foreach (var item in CurrentPageItems)
@@ -82,6 +82,14 @@
                             }
                             rowIndex++;
                         }
+                    }
+                    else
+                    {
+                        <tr>
+                            <th colspan="1000" class="mud-table-empty-row">
+                                <MudText Class="my-3">@(Loading ? LoadingString : NoRecordsString)</MudText>
+                            </th>
+                        </tr>
                     }
                 </tbody>
                 @if (FooterContent != null)

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -87,7 +87,7 @@
                     {
                         <tr>
                             <th colspan="1000" class="mud-table-empty-row">
-                                <MudText Class="my-3">@(Loading ? LoadingString : NoRecordsString)</MudText>
+                                <MudText Class="my-3">@(Loading ? LoadingContent : NoRecordsContent)</MudText>
                             </th>
                         </tr>
                     }
@@ -119,3 +119,14 @@
 </div>
 
 
+@code {
+    /// <summary>
+    /// Defines the table body content when there are no matching records found
+    /// </summary>
+    [Parameter] public RenderFragment NoRecordsContent { get; set; } = @<p>No matching records found</p>;
+
+    /// <summary>
+    /// Defines the table body content when the table has no rows and is loading
+    /// </summary>
+    [Parameter] public RenderFragment LoadingContent { get; set; } = @<p>Loading...</p>;
+}

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -87,7 +87,7 @@
                     {
                         <tr>
                             <th colspan="1000" class="mud-table-empty-row">
-                                <MudText Class="my-3">
+                                <div Class="my-3">
                                     @if(Loading)
                                     {
                                         @LoadingContent
@@ -96,7 +96,7 @@
                                     {
                                         @NoRecordsContent
                                     }
-                                </MudText>
+                                </div>
                             </th>
                         </tr>
                     }

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -83,11 +83,20 @@
                             rowIndex++;
                         }
                     }
-                    else
+                    else if(Loading ? LoadingContent != null : NoRecordsContent != null)
                     {
                         <tr>
                             <th colspan="1000" class="mud-table-empty-row">
-                                <MudText Class="my-3">@(Loading ? LoadingContent : NoRecordsContent)</MudText>
+                                <MudText Class="my-3">
+                                    @if(Loading)
+                                    {
+                                        @LoadingContent
+                                    }
+                                    else
+                                    {
+                                        @NoRecordsContent
+                                    }
+                                </MudText>
                             </th>
                         </tr>
                     }
@@ -117,16 +126,3 @@
         }
     </CascadingValue>
 </div>
-
-
-@code {
-    /// <summary>
-    /// Defines the table body content when there are no matching records found
-    /// </summary>
-    [Parameter] public RenderFragment NoRecordsContent { get; set; } = @<p>No matching records found</p>;
-
-    /// <summary>
-    /// Defines the table body content when the table has no rows and is loading
-    /// </summary>
-    [Parameter] public RenderFragment LoadingContent { get; set; } = @<p>Loading...</p>;
-}

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -38,6 +38,16 @@ namespace MudBlazor
         internal string GetHorizontalScrollbarStyle() => HorizontalScrollbar ? ";display: block; overflow-x: auto;" : string.Empty;
 
         /// <summary>
+        /// The localizable "No matching records found" text.
+        /// </summary>
+        [Parameter] public string NoRecordsString { get; set; } = "No matching records found";
+
+        /// <summary>
+        /// The localizable "Loading..." text.
+        /// </summary>
+        [Parameter] public string LoadingString { get; set; } = "Loading...";
+
+        /// <summary>
         /// The data to display in the table. MudTable will render one row per item
         /// </summary>
         [Parameter]
@@ -289,6 +299,7 @@ namespace MudBlazor
             if (ServerData == null)
                 return;
 
+            Loading = true;
             var label = Context.CurrentSortLabel;
 
             var state = new TableState
@@ -300,6 +311,7 @@ namespace MudBlazor
             };
 
             _server_data = await ServerData(state);
+            Loading = false;
             StateHasChanged();
             Context?.PagerStateHasChanged?.Invoke();
         }

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -31,6 +31,16 @@ namespace MudBlazor
         [Parameter] public RenderFragment<T> RowEditingTemplate { get; set; }
 
         /// <summary>
+        /// Defines the table body content when there are no matching records found
+        /// </summary>
+        [Parameter] public RenderFragment NoRecordsContent { get; set; }
+
+        /// <summary>
+        /// Defines the table body content  the table has no rows and is loading
+        /// </summary>
+        [Parameter] public RenderFragment LoadingContent { get; set; }
+
+        /// <summary>
         /// Defines if the table has a horizontal scrollbar.
         /// </summary>
         [Parameter] public bool HorizontalScrollbar { get; set; }
@@ -301,6 +311,10 @@ namespace MudBlazor
             };
 
             _server_data = await ServerData(state);
+
+            if (CurrentPage * RowsPerPage > _server_data.TotalItems)
+                CurrentPage = 0;
+
             Loading = false;
             StateHasChanged();
             Context?.PagerStateHasChanged?.Invoke();

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -38,16 +38,6 @@ namespace MudBlazor
         internal string GetHorizontalScrollbarStyle() => HorizontalScrollbar ? ";display: block; overflow-x: auto;" : string.Empty;
 
         /// <summary>
-        /// The localizable "No matching records found" text.
-        /// </summary>
-        [Parameter] public string NoRecordsString { get; set; } = "No matching records found";
-
-        /// <summary>
-        /// The localizable "Loading..." text.
-        /// </summary>
-        [Parameter] public string LoadingString { get; set; } = "Loading...";
-
-        /// <summary>
         /// The data to display in the table. MudTable will render one row per item
         /// </summary>
         [Parameter]

--- a/src/MudBlazor/Styles/components/_table.scss
+++ b/src/MudBlazor/Styles/components/_table.scss
@@ -338,6 +338,20 @@
     display: none;
 }
 
+.mud-table-loading {
+    position: relative;
+
+    & .mud-table-loading-progress {
+        position: absolute;
+        width: 100%;
+    }
+}
+
+.mud-table-empty-row {
+    vertical-align: middle;
+    text-align: center;
+}
+
 @mixin table-display-smalldevices ($breakpoint) {
     .mud-#{$breakpoint}table {
         .mud-table-root .mud-table-head,


### PR DESCRIPTION
- Set loading in table automatically for server side pagination
- Have text when there are no rows found / when loading in table
- table progress loader is put over the first row instead of between the first row and Thead.
![TableEmptyRow](https://user-images.githubusercontent.com/83287840/122119695-c5a77880-ce29-11eb-88f4-a79e0fb11d5d.gif)
