### PR TITLE
MudAvatar: fixes background color for outlined variants (#1987)

### DIFF
--- a/src/MudBlazor/Styles/components/_avatar.scss
+++ b/src/MudBlazor/Styles/components/_avatar.scss
@@ -58,7 +58,7 @@
 
 .mud-avatar-outlined {
     color: var(--mud-palette-text-primary);
-    background-color: var(--mud-palette-white);
+    background-color: unset;
     border: 1px solid var(--mud-palette-text-primary);
 
     @each $color in $mud-palette-colors {


### PR DESCRIPTION
Fixes #1987
Before:
![grafik](https://user-images.githubusercontent.com/62108893/123257505-8b596d80-d4f2-11eb-9224-03695b5bd8dd.png)

After:
![grafik](https://user-images.githubusercontent.com/62108893/123257458-7c72bb00-d4f2-11eb-900e-06a70d72a1b7.png)
