### PR TITLE
DatePicker and TimePicker: added ReadOnly parameter

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/DatePicker/DatePickerPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DatePicker/DatePickerPage.razor
@@ -11,7 +11,10 @@
                 <Title>Basic Usage</Title>
                 <Description>
                     <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">Note: Always use the two-way binding <CodeInline>@@bind-Date</CodeInline> to bind to a field of type <CodeInline>DateTime?</CodeInline></MudAlert>
-                    <MudText Class="py-6">If <CodeInline>AutoClose</CodeInline> is set to true and PickerActions are defined, selecting the day will close the MudDatePicker.</MudText>
+                    <MudText Class="py-6">
+                        If <CodeInline>AutoClose</CodeInline> is set to true and PickerActions are defined, selecting the day will close the MudDatePicker.
+                        If <CodeInline>ReadOnly</CodeInline> is set to true, the DatePicker can be used but the value will remain unchanged regardless of the actions performed or the values entered.
+                    </MudText>
                 </Description>
             </SectionHeader>
             <SectionContent Outlined="true">

--- a/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerBasicUsageExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DatePicker/Examples/DatePickerBasicUsageExample.razor
@@ -1,10 +1,11 @@
 ﻿@namespace MudBlazor.Docs.Examples
 <MudGrid>
     <MudItem xs="12" sm="6" md="4">
-        <MudDatePicker Label="Basic example" @bind-Date="date" />
+        <MudDatePicker Label="Basic example" @bind-Date="date" ReadOnly="@readOnly"/>
+        <MudSwitch @bind-Checked="@readOnly" Color="Color.Tertiary">ReadOnly</MudSwitch>
     </MudItem>
     <MudItem xs="12" sm="6" md="4">
-        <MudDatePicker Label="Basic example (editable)" Editable="true" />
+        <MudDatePicker Label="Basic example (editable)" Editable="true" @bind-Date="date" />
     </MudItem>
     <MudItem xs="12" sm="6" md="4">
         <MudDatePicker Label="Only Calendar" @bind-Date="date" DisableToolbar="true" HelperText="No header" />
@@ -38,4 +39,5 @@
     MudDatePicker _picker;
     DateTime? date = DateTime.Today;
     private bool autoClose;
+    private bool readOnly;
 }

--- a/src/MudBlazor.Docs/Pages/Components/TimePicker/Examples/TimePickerBasicUsageExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TimePicker/Examples/TimePickerBasicUsageExample.razor
@@ -1,7 +1,8 @@
 ﻿@namespace MudBlazor.Docs.Examples
 <MudGrid>
     <MudItem xs="12" sm="6" md="4">
-        <MudTimePicker Label="12 hours" AmPm="true" @bind-Time="time" />
+        <MudTimePicker Label="12 hours" AmPm="true" @bind-Time="time" ReadOnly="@readOnly" />
+        <MudSwitch @bind-Checked="@readOnly" Color="Color.Tertiary">ReadOnly</MudSwitch>
     </MudItem>
     <MudItem xs="12" sm="6" md="4">
         <MudTimePicker Label="12 hours custom format" AmPm="true" TimeFormat="h:mm tt" @bind-Time="time" />
@@ -26,4 +27,5 @@
 @code{
     MudTimePicker _picker;
     TimeSpan? time = new TimeSpan(00, 45, 00);
+    private bool readOnly;
 }

--- a/src/MudBlazor.Docs/Pages/Components/TimePicker/TimePickerPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TimePicker/TimePickerPage.razor
@@ -10,6 +10,10 @@
                 <Title>Basic Usage</Title>
                 <Description>
                     <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">Note: Always use the two-way binding <CodeInline>@@bind-Time</CodeInline> to bind to a field of type <CodeInline>TimeSpan?</CodeInline></MudAlert>
+                    <MudText Class="py-6">
+                        If <CodeInline>AutoClose</CodeInline> is set to true and PickerActions are defined, selecting the hour and then the minutes will close the MudTimePicker.
+                        If <CodeInline>ReadOnly</CodeInline> is set to true, the TimePicker can be used but the value will remain unchanged regardless of the actions performed or the values entered.
+                    </MudText>
                 </Description>
             </SectionHeader>
             <SectionContent Outlined="true">

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -493,5 +493,71 @@ namespace MudBlazor.UnitTests.Components
                 datePicker.Instance.Date.Should().Be(new DateTime(now.Year, now.Month, 19));
             }
         }
+
+        [Test]
+        public async Task CheckReadOnlyTest()
+        {
+            // Define a date for comparison
+            DateTime now = new DateTime(DateTime.Now.Year, DateTime.Now.Month, DateTime.Now.Day);
+
+            // Get access to the datepicker of the instance
+            var comp = ctx.RenderComponent<MudDatePicker>();
+            var picker = comp.Instance;
+
+            // Open the datepicker
+            await comp.InvokeAsync(() => picker.Open());
+
+            // Clicking a day button to select a date
+            // It must be a different day than the day of now!
+            // So the test is working when the day is 20
+            if (now.Day != 20)
+            {
+                comp.FindAll("button.mud-picker-calendar-day")
+                    .Where(x => x.TrimmedText().Equals("20")).First().Click();
+            }
+            else
+            {
+                comp.FindAll("button.mud-picker-calendar-day")
+                    .Where(x => x.TrimmedText().Equals("19")).First().Click();
+            }
+
+            // Close the datepicker
+            await comp.InvokeAsync(() => picker.Close());
+
+            // Check that the date should be equal to the new date 19 or 20
+            if (now.Day != 20)
+            {
+                picker.Date.Should().Be(new DateTime(now.Year, now.Month, 20));
+            }
+            else
+            {
+                picker.Date.Should().Be(new DateTime(now.Year, now.Month, 19));
+            }
+
+            // Change the value of readonly and update the value of now
+            now = picker.Date.Value;
+            picker.ReadOnly = true;
+
+            // Open the datepicker
+            await comp.InvokeAsync(() => picker.Open());
+
+            // Clicking a day button to select a date
+            if (now.Day != 21)
+            {
+                comp.FindAll("button.mud-picker-calendar-day")
+                    .Where(x => x.TrimmedText().Equals("22")).First().Click();
+            }
+            else
+            {
+                comp.FindAll("button.mud-picker-calendar-day")
+                    .Where(x => x.TrimmedText().Equals("21")).First().Click();
+            }
+
+            // Close the datepicker
+            await comp.InvokeAsync(() => picker.Close());
+
+            // Check that the date should remain the same because readonly is true
+            picker.Date.Should().Be(now);
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
@@ -401,5 +401,50 @@ namespace MudBlazor.UnitTests.Components
             picker.Time.Value.Minutes.Should().Be(30);
             Console.Write(comp.Markup);
         }
+
+        [Test]
+        public async Task CheckReadOnlyTest()
+        {
+            // Get access to the timepicker of the instance
+            var comp = ctx.RenderComponent<MudTimePicker>();
+            var picker = comp.Instance;
+
+            // Open the timepicker
+            await comp.InvokeAsync(() => picker.Open());
+
+            // Select 16 hours
+            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[3].Click();
+            picker.TimeIntermediate.Value.Hours.Should().Be(16);
+
+            // Select 30 minutes
+            comp.FindAll("div.mud-minute")[30].Click();
+            picker.TimeIntermediate.Value.Minutes.Should().Be(30);
+
+            // Click outside of the timepicker
+            comp.Find("div.mud-overlay").Click();
+
+            // Check that the time have been changed
+            picker.Time.Should().Be(new TimeSpan(16, 30, 00));
+
+            // Changer the readonly to true
+            picker.ReadOnly = true;
+
+            // Open the timepicker
+            await comp.InvokeAsync(() => picker.Open());
+
+            // Select 17 hours
+            comp.FindAll("div.mud-picker-stick-outer.mud-hour")[4].Click();
+            picker.TimeIntermediate.Value.Hours.Should().Be(17);
+
+            // Select 31 minutes
+            comp.FindAll("div.mud-minute")[34].Click();
+            picker.TimeIntermediate.Value.Minutes.Should().Be(34);
+
+            // Click outside of the timepicker
+            comp.Find("div.mud-overlay").Click();
+
+            // Check that the time have not been changed
+            picker.Time.Should().Be(new TimeSpan(16, 30, 00));
+        }
     }
 }

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -101,6 +101,8 @@ namespace MudBlazor
 
         protected override async void Submit()
         {
+            if (ReadOnly)
+                return;
             if (_selectedDate == null)
                 return;
 

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -259,6 +259,8 @@ namespace MudBlazor
 
         protected override async void Submit()
         {
+            if (ReadOnly)
+                return;
             if (_firstDate == null || _secondDate == null)
                 return;
 

--- a/src/MudBlazor/Components/Picker/MudPicker.razor
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor
@@ -8,7 +8,7 @@
 {
 
     protected virtual RenderFragment InputContent =>
-        @<MudTextField @ref="_inputReference" @attributes="UserAttributes" Label="@Label" @bind-Text="@Text" HelperText="@HelperText" Variant="@InputVariant" ReadOnly="@(!Editable)" T="string" Style="@Style"
+        @<MudTextField @ref="_inputReference" @attributes="UserAttributes" Label="@Label" @bind-Text="@Text" HelperText="@HelperText" Variant="@InputVariant" ReadOnly="@(!Editable || ReadOnly)" T="string" Style="@Style"
                     @onclick="(() => { if (!Editable) ToggleState(); })" OnAdornmentClick="ToggleState" Disabled="@Disabled" Adornment="@Adornment"
                     AdornmentIcon="@AdornmentIcon" IconSize="@IconSize" Margin="@Margin"
                     Required="@Required" RequiredError="@RequiredError" Error="@Error" ErrorText="@ErrorText"/>;

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -110,6 +110,11 @@ namespace MudBlazor
         [Parameter] public bool Square { get; set; }
 
         /// <summary>
+        /// If true, no date or time can be defined.
+        /// </summary>
+        [Parameter] public bool ReadOnly { get; set; }
+
+        /// <summary>
         /// If true, border-radius is set to theme default when in Static Mode.
         /// </summary>
         [Parameter] public bool Rounded { get; set; }

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -162,6 +162,8 @@ namespace MudBlazor
 
         protected override void Submit()
         {
+            if (ReadOnly)
+                return;
             Time = TimeIntermediate;
         }
 


### PR DESCRIPTION
This PR is a proposition to solve the [can we have "MudDatePicker" Readonly](https://github.com/Garderoben/MudBlazor/issues/1924) issue.
![D](https://user-images.githubusercontent.com/16502423/122656660-f7d41580-d15c-11eb-87b7-07947843bf3c.png)
![T](https://user-images.githubusercontent.com/16502423/122656663-f99dd900-d15c-11eb-850c-96c28e25861c.png)
