### PR TITLE
DateRangePicker: Fix initializing DateRange with null values

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
@@ -418,5 +418,33 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("button.mud-picker-calendar-day").Select(button => (button as IHtmlButtonElement).IsDisabled)
                 .Should().OnlyContain(disabled => disabled == false);
         }
+
+        [Test]
+        public void InitializeDateRange_DefaultConstructor()
+        {
+            var range = new DateRange();
+
+            var comp = OpenPicker(Parameter(nameof(MudDateRangePicker.DateRange), range));
+
+            comp.Instance.DateRange.Should().NotBeNull();
+            comp.Instance.DateRange.Start.Should().NotBe(default);
+            comp.Instance.DateRange.End.Should().NotBe(default);
+            comp.Instance.DateRange.Start.Should().BeNull();
+            comp.Instance.DateRange.End.Should().BeNull();
+        }
+
+        [Test]
+        public void InitializeDateRange_AllNullValues()
+        {
+            var range = new DateRange(null, null);
+
+            var comp = OpenPicker(Parameter(nameof(MudDateRangePicker.DateRange), range));
+
+            comp.Instance.DateRange.Should().NotBeNull();
+            comp.Instance.DateRange.Start.Should().NotBe(default);
+            comp.Instance.DateRange.End.Should().NotBe(default);
+            comp.Instance.DateRange.Start.Should().BeNull();
+            comp.Instance.DateRange.End.Should().BeNull();
+        }
     }
 }

--- a/src/MudBlazor.sln
+++ b/src/MudBlazor.sln
@@ -24,6 +24,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MudBlazor.Examples.Data", "MudBlazor.Examples.Data\MudBlazor.Examples.Data.csproj", "{D9290286-6DD8-478C-A902-23660C554A1C}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MyMudBlazorTestApp", "..\..\MyMudBlazorTestApp\MyMudBlazorTestApp\MyMudBlazorTestApp\MyMudBlazorTestApp.csproj", "{92275D16-0FCC-4BAF-AB94-FAC8F6BA49AA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -62,6 +64,10 @@ Global
 		{D9290286-6DD8-478C-A902-23660C554A1C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D9290286-6DD8-478C-A902-23660C554A1C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D9290286-6DD8-478C-A902-23660C554A1C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{92275D16-0FCC-4BAF-AB94-FAC8F6BA49AA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{92275D16-0FCC-4BAF-AB94-FAC8F6BA49AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{92275D16-0FCC-4BAF-AB94-FAC8F6BA49AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{92275D16-0FCC-4BAF-AB94-FAC8F6BA49AA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/MudBlazor.sln
+++ b/src/MudBlazor.sln
@@ -24,8 +24,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MudBlazor.Examples.Data", "MudBlazor.Examples.Data\MudBlazor.Examples.Data.csproj", "{D9290286-6DD8-478C-A902-23660C554A1C}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MyMudBlazorTestApp", "..\..\MyMudBlazorTestApp\MyMudBlazorTestApp\MyMudBlazorTestApp\MyMudBlazorTestApp.csproj", "{92275D16-0FCC-4BAF-AB94-FAC8F6BA49AA}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -64,10 +62,6 @@ Global
 		{D9290286-6DD8-478C-A902-23660C554A1C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D9290286-6DD8-478C-A902-23660C554A1C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D9290286-6DD8-478C-A902-23660C554A1C}.Release|Any CPU.Build.0 = Release|Any CPU
-		{92275D16-0FCC-4BAF-AB94-FAC8F6BA49AA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{92275D16-0FCC-4BAF-AB94-FAC8F6BA49AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{92275D16-0FCC-4BAF-AB94-FAC8F6BA49AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{92275D16-0FCC-4BAF-AB94-FAC8F6BA49AA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -275,7 +275,10 @@ namespace MudBlazor
 
         protected virtual bool HasValue(T value)
         {
-            return typeof(T) == typeof(string) ? !IsNullOrWhiteSpace(value as string) : value != null;
+            if (typeof(T) == typeof(string))
+                return !string.IsNullOrWhiteSpace(value as string);
+
+            return value != null;
         }
 
         protected virtual void ValidateWithAttribute(ValidationAttribute attr, T value, List<string> errors)

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -251,13 +251,10 @@ namespace MudBlazor
                 }
 
                 // required error (must be last, because it is least important!)
-                var hasValue = HasValue(_value);
                 if (Required)
                 {
-                    if (!hasValue && Touched)
-                    {
+                    if (Touched && !HasValue(_value))
                         errors.Add(RequiredError);
-                    }
                 }
             }
             finally
@@ -278,10 +275,7 @@ namespace MudBlazor
 
         protected virtual bool HasValue(T value)
         {
-            if (typeof(T) == typeof(string))
-                return !string.IsNullOrWhiteSpace((string)(object)value);
-
-            return value != null;
+            return typeof(T) == typeof(string) ? !IsNullOrWhiteSpace(value as string) : value != null;
         }
 
         protected virtual void ValidateWithAttribute(ValidationAttribute attr, T value, List<string> errors)

--- a/src/MudBlazor/Components/DatePicker/DateRange.cs
+++ b/src/MudBlazor/Components/DatePicker/DateRange.cs
@@ -5,19 +5,22 @@ namespace MudBlazor
 {
     public class DateRange : Range<DateTime?>
     {
+        public DateRange() : base(null, null)
+        {
+        }
+
         public DateRange(DateTime? start, DateTime? end) : base(start, end)
         {
-
         }
 
         public string ToString(Converter<DateTime?, string> converter)
         {
-            return Start == null || End == null ? string.Empty : RangeConverter<DateTime>.Join(converter.Set(Start.Value), converter.Set(End.Value));
+            return Start is null || End is null ? string.Empty : RangeConverter<DateTime>.Join(converter.Set(Start.Value), converter.Set(End.Value));
         }
 
         public string ToIsoDateString()
         {
-            return Start == null || End == null ? string.Empty : RangeConverter<DateTime>.Join(Start.ToIsoDateString(), End.ToIsoDateString());
+            return Start is null || End is null ? string.Empty : RangeConverter<DateTime>.Join(Start.ToIsoDateString(), End.ToIsoDateString());
         }
 
         public static bool TryParse(string value, Converter<DateTime?, string> converter, out DateRange date)

--- a/src/MudBlazor/Components/DatePicker/DateRange.cs
+++ b/src/MudBlazor/Components/DatePicker/DateRange.cs
@@ -15,12 +15,18 @@ namespace MudBlazor
 
         public string ToString(Converter<DateTime?, string> converter)
         {
-            return Start is null || End is null ? string.Empty : RangeConverter<DateTime>.Join(converter.Set(Start.Value), converter.Set(End.Value));
+            if (Start == null || End == null)
+                return string.Empty;
+
+            return RangeConverter<DateTime>.Join(converter.Set(Start.Value), converter.Set(End.Value));
         }
 
         public string ToIsoDateString()
         {
-            return Start is null || End is null ? string.Empty : RangeConverter<DateTime>.Join(Start.ToIsoDateString(), End.ToIsoDateString());
+            if (Start == null || End == null)
+                return string.Empty;
+
+            return RangeConverter<DateTime>.Join(Start.ToIsoDateString(), End.ToIsoDateString());
         }
 
         public static bool TryParse(string value, Converter<DateTime?, string> converter, out DateRange date)

--- a/src/MudBlazor/Components/DatePicker/DateRange.cs
+++ b/src/MudBlazor/Components/DatePicker/DateRange.cs
@@ -12,15 +12,12 @@ namespace MudBlazor
 
         public string ToString(Converter<DateTime?, string> converter)
         {
-            if (Start == null || End == null)
-                return "";
-
-            return RangeConverter<DateTime>.Join(converter.Set(Start.Value), converter.Set(End.Value));
+            return Start == null || End == null ? string.Empty : RangeConverter<DateTime>.Join(converter.Set(Start.Value), converter.Set(End.Value));
         }
 
         public string ToIsoDateString()
         {
-            return RangeConverter<DateTime>.Join(Start.ToIsoDateString(), End.ToIsoDateString());
+            return Start == null || End == null ? string.Empty : RangeConverter<DateTime>.Join(Start.ToIsoDateString(), End.ToIsoDateString());
         }
 
         public static bool TryParse(string value, Converter<DateTime?, string> converter, out DateRange date)

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -40,12 +40,11 @@ namespace MudBlazor
         {
             if (_dateRange != range)
             {
-                var doesRangeContainDisabledDates = Enumerable
+                if (null != range.Start && null != range.End && Enumerable
                     .Range(0, int.MaxValue)
                     .Select(index => range.Start.Value.AddDays(index))
                     .TakeWhile(date => date <= range.End.Value)
-                    .Any(date => IsDateDisabledFunc(date.Date));
-                if (doesRangeContainDisabledDates)
+                    .Any(date => IsDateDisabledFunc(date.Date)))
                 {
                     _rangeText = null;
                     await SetTextAsync(null, false);
@@ -57,18 +56,12 @@ namespace MudBlazor
                 if (updateValue)
                 {
                     Converter.GetError = false;
-                    if (_dateRange == null)
-                    {
-                        _rangeText = null;
-                        await SetTextAsync(null, false);
-                    }
-                    else
-                    {
-                        _rangeText = new Range<string>(
-                            Converter.Set(_dateRange.Start),
-                            Converter.Set(_dateRange.End));
-                        await SetTextAsync(_dateRange.ToString(Converter), false);
-                    }
+
+                    _rangeText = _dateRange != null
+                        ? new Range<string>(Converter.Set(_dateRange.Start), Converter.Set(_dateRange.End))
+                        : null;
+
+                    await SetTextAsync(_dateRange?.ToString(Converter), false);
                 }
 
                 await DateRangeChanged.InvokeAsync(_dateRange);
@@ -259,9 +252,7 @@ namespace MudBlazor
 
         protected override async void Submit()
         {
-            if (ReadOnly)
-                return;
-            if (_firstDate == null || _secondDate == null)
+            if (ReadOnly || _firstDate == null || _secondDate == null)
                 return;
 
             await SetDateRangeAsync(new DateRange(_firstDate, _secondDate), true);

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -55,12 +55,18 @@ namespace MudBlazor
                 if (updateValue)
                 {
                     Converter.GetError = false;
-
-                    _rangeText = _dateRange != null
-                        ? new Range<string>(Converter.Set(_dateRange.Start), Converter.Set(_dateRange.End))
-                        : null;
-
-                    await SetTextAsync(_dateRange?.ToString(Converter), false);
+                    if (_dateRange == null)
+                    {
+                        _rangeText = null;
+                        await SetTextAsync(null, false);
+                    }
+                    else
+                    {
+                        _rangeText = new Range<string>(
+                            Converter.Set(_dateRange.Start),
+                            Converter.Set(_dateRange.End));
+                        await SetTextAsync(_dateRange.ToString(Converter), false);
+                    }
                 }
 
                 await DateRangeChanged.InvokeAsync(_dateRange);

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -39,7 +39,7 @@ namespace MudBlazor
         {
             if (_dateRange != range)
             {
-                if (null != range && null != range.Start && null != range.End && Enumerable
+                if (range?.Start != null && range?.End != null && Enumerable
                     .Range(0, int.MaxValue)
                     .Select(index => range.Start.Value.AddDays(index))
                     .TakeWhile(date => date <= range.End.Value)
@@ -257,10 +257,11 @@ namespace MudBlazor
 
         protected override async void Submit()
         {
-            if (ReadOnly || _firstDate == null || _secondDate == null)
+            if (ReadOnly)
                 return;
+            if (_firstDate == null || _secondDate == null)
 
-            await SetDateRangeAsync(new DateRange(_firstDate, _secondDate), true);
+                await SetDateRangeAsync(new DateRange(_firstDate, _secondDate), true);
 
             _firstDate = null;
             _secondDate = null;

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.Extensions;
 using MudBlazor.Utilities;
-using static System.String;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -39,11 +39,13 @@ namespace MudBlazor
         {
             if (_dateRange != range)
             {
-                if (range?.Start != null && range?.End != null && Enumerable
+                var doesRangeContainDisabledDates = range?.Start != null && range?.End != null && Enumerable
                     .Range(0, int.MaxValue)
                     .Select(index => range.Start.Value.AddDays(index))
                     .TakeWhile(date => date <= range.End.Value)
-                    .Any(date => IsDateDisabledFunc(date.Date)))
+                    .Any(date => IsDateDisabledFunc(date.Date));
+
+                if (doesRangeContainDisabledDates)
                 {
                     _rangeText = null;
                     await SetTextAsync(null, false);
@@ -260,8 +262,9 @@ namespace MudBlazor
             if (ReadOnly)
                 return;
             if (_firstDate == null || _secondDate == null)
+                return;
 
-                await SetDateRangeAsync(new DateRange(_firstDate, _secondDate), true);
+            await SetDateRangeAsync(new DateRange(_firstDate, _secondDate), true);
 
             _firstDate = null;
             _secondDate = null;

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -40,7 +40,7 @@ namespace MudBlazor
         {
             if (_dateRange != range)
             {
-                if (null != range.Start && null != range.End && Enumerable
+                if (null != range && null != range.Start && null != range.End && Enumerable
                     .Range(0, int.MaxValue)
                     .Select(index => range.Start.Value.AddDays(index))
                     .TakeWhile(date => date <= range.End.Value)
@@ -140,7 +140,7 @@ namespace MudBlazor
 
         protected override bool HasValue(DateTime? value)
         {
-            return _dateRange != null;
+            return null != value && value.HasValue;
         }
 
         private DateRange ParseDateRangeValue(string value)


### PR DESCRIPTION
- Fixes #1979;
- Added default constructor: `new DateRange()` because it's just weird to call `new DateRange(null, null)`;
- Corrected some suspicious code in `MudDateRangePicker.HasValue()`;
- Added unit tests; 😄 