### PR TITLE
DialogProvider: Changed modifier for DismissAll() to public

### DIFF
--- a/src/MudBlazor/Components/Dialog/MudDialogProvider.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialogProvider.razor.cs
@@ -56,7 +56,7 @@ namespace MudBlazor
             StateHasChanged();
         }
 
-        private void DismissAll()
+        public void DismissAll()
         {
             _dialogs.ToList().ForEach(r => r.Dismiss(DialogResult.Cancel()));
             _dialogs.Clear();


### PR DESCRIPTION
Changed modifier for DismissAll() to public, because people may want to dismiss all dialogs that are currently displayed.
I can see no reason to hide this method from developers.