### PR TITLE
Carousel: Allow to add and remove items (#1922)

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Carousel/Examples/CarouselBindingExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Carousel/Examples/CarouselBindingExample.razor
@@ -24,7 +24,6 @@
 
     private async Task AddAsync()
     {
-        // A photo is added
         _source.Add($"Item {_source.Count + 1}");
         await Task.Delay(1);
         _carousel.MoveTo(_source.Count - 1);

--- a/src/MudBlazor.Docs/Pages/Components/Carousel/Examples/CarouselBindingExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Carousel/Examples/CarouselBindingExample.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudCarousel ItemsSource="@source" Style="height:200px;" ShowArrows="@arrows" ShowDelimiters="@delimiters" AutoCycle="@autocycle">
+<MudCarousel @ref="_carousel" ItemsSource="@source" Style="height:200px;" ShowArrows="@arrows" ShowDelimiters="@delimiters" AutoCycle="@autocycle">
     <ItemTemplate>
         <div class="d-flex flex-column flex-column justify-center" style="height:100%">
             <MudIcon Class="mx-auto" Icon="@Icons.Custom.Brands.MudBlazor" Size="@Size.Large" />
@@ -11,12 +11,30 @@
 <MudSwitch @bind-Checked="@arrows" Color="Color.Primary">Show Arrows</MudSwitch>
 <MudSwitch @bind-Checked="@delimiters" Color="Color.Primary">Show Delimiters</MudSwitch>
 <MudSwitch @bind-Checked="@autocycle" Color="Color.Primary">Auto Cycle (Default: 5 secs)</MudSwitch>
+<br />
+<MudButton Class="ma-2" Variant="Variant.Filled" Color="Color.Primary" OnClick="AddAsync">Add</MudButton>
+<MudButton Class="ma-2" Variant="Variant.Filled" Color="Color.Error" OnClick="@(async () => await DeleteAsync(_carousel.SelectedIndex))">Delete</MudButton>
 
-@code{
-
+@code {
+    private MudCarousel<string> _carousel;
     private bool arrows = true;
     private bool delimiters = true;
     private bool autocycle = true;
     private IList<string> source = new List<string>() { "Item One", "Item Two", "Item Three", "Item Four", "Item Five" };
+
+    private async Task AddAsync()
+    {
+        // A photo is added
+        source.Add($"Item {source.Count + 1}");
+        await Task.Delay(1);
+    }
+
+    private async Task DeleteAsync(int index)
+    {
+        if (source.Any())
+            source.RemoveAt(index);
+
+        await Task.Delay(1);
+    }
 
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Carousel/CarouselBindingTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Carousel/CarouselBindingTest.razor
@@ -1,4 +1,4 @@
-﻿@namespace MudBlazor.Docs.Examples
+﻿@namespace MudBlazor.UnitTests.TestComponents
 
 <MudCarousel @ref="_carousel" ItemsSource="@_source" Style="height:200px;" ShowArrows="@_arrows" ShowDelimiters="@_delimiters" AutoCycle="@_autocycle">
     <ItemTemplate>
@@ -8,21 +8,15 @@
         </div>
     </ItemTemplate>
 </MudCarousel>
-<MudSwitch @bind-Checked="@_arrows" Color="Color.Primary">Show Arrows</MudSwitch>
-<MudSwitch @bind-Checked="@_delimiters" Color="Color.Primary">Show Delimiters</MudSwitch>
-<MudSwitch @bind-Checked="@_autocycle" Color="Color.Primary">Auto Cycle (Default: 5 secs)</MudSwitch>
-<br />
-<MudButton Class="ma-2" Variant="Variant.Filled" Color="Color.Primary" OnClick="AddAsync">Add</MudButton>
-<MudButton Class="ma-2" Variant="Variant.Filled" Color="Color.Error" OnClick="@(async () => await DeleteAsync(_carousel.SelectedIndex))">Delete</MudButton>
 
 @code {
     private MudCarousel<string> _carousel;
     private bool _arrows = true;
     private bool _delimiters = true;
-    private bool _autocycle = true;
+    private bool _autocycle = false;
     private IList<string> _source = new List<string>() { "Item 1", "Item 2", "Item 3", "Item 4", "Item 5" };
 
-    private async Task AddAsync()
+    public async Task AddAsync()
     {
         // A photo is added
         _source.Add($"Item {_source.Count + 1}");
@@ -30,7 +24,7 @@
         _carousel.MoveTo(_source.Count - 1);
     }
 
-    private async Task DeleteAsync(int index)
+    public async Task DeleteAsync(int index)
     {
         if (_source.Any())
         {

--- a/src/MudBlazor.UnitTests/Components/CarouselTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CarouselTests.cs
@@ -1,6 +1,8 @@
 ﻿#pragma warning disable BL0005 // Set parameter outside component
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
@@ -227,6 +229,39 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.SelectedContainer.Should().Be(comp.Instance.Items[0]);
         }
 
+        /// <summary>
+        /// Testing DataBinding with Add and Remove from data source (MVVM, MVC and another patterns)
+        /// </summary>
+        /// <returns></returns>
+        [Test]
+        public async Task CarouselTest_DataBinding()
+        {
+            var comp = ctx.RenderComponent<CarouselBindingTest>();
+            // print the generated html
+            Console.WriteLine(comp.Markup);
+            //// select elements needed for the test
+            var carousel = comp.FindComponent<MudCarousel<string>>().Instance;
+            //// validating some renders
+            carousel.Should().NotBeNull();
+            carousel.MoveTo(0);
+            //// working with ItemsSource
+            var source = carousel.ItemsSource;
+            source.Count().Should().Be(5);
+            carousel.Items.Count.Should().Be(5);
+            carousel.SelectedIndex.Should().Be(0);
+            //// adding item
+            ((IList<string>)source).Add("Item added by hand");
+            source.Count().Should().Be(6);
+            carousel.Items.Count.Should().Be(5); // should call StateHasChanged() or Task.Delay(1)
+            await Task.Delay(1);
+            carousel.Items.Count.Should().Be(6);
+            //// removing item
+            ((IList<string>)source).RemoveAt(source.Count() - 1);
+            source.Count().Should().Be(5);
+            carousel.Items.Count.Should().Be(6); // should call StateHasChanged()
+            comp.Render();
+            carousel.Items.Count.Should().Be(5);
+        }
 
     }
 }

--- a/src/MudBlazor.UnitTests/Components/CarouselTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CarouselTests.cs
@@ -234,7 +234,7 @@ namespace MudBlazor.UnitTests.Components
         /// </summary>
         /// <returns></returns>
         [Test]
-        public async Task CarouselTest_DataBinding()
+        public void CarouselTest_DataBinding()
         {
             var comp = ctx.RenderComponent<CarouselBindingTest>();
             // print the generated html
@@ -253,12 +253,12 @@ namespace MudBlazor.UnitTests.Components
             ((IList<string>)source).Add("Item added by hand");
             source.Count().Should().Be(6);
             carousel.Items.Count.Should().Be(5); // should call StateHasChanged() or Task.Delay(1)
-            await Task.Delay(1);
+            comp.Render();
             carousel.Items.Count.Should().Be(6);
             //// removing item
             ((IList<string>)source).RemoveAt(source.Count() - 1);
             source.Count().Should().Be(5);
-            carousel.Items.Count.Should().Be(6); // should call StateHasChanged()
+            carousel.Items.Count.Should().Be(6); // should call StateHasChanged() or Task.Delay(1)
             comp.Render();
             carousel.Items.Count.Should().Be(5);
         }

--- a/src/MudBlazor/Base/MudBaseItemsControl.cs
+++ b/src/MudBlazor/Base/MudBaseItemsControl.cs
@@ -57,7 +57,7 @@ namespace MudBlazor
         /// </summary>
         public TChildComponent SelectedContainer
         {
-            get => SelectedIndex >= 0 ? Items[SelectedIndex] : null;
+            get => SelectedIndex >= 0 && Items.Count > SelectedIndex ? Items[SelectedIndex] : null;
         }
 
         protected override Task OnAfterRenderAsync(bool firstRender)
@@ -136,7 +136,7 @@ namespace MudBlazor
             get => ItemsSource == null ? Items[SelectedIndex] : ItemsSource.ElementAtOrDefault(SelectedIndex);
         }
 
-        internal IEnumerable<TData> RefreshItemsSource()
+        internal IEnumerable<TData> RefreshedItemsSource()
         {
             return ItemsSource;
         }

--- a/src/MudBlazor/Base/MudBaseItemsControl.cs
+++ b/src/MudBlazor/Base/MudBaseItemsControl.cs
@@ -136,5 +136,10 @@ namespace MudBlazor
             get => ItemsSource == null ? Items[SelectedIndex] : ItemsSource.ElementAtOrDefault(SelectedIndex);
         }
 
+        internal IEnumerable<TData> RefreshItemsSource()
+        {
+            return ItemsSource;
+        }
+
     }
 }

--- a/src/MudBlazor/Base/MudBaseItemsControl.cs
+++ b/src/MudBlazor/Base/MudBaseItemsControl.cs
@@ -136,10 +136,5 @@ namespace MudBlazor
             get => ItemsSource == null ? Items[SelectedIndex] : ItemsSource.ElementAtOrDefault(SelectedIndex);
         }
 
-        internal IEnumerable<TData> RefreshedItemsSource()
-        {
-            return ItemsSource;
-        }
-
     }
 }

--- a/src/MudBlazor/Components/Carousel/MudCarouselItem.razor.cs
+++ b/src/MudBlazor/Components/Carousel/MudCarouselItem.razor.cs
@@ -1,36 +1,38 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
+using MudBlazor;
 using MudBlazor.Extensions;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
 {
-    public partial class MudCarouselItem : MudComponentBase
+    public partial class MudCarouselItem : MudComponentBase, IDisposable
     {
         protected string Classname =>
                     new CssBuilder("mud-carousel-item")
                          .AddClass($"mud-carousel-item-{Color.ToDescriptionString()}")
-                         .AddClass("mud-carousel-item-exit", Parent.LastContainer == this)
+                         .AddClass("mud-carousel-item-exit", !_disposed && Parent.LastContainer == this)
 
-                         .AddClass("mud-carousel-transition-fade-in", Transition == Transition.Fade && Parent.SelectedContainer == this)
-                         .AddClass("mud-carousel-transition-fade-out", Transition == Transition.Fade && Parent.LastContainer == this)
+                         .AddClass("mud-carousel-transition-fade-in", !_disposed && Transition == Transition.Fade && Parent.SelectedContainer == this)
+                         .AddClass("mud-carousel-transition-fade-out", !_disposed && Transition == Transition.Fade && Parent.LastContainer == this)
 
-                         .AddClass("mud-carousel-transition-slide-next-enter", Transition == Transition.Slide && RightToLeft == false && Parent.SelectedContainer == this && Parent._moveNext)
-                         .AddClass("mud-carousel-transition-slide-next-exit", Transition == Transition.Slide && RightToLeft == false && Parent.LastContainer == this && Parent._moveNext)
+                         .AddClass("mud-carousel-transition-slide-next-enter", !_disposed && Transition == Transition.Slide && RightToLeft == false && Parent.SelectedContainer == this && Parent._moveNext)
+                         .AddClass("mud-carousel-transition-slide-next-exit", !_disposed && Transition == Transition.Slide && RightToLeft == false && Parent.LastContainer == this && Parent._moveNext)
 
-                         .AddClass("mud-carousel-transition-slide-prev-enter", Transition == Transition.Slide && RightToLeft == false && Parent.SelectedContainer == this && !Parent._moveNext)
-                         .AddClass("mud-carousel-transition-slide-prev-exit", Transition == Transition.Slide && RightToLeft == false && Parent.LastContainer == this && !Parent._moveNext)
+                         .AddClass("mud-carousel-transition-slide-prev-enter", !_disposed && Transition == Transition.Slide && RightToLeft == false && Parent.SelectedContainer == this && !Parent._moveNext)
+                         .AddClass("mud-carousel-transition-slide-prev-exit", !_disposed && Transition == Transition.Slide && RightToLeft == false && Parent.LastContainer == this && !Parent._moveNext)
 
-                         .AddClass("mud-carousel-transition-slide-next-rtl-enter", Transition == Transition.Slide && RightToLeft == true && Parent.SelectedContainer == this && Parent._moveNext)
-                         .AddClass("mud-carousel-transition-slide-next-rtl-exit", Transition == Transition.Slide && RightToLeft == true && Parent.LastContainer == this && Parent._moveNext)
+                         .AddClass("mud-carousel-transition-slide-next-rtl-enter", !_disposed && Transition == Transition.Slide && RightToLeft == true && Parent.SelectedContainer == this && Parent._moveNext)
+                         .AddClass("mud-carousel-transition-slide-next-rtl-exit", !_disposed && Transition == Transition.Slide && RightToLeft == true && Parent.LastContainer == this && Parent._moveNext)
 
-                         .AddClass("mud-carousel-transition-slide-prev-rtl-enter", Transition == Transition.Slide && RightToLeft == true && Parent.SelectedContainer == this && !Parent._moveNext)
-                         .AddClass("mud-carousel-transition-slide-prev-rtl-exit", Transition == Transition.Slide && RightToLeft == true && Parent.LastContainer == this && !Parent._moveNext)
+                         .AddClass("mud-carousel-transition-slide-prev-rtl-enter", !_disposed && Transition == Transition.Slide && RightToLeft == true && Parent.SelectedContainer == this && !Parent._moveNext)
+                         .AddClass("mud-carousel-transition-slide-prev-rtl-exit", !_disposed && Transition == Transition.Slide && RightToLeft == true && Parent.LastContainer == this && !Parent._moveNext)
 
-                         .AddClass("mud-carousel-transition-none", Transition == Transition.None && Parent.SelectedContainer != this)
+                         .AddClass("mud-carousel-transition-none", !_disposed && Transition == Transition.None && Parent.SelectedContainer != this)
 
-                         .AddClass(CustomTransitionEnter, Transition == Transition.Custom && Parent.SelectedContainer == this && Parent.SelectedContainer == this)
-                         .AddClass(CustomTransitionExit, Transition == Transition.Custom && Parent.LastContainer == this && Parent.LastContainer == this)
+                         .AddClass(CustomTransitionEnter, !_disposed && Transition == Transition.Custom && Parent.SelectedContainer == this && Parent.SelectedContainer == this)
+                         .AddClass(CustomTransitionExit, !_disposed && Transition == Transition.Custom && Parent.LastContainer == this && Parent.LastContainer == this)
 
                          .AddClass(Class)
                          .Build();
@@ -63,14 +65,21 @@ namespace MudBlazor
         [Parameter] public string CustomTransitionExit { get; set; }
 
 
-        public bool IsVisible => Parent == null ? false : Parent.LastContainer == this || Parent.SelectedIndex == Parent.Items.IndexOf(this);
+        public bool IsVisible => Parent != null && (Parent.LastContainer == this || Parent.SelectedIndex == Parent.Items.IndexOf(this));
 
 
         protected override async Task OnInitializedAsync()
         {
             await Task.CompletedTask;
-
             Parent?.Items.Add(this);
         }
+
+        private bool _disposed = false;
+        public void Dispose()
+        {
+            _disposed = true;
+            Parent?.Items.Remove(this);
+        }
+
     }
 }


### PR DESCRIPTION
This is a Fix for #1922  

- Implemented IDisposable for MudCarouselItem, that fixes DataBinding ItemsSource parameter with phsycal Items from MudBaseItemsControl;
 - Updated Carousel DataBinding example with Add and Delete actions;
 - Added some tests.