### PR TITLE
Snackbar: added start/end position, fixed alignment bug (RTL)

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Snackbar/Examples/SnackbarPositionExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Snackbar/Examples/SnackbarPositionExample.razor
@@ -2,12 +2,17 @@
 
 @inject ISnackbar Snackbar
 
+<MudButton @onclick="@(() => ChangePosition("Top-Start", Defaults.Classes.Position.TopStart))" Color="Color.Primary" >Top-Start</MudButton>
 <MudButton @onclick="@(() => ChangePosition("Top-Left", Defaults.Classes.Position.TopLeft))" Color="Color.Primary" >Top-Left</MudButton>
 <MudButton @onclick="@(() => ChangePosition("Top-Center", Defaults.Classes.Position.TopCenter))" Color="Color.Primary" >Top-Center</MudButton>
 <MudButton @onclick="@(() => ChangePosition("Top-Right", Defaults.Classes.Position.TopRight))" Color="Color.Primary" >Top-Right</MudButton>
+<MudButton @onclick="@(() => ChangePosition("Top-End", Defaults.Classes.Position.TopEnd))" Color="Color.Primary" >Top-End</MudButton>
+<MudSpacer/>
+<MudButton @onclick="@(() => ChangePosition("Bottom-Start", Defaults.Classes.Position.BottomStart))" Color="Color.Default" >Bottom-Start</MudButton>
 <MudButton @onclick="@(() => ChangePosition("Bottom-Left", Defaults.Classes.Position.BottomLeft))" Color="Color.Default" >Bottom-Left</MudButton>
 <MudButton @onclick="@(() => ChangePosition("Bottom-Center", Defaults.Classes.Position.BottomCenter))" Color="Color.Default" >Bottom-Center</MudButton>
 <MudButton @onclick="@(() => ChangePosition("Bottom-Right", Defaults.Classes.Position.BottomRight))" Color="Color.Default" >Bottom-Right</MudButton>
+<MudButton @onclick="@(() => ChangePosition("Bottom-End", Defaults.Classes.Position.BottomEnd))" Color="Color.Default" >Bottom-End</MudButton>
 
 @code {
     void ChangePosition(string message, string position)

--- a/src/MudBlazor/Components/Snackbar/Defaults.cs
+++ b/src/MudBlazor/Components/Snackbar/Defaults.cs
@@ -12,10 +12,14 @@ namespace MudBlazor
                 public const string TopLeft = "mud-snackbar-location-top-left";
                 public const string TopCenter = "mud-snackbar-location-top-center";
                 public const string TopRight = "mud-snackbar-location-top-right";
+                public const string TopStart = "mud-snackbar-location-top-start";
+                public const string TopEnd = "mud-snackbar-location-top-end";
 
                 public const string BottomLeft = "mud-snackbar-location-bottom-left";
                 public const string BottomCenter = "mud-snackbar-location-bottom-center";
                 public const string BottomRight = "mud-snackbar-location-bottom-right";
+                public const string BottomStart = "mud-snackbar-location-bottom-start";
+                public const string BottomEnd = "mud-snackbar-location-bottom-end";
             }
         }
     }

--- a/src/MudBlazor/Components/Snackbar/MudSnackbarElement.razor
+++ b/src/MudBlazor/Components/Snackbar/MudSnackbarElement.razor
@@ -30,7 +30,7 @@
 
             @if (ShowCloseIcon)
             {
-                <MudIconButton Icon="@Icons.Material.Filled.Close" Size="Size.Small" Class="ml-2" OnClick="CloseIconClicked" />
+                <MudIconButton Icon="@Icons.Material.Filled.Close" Size="Size.Small" Class="ms-2" OnClick="CloseIconClicked" />
             }
 
         </div>

--- a/src/MudBlazor/Components/Snackbar/MudSnackbarProvider.razor.cs
+++ b/src/MudBlazor/Components/Snackbar/MudSnackbarProvider.razor.cs
@@ -14,15 +14,30 @@ namespace MudBlazor
     {
         [Inject] private ISnackbar Snackbars { get; set; }
 
+        [CascadingParameter] public bool RightToLeft { get; set; }
+
         protected IEnumerable<Snackbar> Snackbar => Snackbars.Configuration.NewestOnTop
                 ? Snackbars.ShownSnackbars.Reverse()
                 : Snackbars.ShownSnackbars;
 
         protected string Classname =>
             new CssBuilder(Class)
-            .AddClass(Snackbars.Configuration.PositionClass)
+            .AddClass(GetPositionClass())
         .Build();
 
+        private string GetPositionClass()
+        {
+            var positionClass = Snackbars.Configuration.PositionClass;
+            return positionClass switch
+            {
+                Defaults.Classes.Position.BottomStart => RightToLeft ? Defaults.Classes.Position.BottomRight : Defaults.Classes.Position.BottomLeft,
+                Defaults.Classes.Position.BottomEnd => RightToLeft ? Defaults.Classes.Position.BottomLeft : Defaults.Classes.Position.BottomRight,
+                Defaults.Classes.Position.TopStart => RightToLeft ? Defaults.Classes.Position.TopRight : Defaults.Classes.Position.TopLeft,
+                Defaults.Classes.Position.TopEnd => RightToLeft ? Defaults.Classes.Position.TopLeft : Defaults.Classes.Position.TopRight,
+                _ => positionClass
+            };
+        }
+        
         protected override void OnInitialized()
         {
             base.OnInitialized();

--- a/src/MudBlazor/Styles/components/_snackbar.scss
+++ b/src/MudBlazor/Styles/components/_snackbar.scss
@@ -41,6 +41,7 @@
         margin-inline-start: auto;
         margin-inline-end: -8px;
         padding-inline-start: 16px;
+        padding-inline-end: unset;
 
         & > button {
             color: inherit;


### PR DESCRIPTION
Closes `Snackbar: Start/End options for Position` in https://github.com/Garderoben/MudBlazor/issues/92#issuecomment-866619540
Requires #2040
![snackbar](https://user-images.githubusercontent.com/62108893/123561128-03e85480-d7a7-11eb-94f4-c7dacec4003d.gif)
