### PR TITLE
Carousel Improvements

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Autocomplete/AutocompletePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Autocomplete/AutocompletePage.razor
@@ -48,7 +48,8 @@
                 <Title>Validation</Title>
                 <Description>
                     Below there are different examples of validation with the MudAutocomplete control. The validation uses an EditForm or a MudForm. The result and display will vary if the 
-                    <CodeInline Tag="true">CoerceValue</CodeInline> option is set to <CodeInline Tag="true">true</CodeInline>. But also if characters are typed into the control instead of a selection from the dropdown list.
+                    <CodeInline Tag="true">CoerceValue</CodeInline> option is set to <CodeInline Tag="true">true</CodeInline>. But also if characters are typed into the control instead of a selection from the dropdown list.<br/>
+                    For more info on form validation check out <MudLink Href="/components/form">Form</MudLink>.
                 </Description>
             </SectionHeader>
             <SectionContent Outlined="true" DisplayFlex="true">

--- a/src/MudBlazor.Docs/Pages/Components/Autocomplete/AutocompletePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Autocomplete/AutocompletePage.razor
@@ -3,7 +3,7 @@
 
 <DocsPage>
     <DocsPageHeader Title="Autocomplete"
-        SubTitle="The autocomplete component offers simple and flexible type-ahead functionality.">
+        SubTitle="The Autocomplete component offers simple and flexible type-ahead functionality.">
         <Description>
             It is great for searching a value from a long list of options. In comparison to a Select, the Autocomplete doesn't need to know the complete item list, 
             it only calls a search function which will return matching items. The search function can even run asynchronously, i.e. for database queries.

--- a/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompleteUsageExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompleteUsageExample.razor
@@ -9,7 +9,8 @@
     <MudItem xs="12" sm="6" md="4">
         <MudAutocomplete T="string" Label="US States" @bind-Value="value2" SearchFunc="@Search2" 
                          ResetValueOnEmptyText="@resetValueOnEmptyText" 
-                         CoerceText="@coerceText"  CoerceValue="@coerceValue"/>
+                         CoerceText="@coerceText"  CoerceValue="@coerceValue"
+                         AdornmentIcon="@Icons.Material.Filled.Search" AdornmentColor="Color.Primary" />
     </MudItem>
     <MudItem xs="12" md="12">
         <MudText Class="mb-n3" Typo="Typo.body2">

--- a/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompleteValidationExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompleteValidationExample.razor
@@ -6,6 +6,7 @@
         <EditForm EditContext="editContext1">
         <DataAnnotationsValidator />
             <MudAutocomplete Label="US States" @bind-Value="choice1.State" 
+             AdornmentIcon="@Icons.Material.Filled.Search" AdornmentColor="Color.Primary"
              SearchFunc="@SearchAsync" Immediate="true" CoerceValue="@coerceValue"
              For="@(() => choice1.State)"/>
             <MudButton ButtonType="ButtonType.Button" Variant="Variant.Filled" Color="Color.Primary" 
@@ -30,6 +31,7 @@
         <EditForm EditContext="editContext2">
         <DataAnnotationsValidator />
             <MudAutocomplete Label="US States" @bind-Value="choice2.State" 
+             OpenIcon="@Icons.Material.Filled.Search" AdornmentColor="Color.Secondary"
              SearchFunc="@SearchAsync" Immediate="true" CoerceValue="@coerceValue"
              Validation="@(new Func<string, IEnumerable<string>>(Validate))" />
             <MudButton ButtonType="ButtonType.Button" Variant="Variant.Filled" Color="Color.Primary" 
@@ -53,6 +55,7 @@
     <MudItem xs="12" sm="6" md="4">
         <MudForm @ref="form" @bind-Errors="@errors">
             <MudAutocomplete T="string" Label="US States" @bind-Value="choice3.State" 
+             CloseIcon="@Icons.Material.Filled.Search" AdornmentColor="Color.Tertiary"
              SearchFunc="@SearchAsync" Immediate="true" CoerceValue="@coerceValue"
              Validation="@(new Func<string, IEnumerable<string>>(Validate))" />
             <MudButton Variant="Variant.Filled" Color="Color.Primary" Class="ml-auto mt-3 mb-3" 

--- a/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompleteValidationExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompleteValidationExample.razor
@@ -5,76 +5,49 @@
     <MudItem xs="12" sm="6" md="4">
         <EditForm EditContext="editContext1">
         <DataAnnotationsValidator />
-            <MudAutocomplete Label="US States" @bind-Value="choice1.State" 
+            <MudAutocomplete Label="US States" @bind-Value="choice1.State" Required="true"
+             SearchFunc="@SearchAsync" Immediate="true" CoerceValue="@coerceValue" ResetValueOnEmptyText="true"
              AdornmentIcon="@Icons.Material.Filled.Search" AdornmentColor="Color.Primary"
-             SearchFunc="@SearchAsync" Immediate="true" CoerceValue="@coerceValue"
              For="@(() => choice1.State)"/>
             <MudButton ButtonType="ButtonType.Button" Variant="Variant.Filled" Color="Color.Primary" 
              Class="ml-auto mt-3 mb-3" OnClick="@(()=>success1=editContext1.Validate())">Validate</MudButton>
-            <MudExpansionPanels>
-                <MudExpansionPanel Text="@($"Show Errors or Success")">
                    @if (success1)
                    {
                        <MudText Color="Color.Success">Success</MudText>
                    }
-                   else
-                   {
-                       <MudText Color="@Color.Error">
-                           <ValidationSummary />
-                       </MudText>
-                   }
-                </MudExpansionPanel>
-            </MudExpansionPanels>
-       </EditForm>
+        </EditForm>
     </MudItem>
     <MudItem xs="12" sm="6" md="4">
         <EditForm EditContext="editContext2">
         <DataAnnotationsValidator />
-            <MudAutocomplete Label="US States" @bind-Value="choice2.State" 
+            <MudAutocomplete Label="US States" @bind-Value="choice2.State" Required="true"
+             SearchFunc="@SearchAsync" Immediate="true" CoerceValue="@coerceValue" ResetValueOnEmptyText="true"
              OpenIcon="@Icons.Material.Filled.Search" AdornmentColor="Color.Secondary"
-             SearchFunc="@SearchAsync" Immediate="true" CoerceValue="@coerceValue"
              Validation="@(new Func<string, IEnumerable<string>>(Validate))" />
             <MudButton ButtonType="ButtonType.Button" Variant="Variant.Filled" Color="Color.Primary" 
-             Class="ml-auto mt-3 mb-3" OnClick="@(()=>success2=editContext2.Validate())">Validate</MudButton>
-            <MudExpansionPanels>
-                <MudExpansionPanel Text="@($"Show Errors or Success")">
+                       Class="ml-auto mt-3 mb-3" OnClick="@(()=>success2=editContext2.Validate())">Validate</MudButton>
                    @if (success2)
                    {
                        <MudText Color="Color.Success">Success</MudText>
                    }
-                   else
-                   {
-                       <MudText Color="@Color.Error">
-                           <ValidationSummary />
-                       </MudText>
-                   }
-                </MudExpansionPanel>
-            </MudExpansionPanels>
-       </EditForm>
+        </EditForm>
     </MudItem>
     <MudItem xs="12" sm="6" md="4">
-        <MudForm @ref="form" @bind-Errors="@errors">
-            <MudAutocomplete T="string" Label="US States" @bind-Value="choice3.State" 
+        <MudForm @ref="form">
+            <MudAutocomplete T="string" Label="US States" @bind-Value="choice3.State" Required="true"
+             SearchFunc="@SearchAsync" Immediate="true" CoerceValue="@coerceValue" ResetValueOnEmptyText="true"
              CloseIcon="@Icons.Material.Filled.Search" AdornmentColor="Color.Tertiary"
-             SearchFunc="@SearchAsync" Immediate="true" CoerceValue="@coerceValue"
              Validation="@(new Func<string, IEnumerable<string>>(Validate))" />
             <MudButton Variant="Variant.Filled" Color="Color.Primary" Class="ml-auto mt-3 mb-3" 
              OnClick="@(()=>form.Validate())">Validate</MudButton>
-            <MudExpansionPanels>
-                <MudExpansionPanel Text="@($"Show Errors or Success")">
-                    @if (errors.Length == 0)
+                    @if (form.IsTouched && form.IsValid)
                     {
                         <MudText Color="Color.Success">Success</MudText>
                     }
                     else
                     {
-                        @foreach (var error in errors)
-                        {
-                            <MudText Color="@Color.Error">@error</MudText>
-                        }
+                        <MudText>IsTouched: @form.IsTouched, IsValid: @form.IsValid</MudText>
                     }
-                </MudExpansionPanel>
-            </MudExpansionPanels>
         </MudForm>
 	</MudItem>
     <MudItem xs="12" md="12">
@@ -88,7 +61,6 @@
 </MudGrid>
 
 @code {
-    private string[] errors = { };
     private MudForm form;
     private bool coerceValue;
     private bool success1;

--- a/src/MudBlazor.Docs/Pages/Components/Drawer/DrawerPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Drawer/DrawerPage.razor
@@ -1,19 +1,27 @@
 ﻿@page "/components/drawer"
 
 <DocsPage MaxWidth="MaxWidth.Large">
-    <DocsPageHeader Title="Drawer">
-        <Description>
-            If you use two-way binding <CodeInline>@("@bind-Open=\"...\"")</CodeInline> you can toggle the drawer and it will close itself on navigation. If you set its <CodeInline>Open</CodeInline> parameter without two-way binding
-            you effectively force it to stay open or closed depending on the provided value.
-            <MudAlert Severity="Severity.Warning" Dense="true" Class="mt-3">Common pitfall: use <CodeInline>@("@bind-Open")</CodeInline> instead of <CodeInline>@("Open")</CodeInline> for auto-closing to work.</MudAlert>
-        </Description>
+    <DocsPageHeader Title="Drawer"
+                    SubTitle="Navigation Drawers provide access to destinations in your app.">
     </DocsPageHeader>
+
     <DocsPageContent>
         <DocsPageSection>
             <SectionHeader>
-                <Title>Temporary drawer</Title>
+                <Title>Basic Usage</Title>
                 <Description>
-                    Temporary drawers can be opened temporary above all other content until a section is selected or clicked on an overlay.
+                    If you use two-way binding <CodeInline>@("@bind-Open=\"...\"")</CodeInline> you can toggle the Drawer and it will close itself on navigation. If you set its <CodeInline>Open</CodeInline> parameter without two-way binding
+                    you effectively force it to stay open or closed depending on the provided value.
+                    <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">Always use <CodeInline>@("@bind-Open")</CodeInline> instead of <CodeInline>@("Open")</CodeInline> for auto-closing to work.</MudAlert>
+                </Description>
+
+            </SectionHeader>
+
+            <SectionHeader>
+                <Title>Temporary Drawer</Title>
+                <Description>
+                    Temporary Drawers can be opened temporary above all other content until a section is selected or clicked on an overlay.
+                    <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">Currently only Temporary Drawer supports the <CodeInline>Anchor.Top</CodeInline> and <CodeInline>Anchor.Bottom</CodeInline> parameters.</MudAlert>
                 </Description>
             </SectionHeader>
             <SectionContent Outlined="true">
@@ -25,7 +33,7 @@
             <SectionHeader>
                 <Title>Hide overlay</Title>
                 <Description>
-                    With parameter <CodeInline>DisableOverlay</CodeInline> overlay can be turned off for responsive and temporary drawers.
+                    With parameter <CodeInline>DisableOverlay</CodeInline> overlay can be turned off for Responsive and Temporary Drawers.
                 </Description>
             </SectionHeader>
             <SectionContent Outlined="true">
@@ -35,10 +43,10 @@
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>
-                <Title>Persistent drawer</Title>
+                <Title>Persistent Drawer</Title>
                 <Description>
-                    Persistent drawer is outside of its container, when opens it forces other contents to change their size.
-                    Persistent drawer will be opened until the <CodeInline>Open</CodeInline> parameter is not changed.
+                    Persistent Drawer is outside of its container, when opens it forces other contents to change their size.
+                    Persistent Drawer will be opened until the <CodeInline>Open</CodeInline> parameter is not changed.
                 </Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" FullWidth="true">
@@ -48,10 +56,10 @@
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>
-                <Title>Anchor drawer</Title>
+                <Title>Anchor Drawer</Title>
                 <Description>
-                    With the <CodeInline>Anchor</CodeInline> property you can set the drawer to left or right. The default mode is left.
-                    This example uses persistent drawers.
+                    With the <CodeInline>Anchor</CodeInline> property you can set the Drawer to left or right. The default mode is left.
+                    This example uses Persistent Drawers.
                 </Description>
             </SectionHeader>
             <SectionContent Outlined="true" FullWidth="true">
@@ -61,9 +69,9 @@
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>
-                <Title>Left/right drawer</Title>
+                <Title>Left/Right Drawer</Title>
                 <Description>
-                    <CodeInline>Anchor.Left</CodeInline> and <CodeInline>Anchor.Right</CodeInline> makes drawer's position absolute, they will not follow RTL-LTR changes. 
+                    <CodeInline>Anchor.Left</CodeInline> and <CodeInline>Anchor.Right</CodeInline> makes Drawer's position absolute, they will not follow RTL-LTR changes.
                 </Description>
             </SectionHeader>
             <SectionContent Outlined="true" FullWidth="true">
@@ -73,10 +81,10 @@
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>
-                <Title>Responsive drawer</Title>
+                <Title>Responsive Drawer</Title>
                 <Description>
-                    Responsive drawers are behaves persistent on wider screens and temporary on smaller ones.
-                    Opened drawer closes automatically when window size becomes small, and opens after orginal state has been restored.
+                    Responsive Drawers behaves persistent on wider screens and temporary on smaller ones.
+                    Opened Drawer closes automatically when window size becomes small, and opens after orginal state has been restored.
                 </Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" FullWidth="true">
@@ -84,15 +92,15 @@
                     <DrawerResponsiveExample />
                 </iframe>
             </SectionContent>
-            <SectionSource Code="DrawerResponsiveExample" GitHubFolderName="Drawer" />
+            <SectionSource Code="DrawerResponsiveExample" ShowCode="false" GitHubFolderName="Drawer" />
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>
                 <Title>Clipping</Title>
                 <Description>
-                    A drawer with <CodeInline>ClipMode="Docked"</CodeInline> or <CodeInline>ClipMode="Always"</CodeInline> will not push the AppBar to the side when opening.
-                    This parameter is evaluated only when drawers are used inside a <CodeInline>MudLayout</CodeInline> directly.
-                    This example shows how a different options work with a responsive drawer. Change the size of the window to test all possiblities.
+                    A Drawer with <CodeInline>ClipMode="Docked"</CodeInline> or <CodeInline>ClipMode="Always"</CodeInline> will not push the AppBar to the side when opening.
+                    This parameter is evaluated only when Drawers are used inside a <CodeInline>MudLayout</CodeInline> directly.
+                    This example shows how a different options work with a Responsive Drawer. Change the size of the window to test all possiblities.
                 </Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" FullWidth="true">
@@ -106,7 +114,7 @@
             <SectionHeader>
                 <Title>Custom Breakpoint</Title>
                 <Description>
-                    The switching point for responsive drawers can be changed using <CodeInline>Breakpoint</CodeInline> parameter. The default is <CodeInline>Breakpoint.Md</CodeInline>
+                    The switching point for Responsive Drawers can be changed using <CodeInline>Breakpoint</CodeInline> parameter. The default is <CodeInline>Breakpoint.Md</CodeInline>
                 </Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" FullWidth="true">
@@ -118,9 +126,9 @@
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>
-                <Title>Mini drawer</Title>
+                <Title>Mini Drawer</Title>
                 <Description>
-                    Using mini variant the drawer will shrink (default 56px). Currently only has built-in style support for MudNavLinks.
+                    Using Mini variant the Drawer will shrink (default 56px). Currently only has built-in style support for MudNavLinks.
                 </Description>
             </SectionHeader>
             <SectionContent Outlined="true" FullWidth="true">
@@ -130,9 +138,9 @@
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>
-                <Title>Mini drawer customization</Title>
+                <Title>Mini Drawer Customization</Title>
                 <Description>
-                    This example demonstrates how the combination of several parameters will affect the behaviour of a mini drawer.
+                    This example demonstrates how the combination of several parameters will affect the behaviour of a Mini Drawer.
                 </Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" FullWidth="true">
@@ -144,24 +152,24 @@
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>
-                <Title>Sizing drawers</Title>
+                <Title>Sizing Drawers</Title>
                 <Description>
-                    It is possible to apply custom width/height values for drawers. The following examples demonstrate how to do it for different types of drawers.
+                    It is possible to apply custom width/height values for Sizing Drawers. The following examples demonstrate how to do it for different types of Drawers.
                 </Description>
             </SectionHeader>
 
             <SectionHeader>
-                <SubTitle>1. Change drawers inside <CodeInline>MudLayout</CodeInline></SubTitle>
+                <SubTitle>1. Change Drawers inside <CodeInline>MudLayout</CodeInline></SubTitle>
                 <Description>
-                    Changing the default width (240px) of a left and/or right drawer is possible through setting
+                    Changing the default width (240px) of a left and/or right Drawer is possible through setting
                     <CodeInline>DrawerWidthLeft</CodeInline> and/or <CodeInline>DrawerWidthRight</CodeInline> layout properties.
-                    For mini drawers <CodeInline>DrawerMiniWidthLeft</CodeInline> and/or <CodeInline>DrawerMiniWidthRight</CodeInline> can be used.
+                    For Mini Drawers <CodeInline>DrawerMiniWidthLeft</CodeInline> and/or <CodeInline>DrawerMiniWidthRight</CodeInline> can be used.
                     For more information see <MudLink Href="/customization/default-theme">customization page</MudLink>.
                 </Description>
             </SectionHeader>
 
             <SectionHeader>
-                <SubTitle>2. Change size for temporary drawers</SubTitle>
+                <SubTitle>2. Change size for Temporary Drawers</SubTitle>
                 <Description>Changing the default size is possible by setting the <CodeInline>Width</CodeInline> or <CodeInline>Height</CodeInline> parameters.</Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true">
@@ -170,7 +178,7 @@
             <SectionSource Code="DrawerSizeTemporaryExample" ShowCode="false" GitHubFolderName="Drawer" />
 
             <SectionHeader>
-                <SubTitle>3. Change size for persistent drawers inside <CodeInline>MudDrawerContainer</CodeInline></SubTitle>
+                <SubTitle>3. Change size for Persistent Drawers inside <CodeInline>MudDrawerContainer</CodeInline></SubTitle>
                 <Description>Changing the default size is possible by setting the <CodeInline>Width</CodeInline> parameter.</Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" FullWidth="true">

--- a/src/MudBlazor.Docs/Pages/Components/Select/Examples/MultiSelectCustomizedExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Select/Examples/MultiSelectCustomizedExample.razor
@@ -3,8 +3,9 @@
 
 <MudGrid>
     <MudItem xs="12" md="12">
-        <MudSelect T="string" Label="US States" HelperText="Pick your favorite states" MultiSelection="true" 
-         @bind-Value="value" @bind-SelectedValues="options"
+        <MudSelect T="string" Label="US States" HelperText="Pick your favorite states"
+         MultiSelection="true" OffsetY="true"
+         @bind-Value="value" @bind-SelectedValues="options" AdornmentIcon="@Icons.Material.Filled.Search"
          MultiSelectionTextFunc="@(new Func<List<string>, string>(GetMultiSelectionText))">
             @foreach (var state in states)
             {

--- a/src/MudBlazor.Docs/Pages/Components/Select/Examples/SelectDenseExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Select/Examples/SelectDenseExample.razor
@@ -1,8 +1,9 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 
-<MudSelect T="string" Label="Dense" Dense="true">
-    <MudSelectItem T="string" Value="@("Tyrannosaur")"/>
-    <MudSelectItem T="string" Value="@("Triceratops")"/>
-    <MudSelectItem T="string" Value="@("Oviraptor")"/>
+<MudSelect T="string" Label="Dense" Dense="true"
+           AdornmentIcon="@Icons.Material.Filled.Search">
+    <MudSelectItem Value="@("Tyrannosaur")"/>
+    <MudSelectItem Value="@("Triceratops")"/>
+    <MudSelectItem Value="@("Oviraptor")"/>
 </MudSelect>

--- a/src/MudBlazor.Docs/Pages/Components/Select/Examples/SelectDisabledExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Select/Examples/SelectDisabledExample.razor
@@ -1,7 +1,8 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 
-<MudSelect T="string" Label="Disabled" Disabled="true">
-    <MudSelectItem T="string" Value="@("foo")">Foo</MudSelectItem>
-    <MudSelectItem T="string" Value="@("bar")">Bar</MudSelectItem>
+<MudSelect T="string" Label="Disabled" Disabled="true"
+           AdornmentIcon="@Icons.Material.Filled.SearchOff" AdornmentColor="Color.Primary">
+    <MudSelectItem Value="@("foo")">Foo</MudSelectItem>
+    <MudSelectItem Value="@("bar")">Bar</MudSelectItem>
 </MudSelect>

--- a/src/MudBlazor.Docs/Pages/Components/Select/Examples/SelectUsageExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Select/Examples/SelectUsageExample.razor
@@ -4,14 +4,16 @@
 
 <MudGrid>
     <MudItem xs="12" sm="6" md="4">
-        <MudSelect Label="Select fast-food" @bind-Value="stringValue" HelperText="String">
+        <MudSelect Label="Select fast-food" @bind-Value="stringValue" HelperText="String"
+                   OffsetY="true" AdornmentIcon="@Icons.Material.Filled.Fastfood" AdornmentColor="Color.Primary">
             <MudSelectItem Value="@("Pizza")" Disabled="true">Pizza (Disabled)</MudSelectItem>
             <MudSelectItem Value="@("Burger")">Burger</MudSelectItem>
             <MudSelectItem Value="@("Hotdog")">Hot Dog</MudSelectItem>
         </MudSelect>
     </MudItem>
     <MudItem xs="12" sm="6" md="4">
-        <MudSelect Label="Select drink" @bind-Value="enumValue" HelperText="Enum">
+        <MudSelect Label="Select drink" @bind-Value="enumValue" HelperText="Enum"
+                   OffsetY="true" OpenIcon="@Icons.Material.Filled.LocalDrink" AdornmentColor="Color.Secondary">
             @foreach (Drink item in Enum.GetValues(typeof(Drink)))
             {
                 <MudSelectItem Value="@item">@item</MudSelectItem>
@@ -19,7 +21,8 @@
         </MudSelect>
     </MudItem>
     <MudItem xs="12" sm="6" md="4">
-        <MudSelect Placeholder="Select culture" @bind-Value="cultureValue" HelperText="CultureInfo" ToStringFunc="@convertFunc">
+        <MudSelect Placeholder="Select culture" @bind-Value="cultureValue" HelperText="CultureInfo" ToStringFunc="@convertFunc"
+                   OffsetY="true" CloseIcon="@Icons.Material.Filled.Flag" AdornmentColor="Color.Tertiary">
             <MudSelectItem Value="@(CultureInfo.GetCultureInfo("en-US"))"></MudSelectItem>
             <MudSelectItem Value="@(CultureInfo.GetCultureInfo("de-AT"))"></MudSelectItem>
             <MudSelectItem Value="@(CultureInfo.GetCultureInfo("pt-BR"))"></MudSelectItem>

--- a/src/MudBlazor.Docs/Pages/Components/Select/SelectPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Select/SelectPage.razor
@@ -14,7 +14,7 @@
                     <SelectVariantsExample />
                 </MudContainer>
             </SectionContent>
-            <SectionSource ShowCode="true" Code="SelectVariantsExample" GitHubFolderName="Select" />
+            <SectionSource ShowCode="false" Code="SelectVariantsExample" GitHubFolderName="Select" />
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader>

--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableVirtualizationExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableVirtualizationExample.razor
@@ -1,0 +1,49 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudTable Items="_items" Height="350px" Breakpoint="Breakpoint.Sm" Virtualize="true" FixedHeader="true">
+    <HeaderContent>
+        <MudTh>Column1</MudTh>
+        <MudTh>Column2</MudTh>
+        <MudTh>Column3</MudTh>
+        <MudTh>Column4</MudTh>
+        <MudTh>Column5</MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd DataLabel="Column1">@context.Column1</MudTd>
+        <MudTd DataLabel="Column2">@context.Column2</MudTd>
+        <MudTd DataLabel="Column3">@context.Column3</MudTd>
+        <MudTd DataLabel="Column4">@context.Column4</MudTd>
+        <MudTd DataLabel="Column5">@context.Column5</MudTd>
+    </RowTemplate>
+</MudTable>
+
+@code {
+    public class TestItem
+    {
+        public string Column1 { get; set; }
+        public string Column2 { get; set; }
+        public string Column3 { get; set; }
+        public string Column4 { get; set; }
+        public string Column5 { get; set; }
+    }
+
+
+    private List<TestItem> _items;
+
+    protected override void OnInitialized()
+    {
+        _items = new List<TestItem>();
+        for (int i = 0; i < 20000; i++)
+        {
+            _items.Add(new TestItem
+            {
+                Column1 = $"Value_{i}",
+                Column2 = $"Value_{i}",
+                Column3 = $"Value_{i}",
+                Column4 = $"Value_{i}",
+                Column5 = $"Value_{i}",
+            });
+        }
+    }
+
+}

--- a/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
@@ -153,7 +153,7 @@
             </SectionContent>
             <SectionSource Code="TableRelationalExample" ShowCode="false" GitHubFolderName="Table" />
         </DocsPageSection>
-        
+
         <DocsPageSection>
             <SectionHeader>
                 <Title>Table with horizontal Scrolling</Title>
@@ -162,9 +162,22 @@
                 </Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" FullWidth="true">
-                <TableHorizontalScrollExample/>
+                <TableHorizontalScrollExample />
             </SectionContent>
-            <SectionSource Code="TableHorizontalScrollExample" ShowCode="false" GitHubFolderName="Table"/>
+            <SectionSource Code="TableHorizontalScrollExample" ShowCode="false" GitHubFolderName="Table" />
+        </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader>
+                <Title>Table Virtualization</Title>
+                <Description>
+                    You can virtualize the results of a table to increase rendering speed.
+                </Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" FullWidth="true">
+                <TableVirtualizationExample />
+            </SectionContent>
+            <SectionSource Code="TableVirtualizationExample" ShowCode="false" GitHubFolderName="Table" />
         </DocsPageSection>
 
     </DocsPageContent>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteRequiredTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteRequiredTest.razor
@@ -1,0 +1,36 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudAutocomplete @bind-Value="value" SearchFunc="@Search" Label="RequiredTest" Required="true"/>
+
+@code
+{
+    public static string __description__ = "The Autocomplete should not show required-error initially. The first (empty) item should.";
+
+    string value = null;
+
+    private string[] states =
+{
+        string.Empty,
+        "Alabama", "Alaska", "American Samoa", "Arizona",
+        "Arkansas", "California", "Colorado", "Connecticut",
+        "Delaware", "District of Columbia", "Federated States of Micronesia",
+        "Florida", "Georgia", "Guam", "Hawaii", "Idaho",
+        "Illinois", "Indiana", "Iowa", "Kansas", "Kentucky",
+        "Louisiana", "Maine", "Marshall Islands", "Maryland",
+        "Massachusetts", "Michigan", "Minnesota", "Mississippi",
+        "Missouri", "Montana", "Nebraska", "Nevada",
+        "New Hampshire", "New Jersey", "New Mexico", "New York",
+        "North Carolina", "North Dakota", "Northern Mariana Islands", "Ohio",
+        "Oklahoma", "Oregon", "Palau", "Pennsylvania", "Puerto Rico",
+        "Rhode Island", "South Carolina", "South Dakota", "Tennessee",
+        "Texas", "Utah", "Vermont", "Virgin Island", "Virginia",
+        "Washington", "West Virginia", "Wisconsin", "Wyoming",
+    };
+
+    private async Task<IEnumerable<string>> Search(string value)
+    {
+        await Task.CompletedTask;
+
+        return string.IsNullOrEmpty(value) ? states : states.Where(x => x.Contains(value, StringComparison.InvariantCultureIgnoreCase));
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectRequiredTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectRequiredTest.razor
@@ -1,0 +1,15 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudSelect @bind-Value="value" Label="RequiredTest" Required="true">
+    <MudSelectItem Value="@(string.Empty)" />
+    <MudSelectItem Value="@("1")" />
+    <MudSelectItem Value="@("2")" />
+    <MudSelectItem Value="@("3")" />
+</MudSelect>
+
+@code
+{
+    public static string __description__ = "The Select should not show required-error initially. The first (empty) item should.";
+
+    string value = null;
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/HtmlTextTabsTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/HtmlTextTabsTest.razor
@@ -1,0 +1,14 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudTabs @ref="Tabs">
+    <MudTabPanel Text="Hello <span>World</span>!">
+        <MudText>Content One with HTML panel text</MudText>
+    </MudTabPanel>
+    <MudTabPanel Text="Hello World!">
+        <MudText>Content Two without HTML panel text</MudText>
+    </MudTabPanel>
+</MudTabs>
+
+@code {
+    public MudTabs Tabs;
+}

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -363,5 +363,23 @@ namespace MudBlazor.UnitTests.Components
             autocomplete.ValidationErrors.Should().BeEmpty();
         }
         #endregion
+
+
+        /// <summary>
+        /// Tests the required property.
+        /// </summary>
+        [Test]
+        public async Task Autocomplete_Should_SetRequiredTrue()
+        {
+            var comp = ctx.RenderComponent<AutocompleteRequiredTest>();
+
+            var autocomplete = comp.FindComponent<MudAutocomplete<string>>().Instance;
+
+            autocomplete.Required.Should().BeTrue();
+
+            await comp.InvokeAsync(() => autocomplete.Validate());
+
+            autocomplete.ValidationErrors.First().Should().Be("Required");
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -380,6 +380,57 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public void IsDateDisabledFunc_DisablesCalendarDateButtons()
+        {
+            Func<DateTime, bool> isDisabledFunc = date => true;
+            var comp = OpenPicker(Parameter(nameof(MudDatePicker.IsDateDisabledFunc), isDisabledFunc));
+
+            comp.Instance.IsDateDisabledFunc.Should().Be(isDisabledFunc);
+            comp.FindAll("button.mud-picker-calendar-day").Select(button => (button as IHtmlButtonElement).IsDisabled)
+                .Should().OnlyContain(disabled => disabled == true);
+        }
+
+        [Test]
+        public void IsDateDisabledFunc_SettingDateToADisabledDateYieldsNull()
+        {
+            var wasEventCallbackCalled = false;
+            Func<DateTime, bool> isDisabledFunc = date => true;
+            var comp = ctx.RenderComponent<MudDatePicker>(
+                Parameter(nameof(MudDatePicker.IsDateDisabledFunc), isDisabledFunc),
+                EventCallback("DateChanged", (DateTime? _) => wasEventCallbackCalled = true)
+            );
+
+            comp.SetParam(picker => picker.Date, DateTime.Now);
+
+            comp.Instance.Date.Should().BeNull();
+            wasEventCallbackCalled.Should().BeFalse();
+        }
+
+        [Test]
+        public void IsDateDisabledFunc_SettingDateToAnEnabledDateYieldsTheDate()
+        {
+            var wasEventCallbackCalled = false;
+            var today = DateTime.Today;
+            Func<DateTime, bool> isDisabledFunc = date => date < today;
+            var comp = ctx.RenderComponent<MudDatePicker>(
+                Parameter(nameof(MudDatePicker.IsDateDisabledFunc), isDisabledFunc),
+                EventCallback("DateChanged", (DateTime? _) => wasEventCallbackCalled = true)
+            );
+
+            comp.SetParam(picker => picker.Date, today);
+
+            comp.Instance.Date.Should().Be(today);
+            wasEventCallbackCalled.Should().BeTrue();
+        }
+
+        [Test]
+        public void IsDateDisabledFunc_NoDisabledDatesByDefault()
+        {
+            var comp = OpenPicker();
+            comp.FindAll("button.mud-picker-calendar-day").Select(button => (button as IHtmlButtonElement).IsDisabled)
+                .Should().OnlyContain(disabled => disabled == false);
+        }
+      
         public async Task CheckAutoCloseDatePickerTest()
         {
             // Define a date for comparison

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -572,5 +572,23 @@ namespace MudBlazor.UnitTests.Components
             select.ValidationErrors.Should().BeEmpty();
         }
         #endregion
+
+
+        /// <summary>
+        /// Tests the required property.
+        /// </summary>
+        [Test]
+        public async Task Select_Should_SetRequiredTrue()
+        {
+            var comp = ctx.RenderComponent<SelectRequiredTest>();
+
+            var select = comp.FindComponent<MudSelect<string>>().Instance;
+
+            select.Required.Should().BeTrue();
+
+            await comp.InvokeAsync(() => select.Validate());
+
+            select.ValidationErrors.First().Should().Be("Required");
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -866,6 +866,26 @@ namespace MudBlazor.UnitTests.Components
 
         }
 
+        [Test]
+        public async Task HtmlTextTabs()
+        {
+            ctx.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockResizeObserver()));
+
+            // get the tab panels, we must have 2 tabs, one with html text and one without
+            var comp = ctx.RenderComponent<HtmlTextTabsTest>();
+            Console.WriteLine(comp.Markup);
+            var panels = comp.FindAll(".mud-tab");
+            panels.Should().HaveCount(2);
+
+            // index 0 : html text "Hello <span>World</span>!"
+            panels[0].InnerHtml.Contains("Hello <span>World</span>!").Should().BeTrue();
+            panels[0].TextContent.Contains("Hello World!").Should().BeTrue();
+
+            // index 1 : simple text without html "Hello World!"
+            panels[1].InnerHtml.Contains("Hello World!").Should().BeTrue();
+            panels[1].TextContent.Contains("Hello World!").Should().BeTrue();
+        }
+
         #region Helper
 
         private static double GetSliderValue(IRenderedComponent<ScrollableTabsTest> comp, string attribute = "left")

--- a/src/MudBlazor.sln
+++ b/src/MudBlazor.sln
@@ -24,8 +24,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MudBlazor.Examples.Data", "MudBlazor.Examples.Data\MudBlazor.Examples.Data.csproj", "{D9290286-6DD8-478C-A902-23660C554A1C}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MyMudBlazorTestApp", "..\..\MyMudBlazorTestApp\MyMudBlazorTestApp\MyMudBlazorTestApp\MyMudBlazorTestApp.csproj", "{6651F0CA-D8D5-4D6F-9247-96417A0C4ECD}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -64,10 +62,6 @@ Global
 		{D9290286-6DD8-478C-A902-23660C554A1C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D9290286-6DD8-478C-A902-23660C554A1C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D9290286-6DD8-478C-A902-23660C554A1C}.Release|Any CPU.Build.0 = Release|Any CPU
-		{6651F0CA-D8D5-4D6F-9247-96417A0C4ECD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{6651F0CA-D8D5-4D6F-9247-96417A0C4ECD}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6651F0CA-D8D5-4D6F-9247-96417A0C4ECD}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6651F0CA-D8D5-4D6F-9247-96417A0C4ECD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/MudBlazor.sln
+++ b/src/MudBlazor.sln
@@ -24,6 +24,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MudBlazor.Examples.Data", "MudBlazor.Examples.Data\MudBlazor.Examples.Data.csproj", "{D9290286-6DD8-478C-A902-23660C554A1C}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MyMudBlazorTestApp", "..\..\MyMudBlazorTestApp\MyMudBlazorTestApp\MyMudBlazorTestApp\MyMudBlazorTestApp.csproj", "{6651F0CA-D8D5-4D6F-9247-96417A0C4ECD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -62,6 +64,10 @@ Global
 		{D9290286-6DD8-478C-A902-23660C554A1C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D9290286-6DD8-478C-A902-23660C554A1C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D9290286-6DD8-478C-A902-23660C554A1C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6651F0CA-D8D5-4D6F-9247-96417A0C4ECD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6651F0CA-D8D5-4D6F-9247-96417A0C4ECD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6651F0CA-D8D5-4D6F-9247-96417A0C4ECD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6651F0CA-D8D5-4D6F-9247-96417A0C4ECD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/MudBlazor/Base/MudBaseItemsControl.cs
+++ b/src/MudBlazor/Base/MudBaseItemsControl.cs
@@ -71,17 +71,17 @@ namespace MudBlazor
             return base.OnAfterRenderAsync(firstRender);
         }
 
-        internal bool _movenext = true;
+        internal bool _moveNext = true;
 
         /// <summary>
         /// Move to Previous Item
         /// </summary>
         public void Previous()
         {
-            _movenext = false;
+            _moveNext = false;
 
             if (SelectedIndex > 0)
-                SelectedIndex -= 1;
+                SelectedIndex--;
             else
                 SelectedIndex = Items.Count - 1;
         }
@@ -91,10 +91,10 @@ namespace MudBlazor
         /// </summary>
         public void Next()
         {
-            _movenext = true;
+            _moveNext = true;
 
             if (SelectedIndex < (Items.Count - 1))
-                SelectedIndex += 1;
+                SelectedIndex++;
             else
                 SelectedIndex = 0;
         }
@@ -104,11 +104,12 @@ namespace MudBlazor
         /// </summary>
         public void MoveTo(int index)
         {
-            _movenext = (index >= SelectedIndex);
-            SelectedIndex = index;
+            if (SelectedIndex != index)
+            {
+                _moveNext = index >= SelectedIndex;
+                SelectedIndex = index;
+            }
         }
-
-
     }
 
     public abstract class MudBaseBindableItemsControl<TChildComponent, TData> : MudBaseItemsControl<TChildComponent>

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -7,10 +7,18 @@
         <MudInputControl Label="@Label" Variant="@Variant" HelperText="@HelperText" FullWidth="@FullWidth" Margin="@Margin" Class="@Classname" Style="@Style"
                          Error="@Error" ErrorText="@ErrorText" Disabled="@Disabled" @onclick="@ToggleMenu" Required="@Required">
             <InputContent>
-                <MudInput T="string" @ref="_elementReference" InputType="InputType.Text" Variant="@Variant" @attributes="UserAttributes" Value="@Text" TextChanged="OnTextChanged" DisableUnderLine="@DisableUnderLine" Placeholder="@Placeholder" Disabled=@Disabled ReadOnly="@ReadOnly"
-                          Immediate="true" Margin="@Margin" Class="mud-select-input" Error="@Error" AdornmentIcon="@CurrentIcon" Adornment="@Adornment" AdornmentColor="@AdornmentColor" IconSize="@IconSize"
-                          OnBlur="@OnInputBlurred" OnKeyUp="@this.OnInputKeyUp"  autocomplete=@("mud-disabled-"+Guid.NewGuid()) KeyUpPreventDefault="KeyUpPreventDefault"
+                <MudInput @ref="_elementReference" InputType="InputType.Text"
+                          Class="mud-select-input" Margin="@Margin" 
+                          Variant="@Variant" Value="@Text" DisableUnderLine="@DisableUnderLine"
+                          Disabled="@Disabled" ReadOnly="@ReadOnly" Error="@Error"
+                          AdornmentIcon="@_currentIcon" Adornment="@Adornment" AdornmentColor="@AdornmentColor" IconSize="@IconSize"
                           Clearable="@Clearable" OnClearButtonClick="@OnClearButtonClick"
+                          @attributes="UserAttributes" 
+
+                          TextChanged="OnTextChanged" OnBlur="OnInputBlurred"
+                          OnKeyUp="@this.OnInputKeyUp" autocomplete=@("mud-disabled-"+Guid.NewGuid()) KeyUpPreventDefault="KeyUpPreventDefault"
+                          Placeholder="@Placeholder" Immediate="true"
+                          T="string"
                           />
                 @if (_items!=null && _items.Length!=0)
                 {

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -5,7 +5,7 @@
 <CascadingValue Name="Standalone" Value="false" IsFixed="true">
     <div class="mud-select mud-autocomplete" >
         <MudInputControl Label="@Label" Variant="@Variant" HelperText="@HelperText" FullWidth="@FullWidth" Margin="@Margin" Class="@Classname" Style="@Style"
-                         Error="@Error" ErrorText="@ErrorText" Disabled="@Disabled" @onclick="@ToggleMenu">
+                         Error="@Error" ErrorText="@ErrorText" Disabled="@Disabled" @onclick="@ToggleMenu" Required="@Required">
             <InputContent>
                 <MudInput T="string" @ref="_elementReference" InputType="InputType.Text" Variant="@Variant" @attributes="UserAttributes" Value="@Text" TextChanged="OnTextChanged" DisableUnderLine="@DisableUnderLine" Placeholder="@Placeholder" Disabled=@Disabled ReadOnly="@ReadOnly"
                           Immediate="true" Margin="@Margin" Class="mud-select-input" Error="@Error" AdornmentIcon="@CurrentIcon" Adornment="@Adornment" AdornmentColor="@AdornmentColor" IconSize="@IconSize"

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -64,12 +64,12 @@ namespace MudBlazor
         /// <summary>
         /// The Open Autocomplete Icon
         /// </summary>
-        [Parameter] public string OpenIcon { get; set; } = Icons.Material.Filled.ArrowDropUp;
+        [Parameter] public string OpenIcon { get; set; } = Icons.Material.Filled.ArrowDropDown;
 
         /// <summary>
         /// The Close Autocomplete Icon
         /// </summary>
-        [Parameter] public string CloseIcon { get; set; } = Icons.Material.Filled.ArrowDropDown;
+        [Parameter] public string CloseIcon { get; set; } = Icons.Material.Filled.ArrowDropUp;
 
         //internal event Action<HashSet<T>> SelectionChangedFromOutside;
 
@@ -165,7 +165,9 @@ namespace MudBlazor
             {
                 if (value == _isOpen)
                     return;
+
                 _isOpen = value;
+                UpdateIcon();
                 IsOpenChanged.InvokeAsync(_isOpen).AndForget();
             }
         }
@@ -175,14 +177,14 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public EventCallback<bool> IsOpenChanged { get; set; }
 
-        public string CurrentIcon { get; set; }
+        private string _currentIcon;
 
         private MudInput<string> _elementReference;
 
         public MudAutocomplete()
         {
-            IconSize = Size.Medium;
             Adornment = Adornment.End;
+            IconSize = Size.Medium;
         }
 
         public async Task SelectOption(T value)
@@ -193,7 +195,6 @@ namespace MudBlazor
             await SetTextAsync(GetItemString(value), false);
             _timer?.Dispose();
             IsOpen = false;
-            UpdateIcon();
             BeginValidate();
             StateHasChanged();
         }
@@ -213,20 +214,12 @@ namespace MudBlazor
                 RestoreScrollPosition();
                 await CoerceTextToValue();
             }
-            UpdateIcon();
             StateHasChanged();
         }
 
-        public void UpdateIcon()
+        private void UpdateIcon()
         {
-            if (IsOpen)
-            {
-                CurrentIcon = OpenIcon;
-            }
-            else
-            {
-                CurrentIcon = CloseIcon;
-            }
+            _currentIcon = !string.IsNullOrWhiteSpace(AdornmentIcon) ? AdornmentIcon : _isOpen ? CloseIcon : OpenIcon;
         }
 
         protected override void OnInitialized()
@@ -286,13 +279,11 @@ namespace MudBlazor
             {
                 await CoerceValueToText();
                 IsOpen = false;
-                UpdateIcon();
                 StateHasChanged();
                 return;
             }
 
             IsOpen = true;
-            UpdateIcon();
             StateHasChanged();
         }
 

--- a/src/MudBlazor/Components/Carousel/MudCarousel.razor
+++ b/src/MudBlazor/Components/Carousel/MudCarousel.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor
 @inherits MudBaseBindableItemsControl<MudCarouselItem, TData>
-@implements IDisposable
+@implements IAsyncDisposable
 @typeparam TData
 
 <div @attributes="UserAttributes" class="@Classname" style="@Style">

--- a/src/MudBlazor/Components/Carousel/MudCarousel.razor.cs
+++ b/src/MudBlazor/Components/Carousel/MudCarousel.razor.cs
@@ -1,11 +1,13 @@
 ﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.Extensions;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
 {
-    public partial class MudCarousel<TData> : MudBaseBindableItemsControl<MudCarouselItem, TData>, IDisposable
+    public partial class MudCarousel<TData> : MudBaseBindableItemsControl<MudCarouselItem, TData>, IAsyncDisposable
     {
 
         protected string Classname =>
@@ -20,9 +22,12 @@ namespace MudBlazor
                         .Build();
 
 
-        private System.Timers.Timer _autoCycleTimer;
+        private Timer _timer;
+        private bool _autoCycle = true;
+        private TimeSpan _cycleTimeout = TimeSpan.FromSeconds(5);
+        private Color _currentColor => SelectedContainer != null ? SelectedContainer.Color : Color.Inherit;
+        private void _timerElapsed(object stateInfo) => InvokeAsync(async () => await TimerTickAsync());
 
-        internal Color _currentColor = Color.Inherit;
 
         [CascadingParameter] public bool RightToLeft { get; set; }
 
@@ -35,36 +40,43 @@ namespace MudBlazor
         /// Gets or Sets if bottom bar with Delimiters musb be visible
         /// </summary>
         [Parameter] public bool ShowDelimiters { get; set; } = true;
-
-        private bool _autoCycleField = true;
+        
         /// <summary>
         /// Gets or Sets automatic cycle on item collection
         /// </summary>
         [Parameter] public bool AutoCycle
         {
-            get => _autoCycleField;
+            get => _autoCycle;
             set
             {
-                _autoCycleField = value;
-                if (AutoCycle == true)
-                    Timer_Reset();
+                _autoCycle = value;
+
+                if (_autoCycle)
+                    InvokeAsync(async () => await StartTimerAsync());
+
                 else
-                    Timer_Stop();
+                    InvokeAsync(async () => await StopTimerAsync());
             }
         }
-
-        public TimeSpan _autoCycleTimeField = TimeSpan.FromSeconds(5);
+                
         /// <summary>
         /// Gets or Sets the Auto Cycle time
         /// </summary>
         [Parameter] public TimeSpan AutoCycleTime
         {
-            get => _autoCycleTimeField;
+            get => _cycleTimeout;
             set
             {
-                _autoCycleTimeField = value;
-                if (AutoCycle == true)
-                    Timer_Reset();
+                _cycleTimeout = value;
+
+                if (_autoCycle == true)
+                {
+                    System.Diagnostics.Debug.WriteLine("van hiero");
+                    InvokeAsync(async () => await ResetTimerAsync());
+                }
+
+                else
+                    InvokeAsync(async () => await StopTimerAsync());
             }
         }
 
@@ -86,10 +98,9 @@ namespace MudBlazor
         /// <summary>
         /// Fires when selected Index changed on base class
         /// </summary>
-        private void Selection_Changed()
+        private void SelectionChanged()
         {
-            Timer_Reset();
-            _currentColor = (SelectedContainer != null ? SelectedContainer.Color : Color.Inherit);
+            InvokeAsync(async () => await ResetTimerAsync());
         }
 
         /// <summary>
@@ -97,76 +108,91 @@ namespace MudBlazor
         /// </summary>
         private void OnSwipe(SwipeDirection direction)
         {
-            if (direction == SwipeDirection.LeftToRight)
-                Previous();
-            else if (direction == SwipeDirection.RightToLeft)
-                Next();
-        }
-
-        /// <summary>
-        /// Prepares the AutoCycle's timer for start its ticks, based on AutoCycleTime value
-        /// </summary>
-        private void Timer_Start()
-        {
-            if (AutoCycle == false)
-                return;
-            _autoCycleTimer = new System.Timers.Timer(AutoCycleTime.TotalMilliseconds)
+            switch (direction)
             {
-                Enabled = true
-            };
-            _autoCycleTimer.Elapsed += Timer_Tick;
-        }
+                case SwipeDirection.LeftToRight:
+                    Previous();
+                    break;
 
-        /// <summary>
-        /// Stops the AutoCycle's timer with immediate effect
-        /// </summary>
-        private void Timer_Stop()
-        {
-            if (_autoCycleTimer != null)
-            {
-                _autoCycleTimer.Elapsed -= Timer_Tick;
-                _autoCycleTimer.Dispose();
+                case SwipeDirection.RightToLeft:
+                    Next();
+                    break;
             }
         }
 
         /// <summary>
-        /// Resets the AutoCycle's timer (ex: when user mannualy change the selected index)
+        /// Immediately starts the AutoCycle timer
         /// </summary>
-        private void Timer_Reset()
+        private async ValueTask StartTimerAsync()
         {
-            Timer_Stop();
-            Timer_Start();
+            await Task.CompletedTask;
+
+            if (null != _timer && AutoCycle)
+            {
+                System.Diagnostics.Debug.WriteLine(nameof(StartTimerAsync));
+
+                _timer.Change(AutoCycleTime, TimeSpan.Zero);
+            }
         }
+
+        /// <summary>
+        /// Immediately stops the AutoCycle timer
+        /// </summary>
+        private async ValueTask StopTimerAsync()
+        {
+            await Task.CompletedTask;
+
+            System.Diagnostics.Debug.WriteLine(nameof(StopTimerAsync));
+
+            _timer?.Change(Timeout.Infinite, 0);
+        }
+
+        /// <summary>
+        /// Stops and restart the AutoCycle timer
+        /// </summary>
+        private async ValueTask ResetTimerAsync()
+        {
+            System.Diagnostics.Debug.WriteLine(nameof(ResetTimerAsync));
+
+            await StopTimerAsync();
+            await StartTimerAsync();
+        }
+
 
         /// <summary>
         /// Changes the SelectedIndex to a next one (or restart on 0)
         /// </summary>
-        private void Timer_Tick(object source, System.Timers.ElapsedEventArgs e)
+        private async ValueTask TimerTickAsync()
         {
-            InvokeAsync(Next);
+            System.Diagnostics.Debug.WriteLine(nameof(TimerTickAsync));
+
+            await InvokeAsync(Next);
         }
 
 
-        protected override void OnInitialized()
+        protected override async Task OnAfterRenderAsync(bool firstRender)
         {
-            base.OnInitialized();
-            SelectedIndexChanged = new EventCallback<int>(this, (Action)Selection_Changed);
-        }
+            await Task.CompletedTask;
 
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        protected virtual void Dispose(bool disposing)
-        {
-            if (disposing)
+            if (firstRender)
             {
-                Timer_Stop();
+                SelectedIndexChanged = new EventCallback<int>(this, (Action) SelectionChanged);
+
+                _timer = new Timer(_timerElapsed, null, 0, (int) AutoCycleTime.TotalMilliseconds);
             }
         }
 
 
+        public async ValueTask DisposeAsync()
+        {
+            await DisposeAsync(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual async ValueTask DisposeAsync(bool disposing)
+        {
+            if (disposing)
+                await StopTimerAsync();
+        }
     }
 }

--- a/src/MudBlazor/Components/Carousel/MudCarousel.razor.cs
+++ b/src/MudBlazor/Components/Carousel/MudCarousel.razor.cs
@@ -9,7 +9,6 @@ namespace MudBlazor
 {
     public partial class MudCarousel<TData> : MudBaseBindableItemsControl<MudCarouselItem, TData>, IAsyncDisposable
     {
-
         protected string Classname =>
                     new CssBuilder("mud-carousel")
                          .AddClass($"mud-carousel-{_currentColor.ToDescriptionString()}")
@@ -24,23 +23,26 @@ namespace MudBlazor
 
         private Timer _timer;
         private bool _autoCycle = true;
+        private Color _currentColor = Color.Inherit;
         private TimeSpan _cycleTimeout = TimeSpan.FromSeconds(5);
-        private Color _currentColor => SelectedContainer != null ? SelectedContainer.Color : Color.Inherit;
         private void _timerElapsed(object stateInfo) => InvokeAsync(async () => await TimerTickAsync());
 
 
         [CascadingParameter] public bool RightToLeft { get; set; }
+
 
         /// <summary>
         /// Gets or Sets if 'Next' and 'Previous' arrows must be visible
         /// </summary>
         [Parameter] public bool ShowArrows { get; set; } = true;
 
+
         /// <summary>
         /// Gets or Sets if bottom bar with Delimiters musb be visible
         /// </summary>
         [Parameter] public bool ShowDelimiters { get; set; } = true;
         
+
         /// <summary>
         /// Gets or Sets automatic cycle on item collection
         /// </summary>
@@ -59,6 +61,7 @@ namespace MudBlazor
             }
         }
                 
+
         /// <summary>
         /// Gets or Sets the Auto Cycle time
         /// </summary>
@@ -70,30 +73,31 @@ namespace MudBlazor
                 _cycleTimeout = value;
 
                 if (_autoCycle == true)
-                {
-                    System.Diagnostics.Debug.WriteLine("van hiero");
                     InvokeAsync(async () => await ResetTimerAsync());
-                }
 
                 else
                     InvokeAsync(async () => await StopTimerAsync());
             }
         }
 
+
         /// <summary>
         /// Gets or Sets the Template for the Left Arrow
         /// </summary>
         [Parameter] public RenderFragment NextButtonTemplate { get; set; }
+
 
         /// <summary>
         /// Gets or Sets the Template for the Right Arrow
         /// </summary>
         [Parameter] public RenderFragment PreviousButtonTemplate { get; set; }
 
+
         /// <summary>
         /// Gets or Sets the Template for Delimiters
         /// </summary>
         [Parameter]  public RenderFragment<bool> DelimiterTemplate { get; set; }
+
 
         /// <summary>
         /// Fires when selected Index changed on base class
@@ -101,7 +105,10 @@ namespace MudBlazor
         private void SelectionChanged()
         {
             InvokeAsync(async () => await ResetTimerAsync());
+
+            _currentColor = SelectedContainer != null ? SelectedContainer.Color : Color.Inherit;
         }
+
 
         /// <summary>
         /// Provides Selection changes by horizontal swipe gesture
@@ -128,11 +135,7 @@ namespace MudBlazor
             await Task.CompletedTask;
 
             if (null != _timer && AutoCycle)
-            {
-                System.Diagnostics.Debug.WriteLine(nameof(StartTimerAsync));
-
                 _timer.Change(AutoCycleTime, TimeSpan.Zero);
-            }
         }
 
         /// <summary>
@@ -142,8 +145,6 @@ namespace MudBlazor
         {
             await Task.CompletedTask;
 
-            System.Diagnostics.Debug.WriteLine(nameof(StopTimerAsync));
-
             _timer?.Change(Timeout.Infinite, 0);
         }
 
@@ -152,8 +153,6 @@ namespace MudBlazor
         /// </summary>
         private async ValueTask ResetTimerAsync()
         {
-            System.Diagnostics.Debug.WriteLine(nameof(ResetTimerAsync));
-
             await StopTimerAsync();
             await StartTimerAsync();
         }
@@ -164,8 +163,6 @@ namespace MudBlazor
         /// </summary>
         private async ValueTask TimerTickAsync()
         {
-            System.Diagnostics.Debug.WriteLine(nameof(TimerTickAsync));
-
             await InvokeAsync(Next);
         }
 
@@ -178,7 +175,7 @@ namespace MudBlazor
             {
                 SelectedIndexChanged = new EventCallback<int>(this, (Action) SelectionChanged);
 
-                _timer = new Timer(_timerElapsed, null, 0, (int) AutoCycleTime.TotalMilliseconds);
+                _timer = new Timer(_timerElapsed, null, TimeSpan.Zero, AutoCycleTime);
             }
         }
 
@@ -188,6 +185,7 @@ namespace MudBlazor
             await DisposeAsync(true);
             GC.SuppressFinalize(this);
         }
+
 
         protected virtual async ValueTask DisposeAsync(bool disposing)
         {

--- a/src/MudBlazor/Components/Carousel/MudCarouselItem.razor.cs
+++ b/src/MudBlazor/Components/Carousel/MudCarouselItem.razor.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Components;
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
 using MudBlazor.Extensions;
 using MudBlazor.Utilities;
 
@@ -14,17 +15,17 @@ namespace MudBlazor
                          .AddClass("mud-carousel-transition-fade-in", Transition == Transition.Fade && Parent.SelectedContainer == this)
                          .AddClass("mud-carousel-transition-fade-out", Transition == Transition.Fade && Parent.LastContainer == this)
 
-                         .AddClass("mud-carousel-transition-slide-next-enter", Transition == Transition.Slide && RightToLeft == false && Parent.SelectedContainer == this && Parent._movenext)
-                         .AddClass("mud-carousel-transition-slide-next-exit", Transition == Transition.Slide && RightToLeft == false && Parent.LastContainer == this && Parent._movenext)
+                         .AddClass("mud-carousel-transition-slide-next-enter", Transition == Transition.Slide && RightToLeft == false && Parent.SelectedContainer == this && Parent._moveNext)
+                         .AddClass("mud-carousel-transition-slide-next-exit", Transition == Transition.Slide && RightToLeft == false && Parent.LastContainer == this && Parent._moveNext)
 
-                         .AddClass("mud-carousel-transition-slide-prev-enter", Transition == Transition.Slide && RightToLeft == false && Parent.SelectedContainer == this && !Parent._movenext)
-                         .AddClass("mud-carousel-transition-slide-prev-exit", Transition == Transition.Slide && RightToLeft == false && Parent.LastContainer == this && !Parent._movenext)
+                         .AddClass("mud-carousel-transition-slide-prev-enter", Transition == Transition.Slide && RightToLeft == false && Parent.SelectedContainer == this && !Parent._moveNext)
+                         .AddClass("mud-carousel-transition-slide-prev-exit", Transition == Transition.Slide && RightToLeft == false && Parent.LastContainer == this && !Parent._moveNext)
 
-                         .AddClass("mud-carousel-transition-slide-next-rtl-enter", Transition == Transition.Slide && RightToLeft == true && Parent.SelectedContainer == this && Parent._movenext)
-                         .AddClass("mud-carousel-transition-slide-next-rtl-exit", Transition == Transition.Slide && RightToLeft == true && Parent.LastContainer == this && Parent._movenext)
+                         .AddClass("mud-carousel-transition-slide-next-rtl-enter", Transition == Transition.Slide && RightToLeft == true && Parent.SelectedContainer == this && Parent._moveNext)
+                         .AddClass("mud-carousel-transition-slide-next-rtl-exit", Transition == Transition.Slide && RightToLeft == true && Parent.LastContainer == this && Parent._moveNext)
 
-                         .AddClass("mud-carousel-transition-slide-prev-rtl-enter", Transition == Transition.Slide && RightToLeft == true && Parent.SelectedContainer == this && !Parent._movenext)
-                         .AddClass("mud-carousel-transition-slide-prev-rtl-exit", Transition == Transition.Slide && RightToLeft == true && Parent.LastContainer == this && !Parent._movenext)
+                         .AddClass("mud-carousel-transition-slide-prev-rtl-enter", Transition == Transition.Slide && RightToLeft == true && Parent.SelectedContainer == this && !Parent._moveNext)
+                         .AddClass("mud-carousel-transition-slide-prev-rtl-exit", Transition == Transition.Slide && RightToLeft == true && Parent.LastContainer == this && !Parent._moveNext)
 
                          .AddClass("mud-carousel-transition-none", Transition == Transition.None && Parent.SelectedContainer != this)
 
@@ -61,16 +62,14 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public string CustomTransitionExit { get; set; }
 
-        public bool IsVisible
-        {
-            get
-            {
-                return Parent == null ? false : Parent.LastContainer == this || Parent.SelectedIndex == Parent.Items.IndexOf(this);
-            }
-        }
 
-        protected override void OnInitialized()
+        public bool IsVisible => Parent == null ? false : Parent.LastContainer == this || Parent.SelectedIndex == Parent.Items.IndexOf(this);
+
+
+        protected override async Task OnInitializedAsync()
         {
+            await Task.CompletedTask;
+
             Parent?.Items.Add(this);
         }
     }

--- a/src/MudBlazor/Components/Carousel/MudCarouselItem.razor.cs
+++ b/src/MudBlazor/Components/Carousel/MudCarouselItem.razor.cs
@@ -65,9 +65,7 @@ namespace MudBlazor
         {
             get
             {
-                if (Parent == null)
-                    return false;
-                return Parent.SelectedIndex == Parent.Items.IndexOf(this) || Parent.LastContainer == this;
+                return Parent == null ? false : Parent.LastContainer == this || Parent.SelectedIndex == Parent.Items.IndexOf(this);
             }
         }
 

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor
@@ -98,7 +98,7 @@
                                                 @onclick="(() => { var d = day; OnDayClicked(d); })"
                                                 @onclick:stopPropagation="true"
                                                 onmouseover="this.closest('.mud-picker-calendar-content').style.setProperty('--selected-day', @tempId);"
-                                                disabled="@((day < MinDate) || (day > MaxDate))">
+                                                disabled="@((day < MinDate) || (day > MaxDate) || IsDateDisabledFunc(day))">
                                             <p class="mud-typography mud-typography-body2 mud-inherit-text">@GetCalendarDayOfMonth(day)</p>
                                         </button>
                                     }

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -121,6 +121,20 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public string TitleDateFormat { get; set; } = "ddd, dd MMM";
 
+        /// <summary>
+        /// Function to determine whether a date is disabled
+        /// </summary>
+        [Parameter]
+        public Func<DateTime, bool> IsDateDisabledFunc
+        {
+            get => _isDateDisabledFunc;
+            set
+            {
+                _isDateDisabledFunc = value ?? (_ => false);
+            }
+        }
+        private Func<DateTime, bool> _isDateDisabledFunc = _ => false;
+
         protected virtual bool IsRange { get; } = false;
 
         private OpenTo _currentView;

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -35,6 +35,12 @@ namespace MudBlazor
         {
             if (_value != date)
             {
+                if (date is not null && IsDateDisabledFunc(date.Value.Date))
+                {
+                    await SetTextAsync(null, false);
+                    return;
+                }
+
                 _value = date;
                 if (updateValue)
                 {

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.Extensions;
@@ -39,6 +40,18 @@ namespace MudBlazor
         {
             if (_dateRange != range)
             {
+                var doesRangeContainDisabledDates = Enumerable
+                    .Range(0, int.MaxValue)
+                    .Select(index => range.Start.Value.AddDays(index))
+                    .TakeWhile(date => date <= range.End.Value)
+                    .Any(date => IsDateDisabledFunc(date.Date));
+                if (doesRangeContainDisabledDates)
+                {
+                    _rangeText = null;
+                    await SetTextAsync(null, false);
+                    return;
+                }
+
                 _dateRange = range;
 
                 if (updateValue)

--- a/src/MudBlazor/Components/Form/MudForm.razor.cs
+++ b/src/MudBlazor/Components/Form/MudForm.razor.cs
@@ -31,19 +31,8 @@ namespace MudBlazor
             get => _valid;
             set
             {
-                if (_valid == value)
-                    return;
-                SetIsValid(value);
-                // the user might have bound bind a value that is contrary to the form's validity state. 
-                // thus, we must re-evaluate and push back to rectify the bound variable
-                ReEvaluateIsValid();
+                _valid = value;
             }
-        }
-
-        private async void ReEvaluateIsValid()
-        {
-            await Task.Delay(1);
-            Validate();
         }
 
         private void SetIsValid(bool value)
@@ -220,6 +209,21 @@ namespace MudBlazor
                 control.ResetValidation();
             }
             EvaluateForm(debounce: false);
+        }
+
+        protected override Task OnAfterRenderAsync(bool firstRender)
+        {
+            if (firstRender)
+            {
+                var valid = _formControls.All(x => x.Required == false);
+                if (valid != _valid)
+                {
+                    // the user probably bound a variable to IsValid and it conflicts with our state.
+                    // let's set this right
+                    SetIsValid(valid);
+                }
+            }
+            return base.OnAfterRenderAsync(firstRender);
         }
 
         public void Dispose()

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -7,10 +7,13 @@
         <MudInputControl Label="@Label" Variant="@Variant" HelperText="@HelperText" FullWidth="@FullWidth" Margin="@Margin" Class="@Classname" Style="@Style"
                          Error="@Error" ErrorText="@ErrorText" Disabled="@Disabled" @onclick="@ToggleMenu" Required="@Required">
             <InputContent>
-                <MudInput @ref="_elementReference" @attributes="UserAttributes" Variant="@Variant" Value="@(Strict && !IsValueInList ? null : Text)" DisableUnderLine="@DisableUnderLine" Disabled=@Disabled ReadOnly="true"
-                          Class="mud-select-input" Error="@Error" AdornmentIcon="@CurrentIcon" Adornment="Adornment.End" AdornmentColor="@AdornmentColor" IconSize="@IconSize" Margin="@Margin"
-                          InputType="@(CanRenderValue || (Strict && !IsValueInList) ? InputType.Hidden : InputType.Text)"
-                          Clearable="@Clearable" OnClearButtonClick="@SelectClearButtonClickHandlerAsync"
+                <MudInput @ref="_elementReference" InputType="@(CanRenderValue || (Strict && !IsValueInList) ? InputType.Hidden : InputType.Text)"
+                          Class="mud-select-input" Margin="@Margin" 
+                          Variant="@Variant" Value="@(Strict && !IsValueInList ? null : Text)" DisableUnderLine="@DisableUnderLine"
+                          Disabled="@Disabled" ReadOnly="true" Error="@Error"
+                          AdornmentIcon="@_currentIcon" Adornment="@Adornment" AdornmentColor="@AdornmentColor" IconSize="@IconSize"
+                          Clearable="@Clearable" OnClearButtonClick="(async (e) => await SelectClearButtonClickHandlerAsync(e))"
+                          @attributes="UserAttributes" 
                           >
                     @if (CanRenderValue)
                     {

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -48,12 +48,12 @@ namespace MudBlazor
         /// <summary>
         /// The Open Select Icon
         /// </summary>
-        [Parameter] public string OpenIcon { get; set; } = Icons.Material.Filled.ArrowDropUp;
+        [Parameter] public string OpenIcon { get; set; } = Icons.Material.Filled.ArrowDropDown;
 
         /// <summary>
         /// The Close Select Icon
         /// </summary>
-        [Parameter] public string CloseIcon { get; set; } = Icons.Material.Filled.ArrowDropDown;
+        [Parameter] public string CloseIcon { get; set; } = Icons.Material.Filled.ArrowDropUp;
 
         /// <summary>
         /// Fires when SelectedValues changes.
@@ -130,6 +130,7 @@ namespace MudBlazor
 
         public MudSelect()
         {
+            Adornment = Adornment.End;
             IconSize = Size.Medium;
         }
 
@@ -259,7 +260,7 @@ namespace MudBlazor
 
         internal bool _isOpen;
 
-        public string CurrentIcon { get; set; }
+        public string _currentIcon { get; set; }
 
         public async Task SelectOption(object obj)
         {
@@ -332,16 +333,9 @@ namespace MudBlazor
             await OnBlur.InvokeAsync(new FocusEventArgs());
         }
 
-        public void UpdateIcon()
+        private void UpdateIcon()
         {
-            if (_isOpen)
-            {
-                CurrentIcon = OpenIcon;
-            }
-            else
-            {
-                CurrentIcon = CloseIcon;
-            }
+            _currentIcon = !string.IsNullOrWhiteSpace(AdornmentIcon) ? AdornmentIcon : _isOpen ? CloseIcon : OpenIcon;
         }
 
         protected override void OnInitialized()
@@ -381,7 +375,7 @@ namespace MudBlazor
         /// <summary>
         /// Extra handler for clearing selection.
         /// </summary>
-        protected async Task SelectClearButtonClickHandlerAsync(MouseEventArgs e)
+        protected async ValueTask SelectClearButtonClickHandlerAsync(MouseEventArgs e)
         {
             await SetValueAsync(default, false);
             await SetTextAsync(default, false);
@@ -389,7 +383,7 @@ namespace MudBlazor
             BeginValidate();
             StateHasChanged();
             await SelectedValuesChanged.InvokeAsync(SelectedValues);
-            await OnClearButtonClick.InvokeAsync();
+            await OnClearButtonClick.InvokeAsync(e);
         }
 
         protected async Task SetCustomizedTextAsync(string text, bool updateValue = true,

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -1,6 +1,5 @@
 ﻿@namespace MudBlazor
 @inherits MudTableBase
-@using MudBlazor.Extensions
 @using MudBlazor.Utilities
 @typeparam T
 
@@ -59,29 +58,28 @@
                     @if (CurrentPageItems != null)
                     {
                         var rowIndex = 0;
-                        @foreach (var item in CurrentPageItems)
-                        {
-                            var rowClass = new CssBuilder(RowClass).AddClass(RowClassFunc?.Invoke(item, rowIndex)).Build();
-                            var rowStyle = new StyleBuilder().AddStyle(RowStyle).AddStyle(RowStyleFunc?.Invoke(item, rowIndex)).Build();
-                            <MudTr Class="@rowClass" Style="@rowStyle" Item="item" @key="item" IsCheckable="MultiSelection" IsEditable="RowEditingTemplate != null" 
-                                    IsCheckedChanged="@((value) => { var x = item; OnRowCheckboxChanged(value, x); })">
-                                @if ((!ReadOnly) && RowEditingTemplate != null && object.Equals(_editingItem, item))
-                                { 
-                                    <CascadingValue Value="@Validator" IsFixed="true">
-                                        @RowEditingTemplate(item)
-                                    </CascadingValue>
-                                }
-                                else
+                        <MudVirtualize IsEnabled="@Virtualize" Items="@CurrentPageItems?.ToList()" Context="item">
+                                @{ var rowClass = new CssBuilder(RowClass).AddClass(RowClassFunc?.Invoke(item, rowIndex)).Build(); }
+                                @{ var rowStyle = new StyleBuilder().AddStyle(RowStyle).AddStyle(RowStyleFunc?.Invoke(item, rowIndex)).Build(); }
+                                <MudTr Class="@rowClass" Style="@rowStyle" Item="item" @key="item" IsCheckable="MultiSelection" IsEditable="RowEditingTemplate != null" 
+                                       IsCheckedChanged="@((value) => { var x = item; OnRowCheckboxChanged(value, x); })">
+                                    @if ((!ReadOnly) && RowEditingTemplate != null && object.Equals(_editingItem, item))
+                                    {
+                                        <CascadingValue Value="@Validator" IsFixed="true">
+                                            @RowEditingTemplate(item)
+                                        </CascadingValue>
+                                    }
+                                    else
+                                    {
+                                        @RowTemplate(item)
+                                    }
+                                </MudTr>
+                                @if (ChildRowContent != null)
                                 {
-                                    @RowTemplate(item)
+                                    @ChildRowContent(item)
                                 }
-                            </MudTr>
-                            @if (ChildRowContent != null)
-                            {
-                                @ChildRowContent(item)
-                            }
-                            rowIndex++;
-                        }
+                                @{ rowIndex++; }
+                         </MudVirtualize>
                     }
                 </tbody>
                 @if (FooterContent != null)

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -296,6 +296,10 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public string RowStyle { get; set; }
 
+        /// <summary>
+        /// If true, the results are displayed in a Virtualize component, allowing a boost in rendering speed.
+        /// </summary>
+        [Parameter] public bool Virtualize { get; set; }
 
         #region --> Obsolete Forwarders for Backwards-Compatiblilty
         /// <summary>

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor
@@ -19,7 +19,7 @@
                                 <div @ref="panel.PanelRef" class="@GetTabClass(panel)" style="@GetTabStyle(panel)" @onclick=@( e => ActivatePanel(panel, e, false) )>
                                     @if (!String.IsNullOrEmpty(panel.Text) && String.IsNullOrEmpty(panel.Icon))
                                     {
-                                        @panel.Text
+                                        @((MarkupString)panel.Text)
                                     }
                                     else if (String.IsNullOrEmpty(panel.Text) && !String.IsNullOrEmpty(panel.Icon))
                                     {
@@ -28,7 +28,7 @@
                                     else if (!String.IsNullOrEmpty(panel.Text) && !String.IsNullOrEmpty(panel.Icon))
                                     {
                                         <MudIcon Icon="@panel.Icon" Color="@IconColor" Class="mud-tab-icon-text" />
-                                        @panel.Text
+                                        @((MarkupString)panel.Text)
                                     }
                                     @if (panel.BadgeData != null)
                                     {


### PR DESCRIPTION
This PR improves upon the `MudCarousel` component:

-Replaced `System.Timers.Timer` with `System.Threading.Timer` (excuse my [exaggeration](https://github.com/Garderoben/MudBlazor/discussions/1885));
-Replaced most sync methods with `async` methods;
-Fixed a bug in the `MoveTo()` method of the Delimiters;

To reproduce: [Carousel example](https://mudblazor.com/components/carousel): Click items: 2nd, 1st, 1st: the 2nd item is briefly visible.
(or 3rd, 2nd, 2nd: to see the 3rd item)