### PR TITLE
MudDialog: added TopCenter, BottomCenter,  CenterLeft and CenterRight positions

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogOptionsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogOptionsExample.razor
@@ -7,6 +7,7 @@
 <MudButton OnClick="@((e) => OpenDialog(noHeader))" Color="Color.Secondary">No header Dialog</MudButton>
 <MudButton OnClick="@((e) => OpenDialog(disableBackdropClick))" Color="Color.Tertiary">Disable backdrop dialog</MudButton>
 <MudButton OnClick="@((e) => OpenDialog(fullScreen))" Color="Color.Info">Full Screen Dialog</MudButton>
+<MudButton OnClick="@((e) => OpenDialog(topCenter))" Color="Color.Success">Top Center Dialog</MudButton>
 
 
 @code {
@@ -15,6 +16,7 @@
     DialogOptions noHeader = new DialogOptions() {  NoHeader = true };
     DialogOptions disableBackdropClick = new DialogOptions() { DisableBackdropClick = true };
     DialogOptions fullScreen = new DialogOptions() { FullScreen = true, CloseButton = true };
+    DialogOptions topCenter = new DialogOptions() { Position = DialogPosition.TopCenter };
 
     private void OpenDialog(DialogOptions options)
     {

--- a/src/MudBlazor/Components/Dialog/DialogOptions.cs
+++ b/src/MudBlazor/Components/Dialog/DialogOptions.cs
@@ -28,12 +28,18 @@ namespace MudBlazor
     {
         [Description("center")]
         Center,
+        [Description("centerleft")]
+        CenterLeft,
+        [Description("centerright")]
+        CenterRight,
         [Description("topcenter")]
         TopCenter,
         [Description("topleft")]
         TopLeft,
         [Description("topright")]
         TopRight,
+        [Description("bottomcenter")]
+        BottomCenter,
         [Description("bottomleft")]
         BottomLeft,
         [Description("bottomright")]

--- a/src/MudBlazor/Components/Dialog/DialogOptions.cs
+++ b/src/MudBlazor/Components/Dialog/DialogOptions.cs
@@ -28,6 +28,8 @@ namespace MudBlazor
     {
         [Description("center")]
         Center,
+        [Description("topcenter")]
+        TopCenter,
         [Description("topleft")]
         TopLeft,
         [Description("topright")]

--- a/src/MudBlazor/Styles/components/_dialog.scss
+++ b/src/MudBlazor/Styles/components/_dialog.scss
@@ -14,7 +14,25 @@
     &.mud-dialog-topcenter {
         align-items: flex-start;
         justify-content: center;
-        margin-top: 32px;
+        padding-top: 32px;
+    }
+
+    &.mud-dialog-bottomcenter {
+        align-items: flex-end;
+        justify-content: center;
+        padding-bottom: 32px;
+    }
+
+    &.mud-dialog-centerright {
+        align-items: center;
+        justify-content: flex-end;
+        padding-right: 32px;
+    }
+
+    &.mud-dialog-centerleft {
+        align-items: center;
+        justify-content: flex-start;
+        padding-left: 32px;
     }
 
     &.mud-dialog-topleft .mud-dialog {

--- a/src/MudBlazor/Styles/components/_dialog.scss
+++ b/src/MudBlazor/Styles/components/_dialog.scss
@@ -11,6 +11,12 @@
         justify-content: center;
     }
 
+    &.mud-dialog-topcenter {
+        align-items: flex-start;
+        justify-content: center;
+        margin-top: 32px;
+    }
+
     &.mud-dialog-topleft .mud-dialog {
         position: absolute;
         top: 32px;


### PR DESCRIPTION
Among all the possible positions for a dialog, I found that the _TopCenter_ position was missing from my point of view.
I have also added a _Position_ example in the _Dialog_ section of the official website with _TopCenter_.

![Ex](https://user-images.githubusercontent.com/16502423/123480481-b337f680-d602-11eb-8bb1-0f0daf976362.png)