### PR TITLE
Tabs: Restructure property 'InternalClassName' and add a unit test

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/CustomDynamicTabsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/CustomDynamicTabsExample.razor
@@ -8,12 +8,14 @@
 		}
 	</ChildContent>
 	<Header>
-		<MudTooltip Text="Prepend a tab">
-			<MudIconButton Icon="@Icons.Material.Filled.ChevronLeft" OnClick="@( () => AddTabCallback(false) )" />
-		</MudTooltip>
-		<MudTooltip Text="Append a tab">
-			<MudIconButton Icon="@Icons.Material.Filled.ChevronRight" OnClick="@( () => AddTabCallback(true) )"  />
-		</MudTooltip>
+		<MudButtonGroup>
+			<MudTooltip Text="Prepend a tab">
+				<MudIconButton Icon="@Icons.Material.Filled.ChevronLeft" OnClick="@( () => AddTabCallback(false) )" />
+			</MudTooltip>
+			<MudTooltip Text="Append a tab">
+				<MudIconButton Icon="@Icons.Material.Filled.ChevronRight" OnClick="@( () => AddTabCallback(true) )"  />
+			</MudTooltip>
+		</MudButtonGroup>
 	</Header>
 	<TabPanelHeader>
 		@if(context.Text.StartsWith("Tab") == false)

--- a/src/MudBlazor.UnitTests/Components/DynamicTabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DynamicTabsTests.cs
@@ -60,6 +60,11 @@ namespace MudBlazor.UnitTests.Components
             tabs.CloseIconClass.Should().BeNullOrEmpty();
             tabs.CloseIconStyle.Should().BeNullOrEmpty();
             tabs.CloseIconToolTip.Should().BeNullOrEmpty();
+
+            comp.Nodes.Should().ContainSingle();
+            comp.Nodes[0].Should().BeAssignableTo<IHtmlDivElement>();
+
+            (comp.Nodes[0] as IHtmlDivElement).ClassList.Should().BeEquivalentTo(new[] { "mud-tabs", "mud-dynamic-tabs" });
         }
 
         [Test]

--- a/src/MudBlazor/Components/Tabs/MudDynamicTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudDynamicTabs.razor.cs
@@ -59,6 +59,6 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public string CloseIconToolTip { get; set; } = string.Empty;
 
-        protected override string InternalClassName { get; set; } = "mud-dynamic-tabs";
+        protected override string InternalClassName { get; } = "mud-dynamic-tabs";
     }
 }

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -195,7 +195,10 @@ namespace MudBlazor
         [Parameter]
         public TabHeaderPosition TabPanelHeaderPosition { get; set; } = TabHeaderPosition.After;
 
-        protected virtual String InternalClassName { get; set; } = String.Empty;
+        /// <summary>
+        /// Can be used in derivate class to add a class to the main container. If not overwritten return an empty string
+        /// </summary>
+        protected virtual string InternalClassName { get; } = string.Empty;
 
         private string _prevIcon;
 


### PR DESCRIPTION
After the design work @Garderoben a unit test is added to check if class names are applied as intended, besides the ```InternalClassName``` has now only a getter and a description. Just a tiny improvement 