### PR TITLE
Fix NRE in MudAddEventListenerAsync

### DIFF
--- a/src/MudBlazor/Components/Collapse/MudCollapse.razor.cs
+++ b/src/MudBlazor/Components/Collapse/MudCollapse.razor.cs
@@ -129,8 +129,7 @@ namespace MudBlazor
             {
                 _isRendered = true;
                 await UpdateHeight();
-                if (_dotNetRef != null)
-                    _listenerId = await _container.MudAddEventListenerAsync(_dotNetRef, "animationend", nameof(AnimationEnd));
+                _listenerId = await _container.MudAddEventListenerAsync(_dotNetRef, "animationend", nameof(AnimationEnd));
             }
             else if (_updateHeight && (_state == CollapseState.Entering || _state == CollapseState.Exiting))
             {

--- a/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
+++ b/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
@@ -258,11 +258,8 @@ namespace MudBlazor
                     StateHasChanged();
                 }
 
-                if (_dotNetRef != null)
-                {
-                    _mouseEnterListenerId = await _drawerRef.MudAddEventListenerAsync(_dotNetRef, "mouseenter", nameof(OnMouseEnter), true);
-                    _mouseLeaveListenerId = await _drawerRef.MudAddEventListenerAsync(_dotNetRef, "mouseleave", nameof(OnMouseLeave), true);
-                }
+                _mouseEnterListenerId = await _drawerRef.MudAddEventListenerAsync(_dotNetRef, "mouseenter", nameof(OnMouseEnter), true);
+                _mouseLeaveListenerId = await _drawerRef.MudAddEventListenerAsync(_dotNetRef, "mouseleave", nameof(OnMouseLeave), true);
             }
 
             await base.OnAfterRenderAsync(firstRender);

--- a/src/MudBlazor/Extensions/ElementReferenceExtensions.cs
+++ b/src/MudBlazor/Extensions/ElementReferenceExtensions.cs
@@ -53,13 +53,20 @@ namespace MudBlazor
 
         public static ValueTask<int> MudAddEventListenerAsync<T>(this ElementReference elementReference, DotNetObjectReference<T> dotnet, string @event, string callback, bool stopPropagation = false) where T : class
         {
-            var parameters = dotnet.Value.GetType().GetMethods().First(m => m.Name == callback).GetParameters().Select(p => p.ParameterType);
-            var parameterSpecs = new object[parameters.Count()];
-            for (int i = 0; i < parameters.Count(); ++i)
+            var parameters = dotnet?.Value.GetType().GetMethods().First(m => m.Name == callback).GetParameters().Select(p => p.ParameterType);
+            if (parameters != null)
             {
-                parameterSpecs[i] = GetSerializationSpec(parameters.ElementAt(i));
+                var parameterSpecs = new object[parameters.Count()];
+                for (int i = 0; i < parameters.Count(); ++i)
+                {
+                    parameterSpecs[i] = GetSerializationSpec(parameters.ElementAt(i));
+                }
+                return elementReference.GetJSRuntime()?.InvokeAsync<int>("mudElementRef.addEventListener", elementReference, dotnet, @event, callback, parameterSpecs, stopPropagation) ?? ValueTask.FromResult(0);
             }
-            return elementReference.GetJSRuntime()?.InvokeAsync<int>("mudElementRef.addEventListener", elementReference, dotnet, @event, callback, parameterSpecs, stopPropagation) ?? ValueTask.FromResult(0);
+            else
+            {
+                return new ValueTask<int>(0);
+            }
         }
 
         public static ValueTask MudRemoveEventListenerAsync(this ElementReference elementReference, string @event, int eventId) =>


### PR DESCRIPTION
- Steps to repro.
  - Open docs site
  - Open Nav
  -  Rapidly click between Drawer and Element

```
​ [2021-06-24T07:58:25.639Z] Error: System.NullReferenceException: Object reference not set to an instance of an object.
   at MudBlazor.ElementReferenceExtensions.MudAddEventListenerAsync[T](ElementReference elementReference, DotNetObjectReference`1 dotnet, String event, String callback, Boolean stopPropagation) in C:\Users\mikes.SURCOUF\source\repos\MudBlazor\src\MudBlazor\Extensions\ElementReferenceExtensions.cs:line 56
   at MudBlazor.MudDrawer.OnAfterRenderAsync(Boolean firstRender) in C:\Users\mikes.SURCOUF\source\repos\MudBlazor\src\MudBlazor\Components\Drawer\MudDrawer.razor.cs:line 264
   at Microsoft.AspNetCore.Components.RenderTree.Renderer.GetErrorHandledTask(Task taskToHandle)
```

- There is already a check for `_dotNetRef == null` but this can become immediately stale.
- This PR moves the null check to `MudAddEventListenerAsync` so if a component is disposed during `OnAfterRenderAsync`   `MudAddEventListenerAsync`  fails gracefully.

@henon @tungi52 
