### PR TITLE
MudTooltip: added start/end options for Placement (RTL)

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Tooltip/Examples/TooltipPostionExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tooltip/Examples/TooltipPostionExample.razor
@@ -1,8 +1,11 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 
-<MudTooltip Text="Start/Left" Placement="Placement.Start">
-    <MudButton>Start/Left</MudButton>
+<MudTooltip Text="Start" Placement="Placement.Start">
+    <MudButton>Start</MudButton>
+</MudTooltip>
+<MudTooltip Text="Left" Placement="Placement.Left">
+    <MudButton>Left</MudButton>
 </MudTooltip>
 <MudTooltip Text="Top" Placement="Placement.Top">
     <MudButton>Top</MudButton>
@@ -10,6 +13,9 @@
 <MudTooltip Text="Bottom" Placement="Placement.Bottom">
     <MudButton>Bottom</MudButton>
 </MudTooltip>
-<MudTooltip Text="End/Right" Placement="Placement.End">
-    <MudButton>End/Right</MudButton>
+<MudTooltip Text="Right" Placement="Placement.Right">
+    <MudButton>Right</MudButton>
+</MudTooltip>
+<MudTooltip Text="End" Placement="Placement.End">
+    <MudButton>End</MudButton>
 </MudTooltip>

--- a/src/MudBlazor/Components/Tooltip/MudTooltip.razor.cs
+++ b/src/MudBlazor/Components/Tooltip/MudTooltip.razor.cs
@@ -12,10 +12,14 @@ namespace MudBlazor
             .AddClass("mud-tooltip-inline", Inline)
             .Build();
         protected string Classname => new CssBuilder("mud-tooltip")
-            .AddClass($"mud-tooltip-placement-{Placement.ToDescriptionString()}")
+            .AddClass($"mud-tooltip-placement-{ConvertPlacement(Placement).ToDescriptionString()}")
             .AddClass(Class)
             .Build();
 
+        
+        [CascadingParameter]
+        public bool RightToLeft { get; set; }
+        
         /// <summary>
         /// Sets the text to be displayed inside the tooltip.
         /// </summary>
@@ -41,6 +45,16 @@ namespace MudBlazor
         /// Tooltip placement.
         /// </summary>
         [Parameter] public Placement Placement { get; set; } = Placement.Bottom;
+
+        private Placement ConvertPlacement(Placement placement)
+        {
+            return placement switch
+            {
+                Placement.Start => RightToLeft ? Placement.Right : Placement.Left,
+                Placement.End => RightToLeft ? Placement.Left : Placement.Right,
+                _ => placement
+            };
+        }
 
         /// <summary>
         /// Child content of component.

--- a/src/MudBlazor/Enums/Placement.cs
+++ b/src/MudBlazor/Enums/Placement.cs
@@ -4,6 +4,10 @@ namespace MudBlazor
 {
     public enum Placement
     {
+        [Description("left")]
+        Left,
+        [Description("right")]
+        Right,
         [Description("end")]
         End,
         [Description("start")]

--- a/src/MudBlazor/Styles/components/_tooltip.scss
+++ b/src/MudBlazor/Styles/components/_tooltip.scss
@@ -34,13 +34,13 @@
             transform: translate(-50%, calc(100% + 10px));
         }
 
-        &.mud-tooltip-placement-start {
+        &.mud-tooltip-placement-left {
             top: 0;
             left: 0;
             transform: translateX(calc(-100% - 10px));
         }
 
-        &.mud-tooltip-placement-end {
+        &.mud-tooltip-placement-right {
             top: 0;
             right: 0;
             transform: translateX(calc(100% + 10px));


### PR DESCRIPTION
Fixes `MudTooltip: Left/Right options for Placement + End should not be right in RTL, same with Start` in https://github.com/Garderoben/MudBlazor/issues/92#issuecomment-866619540

![tooltip](https://user-images.githubusercontent.com/62108893/123934530-ab29df00-d993-11eb-895b-6327445a3075.gif)
