### PR TITLE
DatePicker: improvements regarding Variant, Adornment and Size

### DIFF
--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor
@@ -6,12 +6,12 @@
 @code{
 
     protected override RenderFragment InputContent=> 
-        @<MudInputControl Label="@Label" Variant="@InputVariant" HelperText="@HelperText" Error="@Error" 
+        @<MudInputControl Label="@Label" Variant="@Variant" HelperText="@HelperText" Error="@Error" 
                           ErrorText="@ErrorText" Disabled="@Disabled" Margin="@Margin" Required="@Required"
                           @onclick="() => { if (!Editable) ToggleState(); }">
                <InputContent>
-                   <MudRangeInput @ref="_rangeInput" @attributes="UserAttributes" InputType="@InputType.Text" Class="@PickerInputClass" Style="@Style" Variant="@InputVariant" ReadOnly="@(!Editable)"
-                                   @bind-Value="@RangeText" Disabled=@Disabled Adornment="@Adornment" AdornmentIcon="@AdornmentIcon" IconSize="@IconSize" OnAdornmentClick="ToggleState"
+                   <MudRangeInput @ref="_rangeInput" @attributes="UserAttributes" InputType="@InputType.Text" Class="@PickerInputClass" Style="@Style" Variant="@Variant" ReadOnly="@(!Editable)"
+                                   @bind-Value="@RangeText" Disabled=@Disabled Adornment="@Adornment" AdornmentIcon="@AdornmentIcon" AdornmentColor="@AdornmentColor" IconSize="@IconSize" OnAdornmentClick="ToggleState"
                                    Required="@Required" RequiredError="@RequiredError" Error="@Error" ErrorText="@ErrorText" Margin="@Margin"/>
                </InputContent>
            </MudInputControl>;

--- a/src/MudBlazor/Components/Input/MudInputAdornment.razor
+++ b/src/MudBlazor/Components/Input/MudInputAdornment.razor
@@ -3,15 +3,15 @@
 
 
 <div class="@Class">
-    @if (!string.IsNullOrEmpty(Text))
+    @if (!string.IsNullOrWhiteSpace(Text))
     {
         <MudText Color="@Color">@Text</MudText>
     }
-    else if (!string.IsNullOrEmpty(Icon))
+    else if (!string.IsNullOrWhiteSpace(Icon))
     {
         @if (AdornmentClick.HasDelegate)
         {
-            <MudIconButton Icon="@Icon" OnClick="@AdornmentClick" Edge="@Edge" Size="Size.Medium" Color="@Color" />
+            <MudIconButton Icon="@Icon" OnClick="@AdornmentClick" Edge="@Edge" Size="@Size" Color="@Color" />
         }
         else
         {
@@ -26,7 +26,7 @@
     [Parameter] public string Text { get; set; }
     [Parameter] public string Icon { get; set; }
     [Parameter] public Edge Edge { get; set; }
-    [Parameter] public Size Size { get; set; }
+    [Parameter] public Size Size { get; set; } = Size.Medium;
     [Parameter] public Color Color { get; set; } = Color.Default;
 
     [Parameter] public EventCallback<MouseEventArgs> AdornmentClick { get; set; }

--- a/src/MudBlazor/Components/Input/MudRangeInput.razor
+++ b/src/MudBlazor/Components/Input/MudRangeInput.razor
@@ -6,7 +6,7 @@
 <div class="@Classname" style="@Style">
     @if (Adornment == Adornment.Start)
     {
-        <MudInputAdornment Class="@AdornmentClassname" Icon="@AdornmentIcon" Size="@IconSize" Text="@AdornmentText" Edge="@Edge.Start" AdornmentClick="@OnAdornmentClick" />
+        <MudInputAdornment Class="@AdornmentClassname" Icon="@AdornmentIcon" Color="@AdornmentColor" Size="@IconSize" Text="@AdornmentText" Edge="@Edge.Start" AdornmentClick="@OnAdornmentClick" />
     }
 
     @if (InputType == InputType.Hidden && ChildContent != null)
@@ -24,7 +24,7 @@
 
     @if (Adornment == Adornment.End)
     {
-        <MudInputAdornment Class="@AdornmentClassname" Icon="@AdornmentIcon" Size="@IconSize" Text="@AdornmentText" Edge="@Edge.End" AdornmentClick="@OnAdornmentClick" />
+        <MudInputAdornment Class="@AdornmentClassname" Icon="@AdornmentIcon" Color="@AdornmentColor" Size="@IconSize" Text="@AdornmentText" Edge="@Edge.End" AdornmentClick="@OnAdornmentClick" />
     }
 
     @if (Variant == Variant.Outlined)

--- a/src/MudBlazor/Components/Picker/MudPicker.razor
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor
@@ -8,9 +8,9 @@
 {
 
     protected virtual RenderFragment InputContent =>
-        @<MudTextField @ref="_inputReference" @attributes="UserAttributes" Label="@Label" @bind-Text="@Text" HelperText="@HelperText" Variant="@InputVariant" ReadOnly="@(!Editable || ReadOnly)" T="string" Style="@Style"
+        @<MudTextField @ref="_inputReference" @attributes="UserAttributes" Label="@Label" @bind-Text="@Text" HelperText="@HelperText" Variant="@Variant" ReadOnly="@(!Editable || ReadOnly)" T="string" Style="@Style"
                     @onclick="(() => { if (!Editable) ToggleState(); })" OnAdornmentClick="ToggleState" Disabled="@Disabled" Adornment="@Adornment"
-                    AdornmentIcon="@AdornmentIcon" IconSize="@IconSize" Margin="@Margin"
+                    AdornmentIcon="@AdornmentIcon" AdornmentColor="@AdornmentColor" IconSize="@IconSize" Margin="@Margin"
                     Required="@Required" RequiredError="@RequiredError" Error="@Error" ErrorText="@ErrorText"/>;
 
     protected virtual RenderFragment PickerContent => null;

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -85,9 +85,14 @@ namespace MudBlazor
         }
 
         /// <summary>
+        /// The color of the adornment if used. It supports the theme colors.
+        /// </summary>
+        [Parameter] public Color AdornmentColor { get; set; } = Color.Default;
+
+        /// <summary>
         /// Sets the icon of the input text field
         /// </summary>
-        [Parameter] public string AdornmentIcon { get; set; } = Icons.Filled.Event;
+        [Parameter] public string AdornmentIcon { get; set; } = Icons.Material.Filled.Event;
 
         /// <summary>
         /// Fired when the dropdown / dialog opens
@@ -155,9 +160,20 @@ namespace MudBlazor
         [Parameter] public PickerVariant PickerVariant { get; set; } = PickerVariant.Inline;
 
         /// <summary>
+        ///  Variant of the text input
+        /// </summary>
+        [Parameter]
+        [Obsolete("Obsolete, use Variant")]
+        public Variant InputVariant
+        {
+            get { return Variant; }
+            set { Variant = value; }
+        }
+
+        /// <summary>
         /// Variant of the text input
         /// </summary>
-        [Parameter] public Variant InputVariant { get; set; } = Variant.Text;
+        [Parameter] public Variant Variant { get; set; } = Variant.Text;
 
         /// <summary>
         /// Sets if the icon will be att start or end, set to false to disable.


### PR DESCRIPTION
- Forwarded `AdornmentColor` attribute;
- Added `Variant` attribute to replace `InputVariant` attribute and marked it `[Obsolete]`.
   These components are the only ones that have this attribute, all others have `Variant`;
- Changed `AdornmentIcon` default from `Icons.Filled.Event` to `Icons.Material.Filled.Event`
   as usage of  `Icons.Material.Filled` seems to be the norm in the docs and `MudTimePicker` also makes use of it;
- Fixed a bug in `MudInputAdornment.razor` where `Size` would always be set to `Size.Medium`;

![image](https://user-images.githubusercontent.com/10358198/123515270-3d756e80-d686-11eb-9e3b-bf4094af782b.png)
