### PR TITLE
Snackbar: Improve fade effect with stopwatch

### DIFF
--- a/src/MudBlazor/Components/Snackbar/SnackBarMessageState.cs
+++ b/src/MudBlazor/Components/Snackbar/SnackBarMessageState.cs
@@ -2,6 +2,7 @@
 //Changes and improvements Copyright (c) The MudBlazor Team.
 
 using System;
+using System.Diagnostics;
 using static System.String;
 
 namespace MudBlazor
@@ -12,7 +13,7 @@ namespace MudBlazor
         public bool UserHasInteracted { get; set; }
         public SnackbarOptions Options { get; }
         public SnackbarState SnackbarState { get; set; }
-        public DateTime TransitionStartTime { get; set; }
+        public Stopwatch Stopwatch { get; } = new Stopwatch();
 
         public SnackBarMessageState(SnackbarOptions options)
         {
@@ -93,7 +94,8 @@ namespace MudBlazor
 
         private int RemainingTransitionMilliseconds(int transitionDuration)
         {
-            var duration = transitionDuration - (TransitionStartTime - DateTime.Now).Milliseconds;
+            var duration = transitionDuration - (int) Stopwatch.ElapsedMilliseconds;
+
             return duration >= 0 ? duration : 0;
         }
     }

--- a/src/MudBlazor/Components/Snackbar/Snackbar.cs
+++ b/src/MudBlazor/Components/Snackbar/Snackbar.cs
@@ -83,12 +83,13 @@ namespace MudBlazor
 
         private void StartTimer(int duration)
         {
-            State.TransitionStartTime = DateTime.Now;
+            State.Stopwatch.Restart();
             Timer?.Change(duration, Timeout.Infinite);
         }
 
         private void StopTimer()
         {
+            State.Stopwatch.Stop();
             Timer?.Change(Timeout.Infinite, Timeout.Infinite);
         }
 


### PR DESCRIPTION
This PR improves the fade effect by replacing the `DateTime` with a `Stopwatch` which measures more accurately.
For one `MudSnackbar` it really does not matter as both return `500 ms.`

`Stopwatch`'s addition is when multiple `MudSnackbars` are being faded.

Some numbers for the "Open Filled Variants" screenshot, fade in, fade out respectively:
DateTime/Stopwatch : 500|500 ms.
DateTime/Stopwatch : 503|497 ms.
DateTime/Stopwatch : 505|495 ms.
DateTime/Stopwatch : 507|493 ms.
DateTime/Stopwatch : 508|492 ms.

DateTime/Stopwatch : 500|500 ms.
DateTime/Stopwatch : 509|491 ms. 
DateTime/Stopwatch : 516|484 ms.
DateTime/Stopwatch : 519|481 ms.
DateTime/Stopwatch : 523|477 ms.

Notice the maintained component order which improves the fading.


Before
![flik](https://user-images.githubusercontent.com/10358198/124366485-c4ef4e80-dc3f-11eb-8aa5-199c1f852e89.gif)

After
![F2](https://user-images.githubusercontent.com/10358198/124366552-27484f00-dc40-11eb-8535-27ddbc181a9c.gif)

Before
![S1](https://user-images.githubusercontent.com/10358198/124366579-52cb3980-dc40-11eb-9df2-2bde352cdc7e.gif)

After
![S2](https://user-images.githubusercontent.com/10358198/124366582-5494fd00-dc40-11eb-80e7-57a2d0723fea.gif)
