### PR TITLE
Donut chart: added start/end options for LegendPosition (RTL)

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/DonutExample2.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/DonutExample2.razor
@@ -10,6 +10,8 @@
     <MudSelectItem T="Position" Value="Position.Left">Left</MudSelectItem>
     <MudSelectItem T="Position" Value="Position.Right">Right</MudSelectItem>
     <MudSelectItem T="Position" Value="Position.Bottom">Bottom</MudSelectItem>
+    <MudSelectItem T="Position" Value="Position.Start">Start</MudSelectItem>
+    <MudSelectItem T="Position" Value="Position.End">End</MudSelectItem>
 </MudSelect>
 
 @code {
@@ -33,6 +35,12 @@
                 break;
             case Position.Bottom:
                 LegendPosition = Position.Bottom;
+                break;
+            case Position.Start:
+                LegendPosition = Position.Start;
+                break;
+            case Position.End:
+                LegendPosition = Position.End;
                 break;
         }
     }

--- a/src/MudBlazor/Components/Chart/MudChart.razor
+++ b/src/MudBlazor/Components/Chart/MudChart.razor
@@ -3,7 +3,7 @@
 @inherits MudChartBase
 
 <CascadingValue Value="@this" IsFixed="true">
-    <div @attributes="UserAttributes" class="@Classname" style="@Style">
+    <div @attributes="UserAttributes" class="@Classname" style="@Style" dir="ltr">
         @if (ChartType == ChartType.Donut)
         {
             <Donut InputData="@InputData" @bind-SelectedIndex="@SelectedIndex" InputLabels="@InputLabels"></Donut>

--- a/src/MudBlazor/Components/Chart/MudChart.razor.cs
+++ b/src/MudBlazor/Components/Chart/MudChart.razor.cs
@@ -22,10 +22,13 @@ namespace MudBlazor
 
         protected string Classname =>
         new CssBuilder("mud-chart")
-           .AddClass($"mud-chart-legend-{LegendPosition.ToDescriptionString()}")
+           .AddClass($"mud-chart-legend-{ConvertLegendPosition(LegendPosition).ToDescriptionString()}")
           .AddClass(Class)
         .Build();
-
+        
+        [CascadingParameter]
+        public bool RightToLeft { get; set; }
+        
         /// <summary>
         /// The Type of the chart.
         /// </summary>
@@ -42,10 +45,20 @@ namespace MudBlazor
         [Parameter] public string Height { get; set; } = "80%";
 
         /// <summary>
-        /// The placment direction of the legend if used.
+        /// The placement direction of the legend if used.
         /// </summary>
         [Parameter] public Position LegendPosition { get; set; } = Position.Bottom;
 
+        private Position ConvertLegendPosition(Position position)
+        {
+            return position switch
+            {
+                Position.Start => RightToLeft ? Position.Right : Position.Left,
+                Position.End => RightToLeft ? Position.Left : Position.Right,
+                _ => position
+            };
+        }
+        
         private int _selectedIndex;
 
         /// <summary>

--- a/src/MudBlazor/Enums/Position.cs
+++ b/src/MudBlazor/Enums/Position.cs
@@ -11,6 +11,10 @@ namespace MudBlazor
         [Description("left")]
         Left,
         [Description("right")]
-        Right
+        Right,
+        [Description("start")]
+        Start,
+        [Description("end")]
+        End
     }
 }


### PR DESCRIPTION
Fixes `Donut Chart: Start/End options for LegendPosition` in https://github.com/Garderoben/MudBlazor/issues/92#issuecomment-866619540

![donut](https://user-images.githubusercontent.com/62108893/123668320-45c2da80-d83b-11eb-9e12-2ed5aee87364.gif)
