### PR TITLE
Border addition for MudAvatar

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Avatar/AvatarPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Avatar/AvatarPage.razor
@@ -6,7 +6,7 @@
         <DocsPageSection>
             <SectionHeader>
                 <Title>Letter avatars</Title>
-                <Description></Description>
+                <Description>By default, the variant has the value <CodeInline>Variant.Filled</CodeInline> with a background of the defined color. To have a border with this same color and a white background, the variant takes the value <CodeInline>Variant.Outlined</CodeInline>.</Description>
             </SectionHeader>
             <SectionContent Outlined="true" DisplayFlex="true">
                 <AvatarLetterExample />

--- a/src/MudBlazor.Docs/Pages/Components/Avatar/Examples/AvatarIconExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Avatar/Examples/AvatarIconExample.razor
@@ -1,11 +1,20 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudAvatar>
-    <MudIcon Icon="@Icons.Material.Filled.AccessAlarm"/>
+<MudAvatar Variant="Variant.Filled">
+    <MudIcon Icon="@Icons.Material.Filled.AccessAlarm" />
 </MudAvatar>
-<MudAvatar Color="Color.Primary">
+<MudAvatar Color="Color.Primary" Variant="Variant.Filled">
     <MudIcon Icon="@Icons.Material.Filled.Folder" />
 </MudAvatar>
-<MudAvatar Color="Color.Secondary">
+<MudAvatar Color="Color.Secondary" Variant="Variant.Filled">
+    <MudIcon Icon="@Icons.Material.Filled.FormatListNumbered" />
+</MudAvatar>
+<MudAvatar Variant="Variant.Outlined">
+    <MudIcon Icon="@Icons.Material.Filled.AccessAlarm" />
+</MudAvatar>
+<MudAvatar Color="Color.Primary" Variant="Variant.Outlined">
+    <MudIcon Icon="@Icons.Material.Filled.Folder" />
+</MudAvatar>
+<MudAvatar Color="Color.Secondary" Variant="Variant.Outlined">
     <MudIcon Icon="@Icons.Material.Filled.FormatListNumbered" />
 </MudAvatar>

--- a/src/MudBlazor.Docs/Pages/Components/Avatar/Examples/AvatarLetterExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Avatar/Examples/AvatarLetterExample.razor
@@ -1,5 +1,8 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudAvatar>A</MudAvatar>
+<MudAvatar Variant="Variant.Filled">A</MudAvatar>
 <MudAvatar Color="Color.Primary">B</MudAvatar>
 <MudAvatar Color="Color.Secondary">AB</MudAvatar>
+<MudAvatar Variant="Variant.Outlined">A</MudAvatar>
+<MudAvatar Variant="Variant.Outlined" Color="Color.Primary">B</MudAvatar>
+<MudAvatar Variant="Variant.Outlined" Color="Color.Secondary">AB</MudAvatar>

--- a/src/MudBlazor.Docs/Pages/Components/Avatar/Examples/AvatarSizeExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Avatar/Examples/AvatarSizeExample.razor
@@ -11,5 +11,11 @@
     <MudAvatar Size="Size.Medium" Color="Color.Primary" Class="ma-2">A</MudAvatar>
     <MudAvatar Size="Size.Large" Color="Color.Primary" Class="ma-2">A</MudAvatar>
     <MudAvatar Style="height:70px; width:70px; font-size:2rem;" Color="Color.Primary" Class="ma-2">A</MudAvatar>
-</MudContainer>     
-        
+</MudContainer>
+<MudContainer>
+    <MudAvatar Size="Size.Small" Color="Color.Primary" Class="ma-2" Variant="Variant.Outlined">A</MudAvatar>
+    <MudAvatar Size="Size.Medium" Color="Color.Primary" Class="ma-2" Variant="Variant.Outlined">A</MudAvatar>
+    <MudAvatar Size="Size.Large" Color="Color.Primary" Class="ma-2" Variant="Variant.Outlined">A</MudAvatar>
+    <MudAvatar Style="height:70px; width:70px; font-size:2rem;" Color="Color.Primary" Class="ma-2" Variant="Variant.Outlined">A</MudAvatar>
+</MudContainer>
+

--- a/src/MudBlazor.Docs/Pages/Components/Avatar/Examples/AvatarVariantsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Avatar/Examples/AvatarVariantsExample.razor
@@ -9,3 +9,12 @@
 <MudAvatar Color="Color.Primary">
     <MudIcon Icon="@Icons.Material.Filled.Comment" />
 </MudAvatar>
+<MudAvatar Square="true" Variant="Variant.Outlined">
+    N
+</MudAvatar>
+<MudAvatar Rounded="true" Color="Color.Secondary"  Variant="Variant.Outlined">
+    <MudIcon Icon="@Icons.Material.Filled.FormatListNumbered" />
+</MudAvatar>
+<MudAvatar Color="Color.Primary" Variant="Variant.Outlined">
+    <MudIcon Icon="@Icons.Material.Filled.Comment" />
+</MudAvatar>

--- a/src/MudBlazor/Components/Avatar/MudAvatar.razor.cs
+++ b/src/MudBlazor/Components/Avatar/MudAvatar.razor.cs
@@ -11,7 +11,8 @@ namespace MudBlazor
           .AddClass($"mud-avatar-{Size.ToDescriptionString()}")
           .AddClass($"mud-avatar-rounded", Rounded)
           .AddClass($"mud-avatar-square", Square)
-          .AddClass($"mud-theme-{Color.ToDescriptionString()}")
+          .AddClass($"mud-avatar-{Variant.ToDescriptionString()}")
+          .AddClass($"mud-avatar-{Variant.ToDescriptionString()}-{Color.ToDescriptionString()}")
           .AddClass(Class)
         .Build();
 
@@ -39,6 +40,11 @@ namespace MudBlazor
         /// The Size of the MudAvatar.
         /// </summary>
         [Parameter] public Size Size { get; set; } = Size.Medium;
+
+        /// <summary>
+        /// The variant to use.
+        /// </summary>
+        [Parameter] public Variant Variant { get; set; } = Variant.Filled;
 
         /// <summary>
         /// Child content of the component.

--- a/src/MudBlazor/Styles/components/_avatar.scss
+++ b/src/MudBlazor/Styles/components/_avatar.scss
@@ -55,3 +55,27 @@
     width: 75%;
     height: 75%;
 }
+
+.mud-avatar-outlined {
+    color: var(--mud-palette-text-primary);
+    background-color: var(--mud-palette-white);
+    border: 2px solid var(--mud-palette-text-primary);
+
+    @each $color in $mud-palette-colors {
+        &.mud-avatar-outlined-#{$color} {
+            color: var(--mud-palette-#{$color});
+            border: 2px solid var(--mud-palette-#{$color});
+        }
+    }
+}
+
+.mud-avatar-filled {
+    color: var(--mud-palette-white);
+    background-color: var(--mud-palette-grey-light);
+
+    @each $color in $mud-palette-colors {
+        &.mud-avatar-filled-#{$color} {
+            background-color: var(--mud-palette-#{$color});
+        }
+    }
+}

--- a/src/MudBlazor/Styles/components/_avatar.scss
+++ b/src/MudBlazor/Styles/components/_avatar.scss
@@ -59,12 +59,12 @@
 .mud-avatar-outlined {
     color: var(--mud-palette-text-primary);
     background-color: var(--mud-palette-white);
-    border: 2px solid var(--mud-palette-text-primary);
+    border: 1px solid var(--mud-palette-text-primary);
 
     @each $color in $mud-palette-colors {
         &.mud-avatar-outlined-#{$color} {
             color: var(--mud-palette-#{$color});
-            border: 2px solid var(--mud-palette-#{$color});
+            border: 1px solid var(--mud-palette-#{$color});
         }
     }
 }


### PR DESCRIPTION
This PR is a proposition for [Avatar with border](https://github.com/Garderoben/MudBlazor/issues/1798) feature request. Below is the result.

![pop](https://user-images.githubusercontent.com/16502423/122632334-7cc61d00-d0d2-11eb-9be5-e9b5c2c289d5.png)