### PR TITLE
MudText: add start/end options for Align (RTL)

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Typography/Examples/TextAlignmentExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Typography/Examples/TextAlignmentExample.razor
@@ -1,7 +1,9 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudText Align="Align.Left"><b>Left</b> Lorem ipsum dolor sit amet.</MudText>
+<MudText Align="Align.Start"><b>Start</b> Lorem ipsum dolor sit amet.</MudText>
 <MudText Align="Align.Right"><b>Right</b> Lorem ipsum dolor sit amet.</MudText>
+<MudText Align="Align.End"><b>End</b> Lorem ipsum dolor sit amet.</MudText>
 <MudText Align="Align.Center"><b>Center</b> Lorem ipsum dolor sit amet.</MudText>
 <MudText Align="Align.Justify"><b>Justify</b> Lorem ipsum dolor sit amet.</MudText>
 <MudText Align="Align.Inherit"><b>Inherit</b> Lorem ipsum dolor sit amet.</MudText>

--- a/src/MudBlazor/Components/Typography/MudText.razor.cs
+++ b/src/MudBlazor/Components/Typography/MudText.razor.cs
@@ -11,11 +11,23 @@ namespace MudBlazor
           .AddClass($"mud-typography-{Typo.ToDescriptionString()}")
           .AddClass($"mud-{Color.ToDescriptionString()}-text")
           .AddClass("mud-typography-gutterbottom", GutterBottom)
-          .AddClass($"mud-typography-align-{Align.ToDescriptionString()}", Align != Align.Inherit)
+          .AddClass($"mud-typography-align-{ConvertAlign(Align).ToDescriptionString()}", Align != Align.Inherit)
           .AddClass("mud-typography-display-inline", Inline)
           .AddClass(Class)
         .Build();
 
+        private Align ConvertAlign(Align align)
+        {
+            return align switch
+            {
+                Align.Start => RightToLeft ? Align.Right : Align.Left,
+                Align.End => RightToLeft ? Align.Left : Align.Right,
+                _ => align
+            };
+        }
+
+        [CascadingParameter] public bool RightToLeft { get; set; }
+        
         /// <summary>
         /// Applies the theme typography styles.
         /// </summary>

--- a/src/MudBlazor/Enums/Align.cs
+++ b/src/MudBlazor/Enums/Align.cs
@@ -13,6 +13,10 @@ namespace MudBlazor
         [Description("right")]
         Right,
         [Description("justify")]
-        Justify
+        Justify,
+        [Description("start")]
+        Start,
+        [Description("end")]
+        End,
     }
 }


### PR DESCRIPTION
Closes `MudText: Start/End options for Align` in https://github.com/Garderoben/MudBlazor/issues/92#issuecomment-866619540

LTR:
![grafik](https://user-images.githubusercontent.com/62108893/124245519-58c9f900-db20-11eb-8827-aeb213972371.png)

RTL:
![grafik](https://user-images.githubusercontent.com/62108893/124245555-60899d80-db20-11eb-8419-0c7eea9f5c55.png)
