### PR TITLE
HtmlColor class

### DIFF
--- a/src/MudBlazor/Colors/HtmlColor.cs
+++ b/src/MudBlazor/Colors/HtmlColor.cs
@@ -1,0 +1,178 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace MudBlazor
+{
+    /// <summary>
+    /// Color Names Supported by All Browsers
+    /// https://www.w3schools.com/colors/colors_names.asp
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    public static class HtmlColor
+    {
+        public static string AliceBlue => "#F0F8FF";
+        public static string AntiqueWhite => "#FAEBD7";
+        public static string Aqua => "#00FFFF";
+        public static string Aquamarine => "#7FFFD4";
+        public static string Azure => "#F0FFFF";
+
+        public static string Beige => "#F5F5DC";
+        public static string Bisque => "#FFE4C4";
+        public static string Black => Colors.Shades.Black;
+        public static string BlanchedAlmond => "#FFEBCD";
+        public static string Blue => "#0000FF";
+        public static string BlueViolet => "#8A2BE2";
+        public static string Brown => "#A52A2A";
+        public static string BurlyWood => "#DEB887";
+        public static string CadetBlue => "#5F9EA0";
+        public static string Chartreuse => "#7FFF00";
+        public static string Chocolate => "#D2691E";
+        public static string Coral => "#FF7F50";
+        public static string CornflowerBlue => "#6495ED";
+        public static string Cornsilk => "#FFF8DC";
+        public static string Crimson => "#DC143C";
+        public static string Cyan => Aqua;
+
+        public static string DarkBlue => "#00008B";
+        public static string DarkCyan => "#008B8B";
+        public static string DarkGoldenRod => "#B8860B";
+        public static string DarkGray => "#A9A9A9";
+        public static string DarkGrey => DarkGray;
+        public static string DarkGreen => "#006400";
+        public static string DarkKhaki => "#BDB76B";
+        public static string DarkMagenta => "#8B008B";
+        public static string DarkOliveGreen => "#556B2F";
+        public static string DarkOrange => "#FF8C00";
+        public static string DarkOrchid => "#9932CC";
+        public static string DarkRed => "#8B0000";
+        public static string DarkSalmon => "#E9967A";
+        public static string DarkSeaGreen => "#8FBC8F";
+        public static string DarkSlateBlue => "#483D8B";
+        public static string DarkSlateGray => "#2F4F4F";
+        public static string DarkSlateGrey => DarkSlateGray;
+        public static string DarkTurquoise => "#00CED1";
+        public static string DarkViolet => "#9400D3";
+        public static string DeepPink => "#FF1493";
+        public static string DeepSkyBlue => "#00BFFF";
+        public static string DimGray => "#696969";
+        public static string DimGrey => DimGray;
+        public static string DodgerBlue => "#1E90FF";
+
+        public static string FireBrick => "#B22222";
+        public static string FloralWhite => "#FFFAF0";
+        public static string ForestGreen => "#228B22";
+        public static string Fuchsia => "#FF00FF";
+
+        public static string Gainsboro => "#DCDCDC";
+        public static string GhostWhite => "#F8F8FF";
+        public static string Gold => "#FFD700";
+        public static string GoldenRod => "#DAA520";
+        public static string Gray => "#808080";
+        public static string Grey => Gray;
+        public static string Green => "#008000";
+        public static string GreenYellow => "#ADFF2F";
+
+        public static string HoneyDew => "#F0FFF0";
+        public static string HotPink => "#FF69B4";
+        public static string IndianRed => "#CD5C5C";
+        public static string Indigo => "#4B0082";
+        public static string Ivory => "#FFFFF0";
+
+        public static string Khaki => "#F0E68C";
+
+        public static string Lavender => "#E6E6FA";
+        public static string LavenderBlush => "#FFF0F5";
+        public static string LawnGreen => "#7CFC00";
+        public static string LemonChiffon => "#FFFACD";
+        public static string LightBlue => "#ADD8E6";
+        public static string LightCoral => "#F08080";
+        public static string LightCyan => "#E0FFFF";
+        public static string LightGoldenRodYellow => "#FAFAD2";
+        public static string LightGray => "#D3D3D3";
+        public static string LightGrey => LightGray;
+        public static string LightGreen => "#90EE90";
+        public static string LightPink => "#FFB6C1";
+        public static string LightSalmon => "#FFA07A";
+        public static string LightSeaGreen => "#20B2AA";
+        public static string LightSkyBlue => "#87CEFA";
+        public static string LightSlateGray => "#778899";
+        public static string LightSlateGrey => LightSlateGray;
+        public static string LightSteelBlue => "#B0C4DE";
+        public static string LightYellow => "#FFFFE0";
+        public static string Lime => "#00FF00";
+        public static string LimeGreen => "#32CD32";
+        public static string Linen => "#FAF0E6";
+
+        public static string Magenta => Fuchsia;
+        public static string Maroon => "#800000";
+        public static string MediumAquaMarine => "#66CDAA";
+        public static string MediumBlue => "#0000CD";
+        public static string MediumOrchid => "#BA55D3";
+        public static string MediumPurple => "#9370DB";
+        public static string MediumSeaGreen => "#3CB371";
+        public static string MediumSlateBlue => "#7B68EE";
+        public static string MediumSpringGreen => "#00FA9A";
+        public static string MediumTurquoise => "#48D1CC";
+        public static string MediumVioletRed => "#C71585";
+        public static string MidnightBlue => "#191970";
+        public static string MintCream => "#F5FFFA";
+        public static string MistyRose => "#FFE4E1";
+        public static string Moccasin => "#FFE4B5";
+
+        public static string NavajoWhite => "#FFDEAD";
+        public static string Navy => "#000080";
+
+        public static string OldLace => "#FDF5E6";
+        public static string Olive => "#808000";
+        public static string OliveDrab => "#6B8E23";
+        public static string Orange => "#FFA500";
+        public static string OrangeRed => "#FF4500";
+        public static string Orchid => "#DA70D6";
+
+        public static string PaleGoldenRod => "#EEE8AA";
+        public static string PaleGreen => "#98FB98";
+        public static string PaleTurquoise => "#AFEEEE";
+        public static string PaleVioletRed => "#DB7093";
+        public static string PapayaWhip => "#FFEFD5";
+        public static string PeachPuff => "#FFDAB9";
+        public static string Peru => "#CD853F";
+        public static string Pink => "#FFC0CB";
+        public static string Plum => "#DDA0DD";
+        public static string PowderBlue => "#B0E0E6";
+        public static string Purple => "#800080";
+
+        public static string RebeccaPurple => "#663399";
+        public static string Red => "#FF0000";
+        public static string RosyBrown => "#BC8F8F";
+        public static string RoyalBlue => "#4169E1";
+
+        public static string SaddleBrown => "#8B4513";
+        public static string Salmon => "#FA8072";
+        public static string SandyBrown => "#F4A460";
+        public static string SeaGreen => "#2E8B57";
+        public static string SeaShell => "#FFF5EE";
+        public static string Sienna => "#A0522D";
+        public static string Silver => "#C0C0C0";
+        public static string SkyBlue => "#87CEEB";
+        public static string SlateBlue => "#6A5ACD";
+        public static string SlateGray => "#708090";
+        public static string SlateGrey => SlateGray;
+        public static string Snow => "#FFFAFA";
+        public static string SpringGreen => "#00FF7F";
+        public static string SteelBlue => "#4682B4";
+
+        public static string Tan => "#D2B48C";
+        public static string Teal => "#008080";
+        public static string Thistle => "#D8BFD8";
+        public static string Tomato => "#FF6347";
+        public static string Turquoise => "#40E0D0";
+
+        public static string Violet => "#EE82EE";
+
+        public static string Wheat => "#F5DEB3";
+        public static string White => Colors.Shades.White;
+        public static string WhiteSmoke => "#F5F5F5";
+
+        public static string Yellow => "#FFFF00";
+        public static string YellowGreen => "#9ACD32";
+    }
+}


### PR DESCRIPTION
This PR implements a public static class:  `HtmlColor` representing the official HTML named colors and values.

The color values in the `MudBlazor.Colors` class are different from the HTML defaults, for example:

`Colors.Red.Default`= `F44336`  != HTML Red: `FF0000`
`Colors.Yellow.Default`= `FFEB3B`  != HTML Yellow: `FFFF00`
`Colors.Green.Default`= `4CAF50`  != HTML Pink: `008000`

The HTML colors can easily be used from code or a Razor component: `Style=@($"color: {HtmlColor.FireBrick}")`