### PR TITLE
MudMenu, MudPopover: add start/end options for Direction (#92)

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuDirectionExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuDirectionExample.razor
@@ -1,6 +1,12 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 
+<MudMenu Label="Direction Start" Variant="Variant.Filled" Color="Color.Default" Direction="Direction.Start">
+    <MudMenuItem>Enlist</MudMenuItem>
+    <MudMenuItem>Barracks</MudMenuItem>
+    <MudMenuItem>Armory</MudMenuItem>
+</MudMenu>
+
 <MudMenu Label="Direction Left" Variant="Variant.Filled" Color="Color.Info" Direction="Direction.Left">
     <MudMenuItem>Enlist</MudMenuItem>
     <MudMenuItem>Barracks</MudMenuItem>
@@ -20,6 +26,12 @@
 </MudMenu>
 
 <MudMenu Label="Direction Right" Variant="Variant.Filled" Color="Color.Error" Direction="Direction.Right">
+    <MudMenuItem>Enlist</MudMenuItem>
+    <MudMenuItem>Barracks</MudMenuItem>
+    <MudMenuItem>Armory</MudMenuItem>
+</MudMenu>
+
+<MudMenu Label="Direction End" Variant="Variant.Filled" Color="Color.Primary" Direction="Direction.End">
     <MudMenuItem>Enlist</MudMenuItem>
     <MudMenuItem>Barracks</MudMenuItem>
     <MudMenuItem>Armory</MudMenuItem>

--- a/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuOffsetExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuOffsetExample.razor
@@ -1,5 +1,11 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
+<MudMenu Label="Offset Start" Variant="Variant.Filled" Color="Color.Info" Direction="Direction.Start" OffsetX="true">
+    <MudMenuItem>Enlist</MudMenuItem>
+    <MudMenuItem>Barracks</MudMenuItem>
+    <MudMenuItem>Armory</MudMenuItem>
+</MudMenu>
+
 <MudMenu Label="Offset Left" Variant="Variant.Filled" Color="Color.Default" Direction="Direction.Left" OffsetX="true">
     <MudMenuItem>Enlist</MudMenuItem>
     <MudMenuItem>Barracks</MudMenuItem>
@@ -24,3 +30,8 @@
     <MudMenuItem>Armory</MudMenuItem>
 </MudMenu>
 
+<MudMenu Label="Offset End" Variant="Variant.Filled" Color="Color.Warning" Direction="Direction.End" OffsetX="true">
+    <MudMenuItem>Enlist</MudMenuItem>
+    <MudMenuItem>Barracks</MudMenuItem>
+    <MudMenuItem>Armory</MudMenuItem>
+</MudMenu>

--- a/src/MudBlazor.Docs/Pages/Components/Popover/Examples/PopoverLocationExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Popover/Examples/PopoverLocationExample.razor
@@ -4,6 +4,8 @@
     <MudItem xs="12" md="2">
         <MudSwitch @bind-Checked="@OffsetX" Label="Offset X" Color="Color.Primary" />
         <MudRadioGroup @bind-SelectedOption="@Direction">
+            <MudRadio Color="Color.Primary" Option="@(Direction.Start)" Disabled="!OffsetX">Start</MudRadio>
+            <MudRadio Color="Color.Primary" Option="@(Direction.End)" Disabled="!OffsetX">End</MudRadio>
             <MudRadio Color="Color.Primary" Option="@(Direction.Left)" Disabled="!OffsetX">Left</MudRadio>
             <MudRadio Color="Color.Primary" Option="@(Direction.Right)" Disabled="!OffsetX">Right</MudRadio>
         </MudRadioGroup>

--- a/src/MudBlazor/Components/Popover/MudPopover.razor.cs
+++ b/src/MudBlazor/Components/Popover/MudPopover.razor.cs
@@ -10,7 +10,7 @@ namespace MudBlazor
         protected string PopoverClass =>
            new CssBuilder("mud-popover")
             .AddClass("mud-popover-open", Open)
-            .AddClass($"mud-popover-{Direction.ToDescriptionString()}")
+            .AddClass($"mud-popover-{ConvertDirection(Direction).ToDescriptionString()}")
             .AddClass("mud-popover-offset-y", OffsetY)
             .AddClass("mud-popover-offset-x", OffsetX)
             .AddClass("mud-paper")
@@ -25,6 +25,18 @@ namespace MudBlazor
             .AddStyle(Style)
             .Build();
 
+        private Direction ConvertDirection(Direction direction)
+        {
+            return direction switch
+            {
+                Direction.Start => RightToLeft ? Direction.Right : Direction.Left,
+                Direction.End => RightToLeft ? Direction.Left : Direction.Right,
+                _ => direction
+            };
+        }
+        
+        [CascadingParameter] public  bool RightToLeft { get; set; }
+        
         /// <summary>
         /// The higher the number, the heavier the drop-shadow. 0 for no shadow set to 8 by default.
         /// </summary>

--- a/src/MudBlazor/Enums/Direction.cs
+++ b/src/MudBlazor/Enums/Direction.cs
@@ -11,6 +11,10 @@ namespace MudBlazor
         [Description("left")]
         Left,
         [Description("right")]
-        Right
+        Right,
+        [Description("start")]
+        Start,
+        [Description("end")]
+        End
     }
 }


### PR DESCRIPTION
Closes `MudMenu: Start/End options for Direction` in https://github.com/Garderoben/MudBlazor/issues/92#issuecomment-866619540
Closes `MudMenu: Start/End options for Offset` in https://github.com/Garderoben/MudBlazor/issues/92#issuecomment-866619540
Closes `MudPopover: Start/End options for Direction` in https://github.com/Garderoben/MudBlazor/issues/92#issuecomment-866619540

![menudocs](https://user-images.githubusercontent.com/62108893/124444768-3b469a80-dd7f-11eb-8c73-fbd5a2180788.gif)
