### PR TITLE
OnPreviewEditClick parameter addition for MudTable

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -856,5 +856,53 @@ namespace MudBlazor.UnitTests.Components
             // Value in the second row should still be equal to 'B'
             comp.FindAll("td")[2].TextContent.Trim().Should().Be("B");
         }
+
+        /// <summary>
+        /// This test validates the behavior of RowEditPreview. It should run after SelectedItem has been updated.
+        /// </summary>
+        [Test]
+        public async Task TableInlineEditCancel3Test()
+        {
+            var comp = ctx.RenderComponent<TableInlineEditCancelTest>();
+            var taskCompletionSource = new TaskCompletionSource<bool>();
+
+            // Get the table and define the RowEditPreview method 
+            var instance = comp.Instance;
+            var table = instance.Table;
+            table.RowEditPreview = RowEditPreview;
+
+            // Click on the second row to trigger the RowEditPreview method
+            var trs = comp.FindAll("tr");
+            trs[2].Click();
+
+            void RowEditPreview(object item)
+            {
+                // Get the value of the SelectedItem
+                string selectedItemValue = table.SelectedItem.Value;
+
+                // Get the value of the object from the RowEditPreview method
+                var rowEditPreviewValue = item.GetType().GetProperty("Value").GetValue(item, null).ToString();
+
+                // Compare these values are equal and are correct
+                if (selectedItemValue == "B" && rowEditPreviewValue == selectedItemValue)
+                {
+                    // Return  a success
+                    taskCompletionSource.SetResult(true);
+                }
+                else
+                {
+                    // Return a failure
+                    taskCompletionSource.SetResult(false);
+                }
+            }
+
+            // Wait for the result during one second maximum
+            // It should be true meaning that SelecteItem had  the correct value before RowEditPreview has finished to complete
+            // Also the object in RowEditPreview and the SelectedItem should be equal
+            var result = taskCompletionSource.Task.Wait(1000);
+
+            // Check that the result should be true
+            result.Should().Be(true);
+        }
     }
 }

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -232,6 +232,11 @@ namespace MudBlazor
         [Parameter] public EventCallback<MouseEventArgs> OnCancelEditClick { get; set; }
 
         /// <summary>
+        /// Event is called before the item is modified in inline editing.
+        /// </summary>
+        [Parameter] public EventCallback<object> OnPreviewEditClick { get; set; }
+
+        /// <summary>
         /// Command executed when the user clicks on the CommitEdit Button.
         /// </summary>
         [Parameter] public ICommand CommitEditCommand { get; set; }
@@ -366,6 +371,11 @@ namespace MudBlazor
                     parameter = item;
                 CommitEditCommand.Execute(parameter);
             }
+        }
+
+        internal async Task OnPreviewEditHandler(object item)
+        {
+            await OnPreviewEditClick.InvokeAsync(item);
         }
 
         internal async Task OnCancelEditHandler(MouseEventArgs ev)

--- a/src/MudBlazor/Components/Table/MudTr.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTr.razor.cs
@@ -53,6 +53,11 @@ namespace MudBlazor
             // Manage any previous edited row
             Context.ManagePreviousEditedRow(this);
 
+            if (IsHeader || !(Context?.Table.Validator.IsValid ?? true))
+                return;
+
+            Context?.Table.SetSelectedItem(Item);
+
             // Manage edition the first time the row is clicked and if the table is editable
             if (!hasBeenClikedFirstTime && IsEditable)
             {
@@ -71,10 +76,6 @@ namespace MudBlazor
                 Context.Table.RowEditPreview?.Invoke(Item);
             }
 
-            if (IsHeader || !(Context?.Table.Validator.IsValid ?? true))
-                return;
-
-            Context?.Table.SetSelectedItem(Item);
             Context?.Table.SetEditingItem(Item);
 
             if (Context?.Table.MultiSelection == true && !IsHeader)

--- a/src/MudBlazor/Components/Table/MudTr.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTr.razor.cs
@@ -64,6 +64,9 @@ namespace MudBlazor
                 hasBeenCanceled = false;
                 hasBeenCommitted = false;
 
+                // Trigger the preview event
+                Context?.Table.OnPreviewEditHandler(Item);
+
                 // Trigger the row edit preview event
                 Context.Table.RowEditPreview?.Invoke(Item);
             }
@@ -126,7 +129,7 @@ namespace MudBlazor
 
         private void CancelEdit(MouseEventArgs ev)
         {
-            // The edit mode is canceled
+            // The edit mode is canceled and trigger the cancel event
             Context?.Table.SetEditingItem(null);
             Context?.Table.OnCancelEditHandler(ev);
 


### PR DESCRIPTION
This PR is a proposition to answer to the [Add 'OnRowEditPreviewClick' event callback to MudTable](https://github.com/Garderoben/MudBlazor/issues/1934) feature request.