### PR TITLE
MudNumericField: fixes spinner width 

### DIFF
--- a/src/MudBlazor/Styles/components/_inputcontrol.scss
+++ b/src/MudBlazor/Styles/components/_inputcontrol.scss
@@ -88,8 +88,8 @@
                 padding-inline-end: 24px;
 
                 &.mud-input-root-margin-dense {
-                    padding-right: 17px; //This must be the same width of the spinners
-                    padding-inline-end: 17px;
+                    padding-right: 20px; //This must be the same width of the spinners
+                    padding-inline-end: 20px;
                 }
             }
             &.mud-input-text input {
@@ -133,7 +133,7 @@
             }
         }
 
-        & .mud-input-underline .mud-input-numeric-spin button {
+        .mud-input-numeric-spin button {
             padding: 2px 0;
         }
     }


### PR DESCRIPTION
Fixes #1932

Before:
![grafik](https://user-images.githubusercontent.com/62108893/122681629-9613ba00-d1f5-11eb-9f14-e0dfab948966.png)

After:
![spinner](https://user-images.githubusercontent.com/62108893/122681671-cfe4c080-d1f5-11eb-8aa3-a1644279db24.png)

