### PR TITLE
Table: Fix fo #1834, Cancelling inline editing can lead to wrong item in list

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -62,7 +62,7 @@ namespace MudBlazor.UnitTests.Components
 
             // Count the number of rows including header
             comp.FindAll("tr").Count.Should().Be(4); // Three rows + header row
-            
+
             // Check the values of rows
             comp.FindAll("td")[0].TextContent.Trim().Should().Be("B");
             comp.FindAll("td")[1].TextContent.Trim().Should().Be("A");
@@ -101,7 +101,7 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("td")[1].TextContent.Trim().Should().Be("B");
             comp.FindAll("td")[2].TextContent.Trim().Should().Be("A");
         }
-      
+
         /// Check if the loading parameter is adding a supplementary row.
         /// </summary>
         [Test]
@@ -119,7 +119,7 @@ namespace MudBlazor.UnitTests.Components
             var switchElement = comp.Find("#switch");
 
             // Click the loading switch
-            switchElement.Change(true); 
+            switchElement.Change(true);
 
             // Count the number of rows
             trs = comp.FindAll("tr");
@@ -823,6 +823,38 @@ namespace MudBlazor.UnitTests.Components
 
             // Value in the second row should still be equal to 'C'
             comp.FindAll("td")[2].TextContent.Trim().Should().Be("C");
+        }
+
+        /// <summary>
+        /// This test validates the processing of the Commit and Cancel buttons for an inline editing table.
+        /// </summary>
+        [Test]
+        public async Task TableInlineEditCancel2Test()
+        {
+            var comp = ctx.RenderComponent<TableInlineEditCancelTest>();
+
+            // Check that the value in the second row is equal to 'B'
+            comp.FindAll("td")[2].TextContent.Trim().Should().Be("B");
+
+            // Click on the second row
+            var trs = comp.FindAll("tr");
+            trs[2].Click();
+
+            // Find the textfield and change the value to 'Z'
+            comp.Find("#Id2").Change("Z");
+
+            // Click on the first row
+            trs[1].Click();
+
+            // Click on the second row
+            trs[2].Click();
+
+            // Click the cancel button
+            var cancelButton = comp.FindAll("button")[1];
+            cancelButton.Click();
+
+            // Value in the second row should still be equal to 'B'
+            comp.FindAll("td")[2].TextContent.Trim().Should().Be("B");
         }
     }
 }

--- a/src/MudBlazor/Components/Table/MudTr.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTr.razor.cs
@@ -8,7 +8,7 @@ namespace MudBlazor
 {
     public partial class MudTr : MudComponentBase
     {
-        internal bool _clickRowFirstTime;
+        public bool ClickRowFirstTime;
 
         internal object _itemCopy;
 
@@ -50,8 +50,13 @@ namespace MudBlazor
         public void OnRowClicked(MouseEventArgs args)
         {
             // Manage the Item Copy the first time the row is clicked
-            if (!_clickRowFirstTime)
+            // if the CanCancelEdit functionality is used
+            if (!ClickRowFirstTime && Context.Table.CanCancelEdit)
             {
+                // Cancel any PreviousRowClick variable
+                Context.CancelAnyClickRowFirstTime();
+
+                // Do a copy of original values
                 CopyOriginalValues();
             }
 
@@ -98,7 +103,7 @@ namespace MudBlazor
 
             // The item object has been edited
             Context.Table.RowEditCommit?.Invoke(Item);
-            _clickRowFirstTime = false;
+            ClickRowFirstTime = false;
         }
 
         private void CancelEdit(MouseEventArgs ev)
@@ -111,19 +116,19 @@ namespace MudBlazor
             CopyOriginalValues();
         }
 
-        private void CopyOriginalValues()
+        public void CopyOriginalValues()
         {
             if (IsEditable && Item != null)
             {
-                if (!_clickRowFirstTime)
+                if (!ClickRowFirstTime)
                 {
                     Context.Table.RowEditPreview?.Invoke(Item);
-                    _clickRowFirstTime = true;
+                    ClickRowFirstTime = true;
                 }
                 else
                 {
                     Context.Table.RowEditCancel?.Invoke(Item);
-                    _clickRowFirstTime = false;
+                    ClickRowFirstTime = false;
                 }
             }
         }

--- a/src/MudBlazor/Components/Table/MudTr.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTr.razor.cs
@@ -56,7 +56,7 @@ namespace MudBlazor
                 // Cancel any PreviousRowClick variable
                 Context.CancelAnyClickRowFirstTime();
 
-                // Do a copy of original values
+                // Do a copy of the original values
                 CopyOriginalValues();
             }
 

--- a/src/MudBlazor/Components/Table/TableContext.cs
+++ b/src/MudBlazor/Components/Table/TableContext.cs
@@ -23,7 +23,7 @@ namespace MudBlazor
         public abstract string SortFieldLabel { get; internal set; }
 
         public abstract SortDirection SortDirection { get; protected set; }
-
+        public abstract void CancelAnyClickRowFirstTime(); 
     }
 
     public class TableContext<T> : TableContext
@@ -56,6 +56,14 @@ namespace MudBlazor
                 // update footer checkbox
                 foreach (var footer in FooterRows)
                     footer.SetChecked(b, notify: false);
+            }
+        }
+
+        public override void CancelAnyClickRowFirstTime()
+        {
+            if (Rows.Values.Any(x => x.ClickRowFirstTime))
+            {
+                Rows.Values.First(x => x.ClickRowFirstTime).CopyOriginalValues();
             }
         }
 

--- a/src/MudBlazor/Components/Table/TableContext.cs
+++ b/src/MudBlazor/Components/Table/TableContext.cs
@@ -23,11 +23,14 @@ namespace MudBlazor
         public abstract string SortFieldLabel { get; internal set; }
 
         public abstract SortDirection SortDirection { get; protected set; }
-        public abstract void CancelAnyClickRowFirstTime(); 
+
+        public abstract void ManagePreviousEditedRow(MudTr row);
     }
 
     public class TableContext<T> : TableContext
     {
+        private MudTr editedRow;
+
         public HashSet<T> Selection { get; set; } = new HashSet<T>();
 
         public Dictionary<T, MudTr> Rows { get; set; } = new Dictionary<T, MudTr>();
@@ -59,11 +62,19 @@ namespace MudBlazor
             }
         }
 
-        public override void CancelAnyClickRowFirstTime()
+        public override void ManagePreviousEditedRow(MudTr row)
         {
-            if (Rows.Values.Any(x => x.ClickRowFirstTime))
+            if (Table.IsEditable)
             {
-                Rows.Values.First(x => x.ClickRowFirstTime).CopyOriginalValues();
+                // Reset edition values of the edited row
+                // if another row is selected for edition
+                if (editedRow != null && row != editedRow)
+                {
+                    editedRow.ManagePreviousEdition();
+                }
+
+                // The selected row is the edited row
+                editedRow = row;
             }
         }
 


### PR DESCRIPTION
This is a proposition to fix the issue reported in [MudTable example: Cancelling inline editing can lead to wrong item in list](https://github.com/Garderoben/MudBlazor/issues/1834)