### PR TITLE
Added MudRTLProvider, removed RightToLeft property from MudLayout (RTL)(BREAKING CHANGE)

### DIFF
--- a/src/MudBlazor.Docs/Pages/Features/RTLLanguages/Examples/RTLLanguagesLayoutExample.razor
+++ b/src/MudBlazor.Docs/Pages/Features/RTLLanguages/Examples/RTLLanguagesLayoutExample.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudLayout RightToLeft="@_rightToLeft">
+<MudRTLProvider RightToLeft="@_rightToLeft">
     <MudCard Class="mb-2" Style="width: 400px">
         <MudCardHeader>
             <CardHeaderAvatar>
@@ -23,8 +23,8 @@
             <MudIconButton Icon="@Icons.Material.Filled.Share" Color="Color.Default" />
         </MudCardActions>
     </MudCard>
-</MudLayout>
-<MudSwitch @bind-Checked="@_rightToLeft" Label="Toggle Right to Left" Color="Color.Primary" Class="mud-float-left mt-n5"/>
+</MudRTLProvider>
+<MudSwitch @bind-Checked="@_rightToLeft" Label="Toggle Right to Left" Color="Color.Primary" Class="mud-float-left"/>
 
 @code {
     private bool _rightToLeft = true;

--- a/src/MudBlazor.Docs/Pages/Features/RTLLanguages/Examples/RTLLanguagesTextfieldExample.razor
+++ b/src/MudBlazor.Docs/Pages/Features/RTLLanguages/Examples/RTLLanguagesTextfieldExample.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudLayout RightToLeft="true">
+<MudRTLProvider RightToLeft="true">
     <MudGrid>
         <MudItem xs="12" sm="4">
             <MudText Align="Align.Left">Text</MudText>
@@ -15,7 +15,7 @@
             <MudTextField InputType="InputType.Email" Label="البريد الإلكتروني" Variant="Variant.Outlined" @bind-Value="@_email" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Email"></MudTextField>
         </MudItem>
     </MudGrid>
-</MudLayout>
+</MudRTLProvider>
 
 @code {
     private string _name { get; set; } = "John Smith";

--- a/src/MudBlazor.Docs/Pages/Features/RTLLanguages/ManualMarkDown/RTLLanguagesMarkdownRtlProvider.razor
+++ b/src/MudBlazor.Docs/Pages/Features/RTLLanguages/ManualMarkDown/RTLLanguagesMarkdownRtlProvider.razor
@@ -1,0 +1,19 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<div class="mud-codeblock">
+<div class="html">
+<pre>
+<span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">MudRTLProvider</span><span class="htmlTagDelimiter">/&gt;</span>
+    <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">MudThemeProvider</span><span class="htmlTagDelimiter">/&gt;</span>
+    <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">MudDialogProvider</span><span class="htmlTagDelimiter">/&gt;</span>
+    <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">MudSnackbarProvider</span><span class="htmlTagDelimiter">/&gt;</span>
+
+    <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">MudLayout</span><span class="htmlTagDelimiter">&gt;</span>
+        <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">MudMainContent</span><span class="htmlTagDelimiter">&gt;</span>
+            <span class="atSign">&#64;</span>Body
+        <span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">MudMainContent</span><span class="htmlTagDelimiter">&gt;</span>
+    <span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">MudLayout</span><span class="htmlTagDelimiter">&gt;</span>
+<span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">MudRTLProvider</span><span class="htmlTagDelimiter">&gt;</span>
+</pre>
+</div>
+</div>

--- a/src/MudBlazor.Docs/Pages/Features/RTLLanguages/RTLLanguagesPage.razor
+++ b/src/MudBlazor.Docs/Pages/Features/RTLLanguages/RTLLanguagesPage.razor
@@ -18,9 +18,25 @@
         </DocsPageSection>
 
         <DocsPageSection>
-            <SectionHeader Title="Enabling RightToLeft">
+            <SectionHeader Title="MudRTLProvider">
                 <Description>
-                    <MudText>Note that you should use <CodeInline>MudLayout</CodeInline> only once in your application.</MudText>
+                    <MudText>
+                        Wrap your code inside a <CodeInline>MudRTLProvider</CodeInline>.
+                        Note that <CodeInline>MudThemeProvider</CodeInline>, <CodeInline>MudDialogProvider</CodeInline> and <CodeInline>MudSnackbarProvider</CodeInline> must be children of
+                        <CodeInline>MudRTLProvider</CodeInline> in order to support RTL. Your <CodeInline>MainLayout.razor</CodeInline>
+                        can look something like this:
+                    </MudText>
+                </Description>
+            </SectionHeader>
+            <RTLLanguagesMarkdownRtlProvider/>
+        </DocsPageSection>
+        
+        <DocsPageSection>
+            <SectionHeader Title="Example">
+                <Description>
+                    <MudText>
+                        By setting <CodeInline>RightToLeft="true"</CodeInline> you can change the layout to RTL.
+                    </MudText>
                 </Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" AutoMarginContent="false">

--- a/src/MudBlazor.Docs/Shared/MainLayout.razor
+++ b/src/MudBlazor.Docs/Shared/MainLayout.razor
@@ -1,25 +1,71 @@
 @using MudBlazor.Docs.Services
 @inherits LayoutComponentBase
 
+<MudRTLProvider RightToLeft="@_rightToLeft">
+    <MudThemeProvider Theme="_currentTheme"/>
+    <MudDialogProvider FullWidth="true" MaxWidth="MaxWidth.ExtraSmall" />
+    <MudSnackbarProvider />
 
-<MudThemeProvider Theme="_currentTheme"/>
-<MudDialogProvider FullWidth="true" MaxWidth="MaxWidth.ExtraSmall" />
-<MudSnackbarProvider />
-
-<MudSwipeArea OnSwipe="@OnSwipe">
-    <MudLayout RightToLeft="@_rightToLeft">
-        <MudAppBar Elevation="25">
-            <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@((e) => DrawerToggle())" />
-            <MudText Typo="Typo.h5" Class="mudblazor-appbar-brand-text d-none d-md-flex">MudBlazor</MudText>
-            <MudSpacer />
-            <MudAutocomplete T="ApiLinkServiceEntry" Placeholder="Search" SearchFunc="Search" Variant="Variant.Outlined" ValueChanged="OnSearchResult" Class="docs-search-bar">
-                <ItemTemplate Context="result">
-                    <MudText>@result.Title</MudText> <MudText Typo="Typo.body2">@result.SubTitle</MudText>
-                </ItemTemplate>
-            </MudAutocomplete>
-            <MudSpacer />
-            <div class="d-none d-md-flex align-center">
-                <MudMenu EndIcon="@Icons.Filled.KeyboardArrowDown" Label="Support" Color="Color.Inherit" Dense="true" Direction="Direction.Right" OffsetY="true">
+    <MudSwipeArea OnSwipe="@OnSwipe">
+        <MudLayout>
+            <MudAppBar Elevation="25">
+                <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@((e) => DrawerToggle())" />
+                <MudText Typo="Typo.h5" Class="mudblazor-appbar-brand-text d-none d-md-flex">MudBlazor</MudText>
+                <MudSpacer />
+                <MudAutocomplete T="ApiLinkServiceEntry" Placeholder="Search" SearchFunc="Search" Variant="Variant.Outlined" ValueChanged="OnSearchResult" Class="docs-search-bar">
+                    <ItemTemplate Context="result">
+                        <MudText>@result.Title</MudText> <MudText Typo="Typo.body2">@result.SubTitle</MudText>
+                    </ItemTemplate>
+                </MudAutocomplete>
+                <MudSpacer />
+                <div class="d-none d-md-flex align-center">
+                    <MudMenu EndIcon="@Icons.Filled.KeyboardArrowDown" Label="Support" Color="Color.Inherit" Dense="true" Direction="Direction.Right" OffsetY="true">
+                        <MudText Typo="Typo.body2" Class="px-4 py-2"><b>Community Support</b></MudText>
+                        <MudMenuItem Link="https://discord.gg/mudblazor" Target="_blank">Discord</MudMenuItem>
+                        <MudMenuItem Link="https://github.com/Garderoben/MudBlazor/discussions" Target="_blank">GitHub Discussions</MudMenuItem>
+                        <MudText Typo="Typo.body2" Class="px-4 py-2"><b>Tools and resources</b></MudText>
+                        <MudMenuItem Link="https://try.mudblazor.com/snippet" Target="_blank">TryMudBlazor</MudMenuItem>
+                        <MudMenuItem Link="https://github.com/Garderoben/MudBlazor.Templates" Target="_blank">Templates</MudMenuItem>
+                        <MudText Typo="Typo.body2" Class="px-4 py-2"><b>Sponsor</b></MudText>
+                        <MudMenuItem Link="https://opencollective.com/mudblazor" Target="_blank">Open Collective</MudMenuItem>
+                    </MudMenu>
+                    <MudDivider Vertical="true" FlexItem="true" DividerType="DividerType.Middle" Class="mx-4 my-3" />
+                    @if (Wasm)
+                    {
+                        <MudTooltip Text="Switch to Blazor server-side">
+                            <MudIconButton Icon="@Icons.Material.Filled.Computer" Color="Color.Inherit" OnClick="@((e) => SwitchToServer())" />
+                        </MudTooltip>
+                    }
+                    else
+                    {
+                        <MudTooltip Text="Switch to Blazor wasm">
+                            <MudIconButton Icon="@Icons.Material.Filled.Dns" Color="Color.Inherit" OnClick="@((e) => SwitchToWasm())" />
+                        </MudTooltip>
+                    }
+                    <MudTooltip Text="Toggle light/dark theme">
+                        <MudIconButton Icon="@Icons.Material.Filled.Brightness4" Color="Color.Inherit" OnClick="@((e) => DarkMode())" />
+                    </MudTooltip>
+                    <MudTooltip Text="GitHub repository">
+                        <MudIconButton Icon="@Icons.Custom.Brands.GitHub" Color="Color.Inherit" Link="https://github.com/Garderoben/MudBlazor" Target="_blank" />
+                    </MudTooltip>
+                    <MudTooltip Text="Toggle right-to-left/left-to-right">
+                        <MudIconButton Icon="@Icons.Material.Filled.FormatTextdirectionRToL" Color="Color.Inherit" OnClick="@((e) => RightToLeftToggle())" />
+                    </MudTooltip>
+                </div>
+                <MudMenu Icon="@Icons.Filled.Settings" Color="Color.Inherit" Dense="true" Direction="Direction.Right" OffsetY="true" Class="d-md-none">
+                    <div class="px-2">
+                        @if (Wasm)
+                        {
+                            <MudIconButton Icon="@Icons.Material.Filled.Computer" Color="Color.Inherit" OnClick="@((e) => SwitchToServer())" />
+                        }
+                        else
+                        {
+                            <MudIconButton Icon="@Icons.Material.Filled.Dns" Color="Color.Inherit" OnClick="@((e) => SwitchToWasm())" />
+                        }
+                        <MudIconButton Icon="@Icons.Material.Filled.Brightness4" Color="Color.Inherit" OnClick="@((e) => DarkMode())" />
+                        <MudIconButton Icon="@Icons.Custom.Brands.GitHub" Color="Color.Inherit" Link="https://github.com/Garderoben/MudBlazor" Target="_blank" />
+                        <MudIconButton Icon="@Icons.Material.Filled.FormatTextdirectionRToL" Color="Color.Inherit" OnClick="@((e) => RightToLeftToggle())" />
+                    </div>
                     <MudText Typo="Typo.body2" Class="px-4 py-2"><b>Community Support</b></MudText>
                     <MudMenuItem Link="https://discord.gg/mudblazor" Target="_blank">Discord</MudMenuItem>
                     <MudMenuItem Link="https://github.com/Garderoben/MudBlazor/discussions" Target="_blank">GitHub Discussions</MudMenuItem>
@@ -29,66 +75,21 @@
                     <MudText Typo="Typo.body2" Class="px-4 py-2"><b>Sponsor</b></MudText>
                     <MudMenuItem Link="https://opencollective.com/mudblazor" Target="_blank">Open Collective</MudMenuItem>
                 </MudMenu>
-                <MudDivider Vertical="true" FlexItem="true" DividerType="DividerType.Middle" Class="mx-4 my-3" />
-                @if (Wasm)
-                {
-                    <MudTooltip Text="Switch to Blazor server-side">
-                        <MudIconButton Icon="@Icons.Material.Filled.Computer" Color="Color.Inherit" OnClick="@((e) => SwitchToServer())" />
-                    </MudTooltip>
-                }
-                else
-                {
-                    <MudTooltip Text="Switch to Blazor wasm">
-                        <MudIconButton Icon="@Icons.Material.Filled.Dns" Color="Color.Inherit" OnClick="@((e) => SwitchToWasm())" />
-                    </MudTooltip>
-                }
-                <MudTooltip Text="Toggle light/dark theme">
-                    <MudIconButton Icon="@Icons.Material.Filled.Brightness4" Color="Color.Inherit" OnClick="@((e) => DarkMode())" />
-                </MudTooltip>
-                <MudTooltip Text="GitHub repository">
-                    <MudIconButton Icon="@Icons.Custom.Brands.GitHub" Color="Color.Inherit" Link="https://github.com/Garderoben/MudBlazor" Target="_blank" />
-                </MudTooltip>
-                <MudTooltip Text="Toggle right-to-left/left-to-right">
-                    <MudIconButton Icon="@Icons.Material.Filled.FormatTextdirectionRToL" Color="Color.Inherit" OnClick="@((e) => RightToLeftToggle())" />
-                </MudTooltip>
-            </div>
-            <MudMenu Icon="@Icons.Filled.Settings" Color="Color.Inherit" Dense="true" Direction="Direction.Right" OffsetY="true" Class="d-md-none">
-                <div class="px-2">
-                    @if (Wasm)
-                    {
-                        <MudIconButton Icon="@Icons.Material.Filled.Computer" Color="Color.Inherit" OnClick="@((e) => SwitchToServer())" />
-                    }
-                    else
-                    {
-                        <MudIconButton Icon="@Icons.Material.Filled.Dns" Color="Color.Inherit" OnClick="@((e) => SwitchToWasm())" />
-                    }
-                    <MudIconButton Icon="@Icons.Material.Filled.Brightness4" Color="Color.Inherit" OnClick="@((e) => DarkMode())" />
-                    <MudIconButton Icon="@Icons.Custom.Brands.GitHub" Color="Color.Inherit" Link="https://github.com/Garderoben/MudBlazor" Target="_blank" />
-                    <MudIconButton Icon="@Icons.Material.Filled.FormatTextdirectionRToL" Color="Color.Inherit" OnClick="@((e) => RightToLeftToggle())" />
-                </div>
-                <MudText Typo="Typo.body2" Class="px-4 py-2"><b>Community Support</b></MudText>
-                <MudMenuItem Link="https://discord.gg/mudblazor" Target="_blank">Discord</MudMenuItem>
-                <MudMenuItem Link="https://github.com/Garderoben/MudBlazor/discussions" Target="_blank">GitHub Discussions</MudMenuItem>
-                <MudText Typo="Typo.body2" Class="px-4 py-2"><b>Tools and resources</b></MudText>
-                <MudMenuItem Link="https://try.mudblazor.com/snippet" Target="_blank">TryMudBlazor</MudMenuItem>
-                <MudMenuItem Link="https://github.com/Garderoben/MudBlazor.Templates" Target="_blank">Templates</MudMenuItem>
-                <MudText Typo="Typo.body2" Class="px-4 py-2"><b>Sponsor</b></MudText>
-                <MudMenuItem Link="https://opencollective.com/mudblazor" Target="_blank">Open Collective</MudMenuItem>
-            </MudMenu>
-        </MudAppBar>
+            </MudAppBar>
 
-        <MudDrawer @bind-Open=_drawerOpen Elevation="25" Class="mudblazor-appbar-band">
-            <MudDrawerHeader Class="mudblazor-brand" LinkToIndex="true">
-                <MudBlazorLogo />
-            </MudDrawerHeader>
-            <NavMenu @ref="@_navMenuRef" />
-        </MudDrawer>
-        <MudMainContent Class="mudblazor-main-content">
-            @Body
-            <MudScrollToTop TopOffset="400" Style="z-index:2000;">
-                <MudFab Icon="@Icons.Material.Filled.KeyboardArrowUp" Color="Color.Primary" />
-            </MudScrollToTop>
-            <NavigationFooter Section=_section Previous="@_previous" Next="@_next" />
-        </MudMainContent>
-    </MudLayout>
-</MudSwipeArea>
+            <MudDrawer @bind-Open=_drawerOpen Elevation="25" Class="mudblazor-appbar-band">
+                <MudDrawerHeader Class="mudblazor-brand" LinkToIndex="true">
+                    <MudBlazorLogo />
+                </MudDrawerHeader>
+                <NavMenu @ref="@_navMenuRef" />
+            </MudDrawer>
+            <MudMainContent Class="mudblazor-main-content">
+                @Body
+                <MudScrollToTop TopOffset="400" Style="z-index:2000;">
+                    <MudFab Icon="@Icons.Material.Filled.KeyboardArrowUp" Color="Color.Primary" />
+                </MudScrollToTop>
+                <NavigationFooter Section=_section Previous="@_previous" Next="@_next" />
+            </MudMainContent>
+        </MudLayout>
+    </MudSwipeArea>
+</MudRTLProvider>

--- a/src/MudBlazor/Components/Drawer/MudDrawerContainer.razor.cs
+++ b/src/MudBlazor/Components/Drawer/MudDrawerContainer.razor.cs
@@ -28,7 +28,7 @@ namespace MudBlazor
         .Build();
 
         [CascadingParameter]
-        public bool Rtl { get; set; }
+        public bool RightToLeft { get; set; }
 
         [Parameter]
         public RenderFragment ChildContent { get; set; }
@@ -81,25 +81,25 @@ namespace MudBlazor
 
         private MudDrawer FindLeftDrawer()
         {
-            Anchor anchor = Rtl ? Anchor.End : Anchor.Start;
+            Anchor anchor = RightToLeft ? Anchor.End : Anchor.Start;
             return _drawers.FirstOrDefault(d => d.Anchor == anchor || d.Anchor == Anchor.Left);
         }
 
         private MudDrawer FindRightDrawer()
         {
-            Anchor anchor = Rtl ? Anchor.Start : Anchor.End;
+            Anchor anchor = RightToLeft ? Anchor.Start : Anchor.End;
             return _drawers.FirstOrDefault(d => d.Anchor == anchor || d.Anchor == Anchor.Right);
         }
 
         private MudDrawer FindLeftMiniDrawer()
         {
-            Anchor anchor = Rtl ? Anchor.End : Anchor.Start;
+            Anchor anchor = RightToLeft ? Anchor.End : Anchor.Start;
             return _drawers.FirstOrDefault(d => d.Variant == DrawerVariant.Mini && (d.Anchor == anchor || d.Anchor == Anchor.Left));
         }
 
         private MudDrawer FindRightMiniDrawer()
         {
-            Anchor anchor = Rtl ? Anchor.Start : Anchor.End;
+            Anchor anchor = RightToLeft ? Anchor.Start : Anchor.End;
             return _drawers.FirstOrDefault(d => d.Variant == DrawerVariant.Mini && (d.Anchor == anchor || d.Anchor == Anchor.Right));
         }
     }

--- a/src/MudBlazor/Components/Layout/MudLayout.razor
+++ b/src/MudBlazor/Components/Layout/MudLayout.razor
@@ -3,8 +3,6 @@
 
 <div @attributes="UserAttributes" class="@Classname" style="@Stylename">
     <CascadingValue IsFixed="true" Value="@this">
-        <CascadingValue Value="@RightToLeft">
-            @ChildContent
-        </CascadingValue>
+        @ChildContent
     </CascadingValue>
 </div>

--- a/src/MudBlazor/Components/Layout/MudLayout.razor.cs
+++ b/src/MudBlazor/Components/Layout/MudLayout.razor.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
@@ -7,32 +7,12 @@ namespace MudBlazor
     {
         protected override string Classname =>
         new CssBuilder("mud-layout")
-            .AddClass("mud-application-layout-rtl", RightToLeft)
             .AddClass(base.Classname)
             .Build();
-
-        private bool _rtl;
 
         public MudLayout()
         {
             Fixed = true;
-        }
-
-        /// <summary>
-        /// If set, changes the layout to RightToLeft.
-        /// </summary>
-        [Parameter]
-        public bool RightToLeft
-        {
-            get => _rtl;
-            set
-            {
-                if (_rtl != value)
-                {
-                    Rtl = _rtl = value;
-                    StateHasChanged();
-                }
-            }
         }
     }
 }

--- a/src/MudBlazor/Components/RTLProvider/MudRTLProvider.razor
+++ b/src/MudBlazor/Components/RTLProvider/MudRTLProvider.razor
@@ -1,0 +1,8 @@
+﻿@namespace MudBlazor
+@inherits MudComponentBase
+
+<MudElement HtmlTag="div" Class="@Classname" Style="@Style" UserAttributes="@UserAttributes" Tag="@Tag">
+    <CascadingValue Value="@RightToLeft">
+        @ChildContent
+    </CascadingValue>
+</MudElement>

--- a/src/MudBlazor/Components/RTLProvider/MudRTLProvider.razor.cs
+++ b/src/MudBlazor/Components/RTLProvider/MudRTLProvider.razor.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.AspNetCore.Components;
+using MudBlazor.Utilities;
+
+namespace MudBlazor
+{
+    public partial class MudRTLProvider : MudComponentBase
+    {
+        protected string Classname =>
+            new CssBuilder("mud-rtl-provider")
+                .AddClass("mud-application-layout-rtl", RightToLeft)
+                .AddClass(Class)
+                .Build();
+
+        private bool _rtl;
+        /// <summary>
+        /// If true, changes the layout to RightToLeft.
+        /// </summary>
+        [Parameter]
+        public bool RightToLeft
+        {
+            get => _rtl;
+            set
+            {
+                _rtl = value;
+                UserAttributes["dir"] = RightToLeft ? "rtl" : "ltr";
+            }
+        }
+
+        /// <summary>
+        /// Child content of the component.
+        /// </summary>
+        [Parameter]
+        public RenderFragment ChildContent { get; set; }
+    }
+}


### PR DESCRIPTION
Closes  #1954
Closes `Dialog + Snackbar: explain in docs RTL page + apply RTL in docs` in https://github.com/Garderoben/MudBlazor/issues/92#issuecomment-866619540
Drawer support isn't working at the moment. I think its not possible to keep the `RightToLeft` property in `MudLayout` for backwards compability. Maybe someone has a solution.

![grafik](https://user-images.githubusercontent.com/62108893/123674302-bec53080-d841-11eb-8141-00d1d8f3016e.png)

