### PR TITLE
Table: add IQueryable variation for table orderBy extension

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableServerSideDataTest4b.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableServerSideDataTest4b.razor
@@ -1,0 +1,52 @@
+@namespace MudBlazor.UnitTests.TestComponents
+
+<MudTable ServerData="@(new Func<TableState, Task<TableData<TestModel>>>(ServerReload))" SortLabel="Sort by">
+    <HeaderContent>
+        <MudTh><MudTableSortLabel SortLabel="a" T="TestModel">a</MudTableSortLabel></MudTh>
+        <MudTh><MudTableSortLabel SortLabel="b" T="TestModel">b</MudTableSortLabel></MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd DataLabel="a">@context.a</MudTd>
+        <MudTd DataLabel="b">@context.b</MudTd>
+    </RowTemplate>
+    <PagerContent>
+        <MudTablePager />
+    </PagerContent>
+</MudTable>
+
+@code {
+#pragma warning disable CS1998 // async without await
+    public static string __description__ = "The server-side loaded table should reload data on mobile sort.";
+
+    public class TestModel
+    {
+        public int a { get; set; }
+        public int b { get; set; }
+    }
+    private int totalItems;
+
+    /// <summary>
+    /// Here we simulate getting the paged, filtered and ordered data from the server
+    /// </summary>
+    private async Task<TableData<TestModel>> ServerReload(TableState state)
+    {
+        // This creates an in-memory IQueryable variation of our IEnumerable test
+        IQueryable<TestModel> data = new List<TestModel>() { new TestModel() { a=1, b=3 },
+                                            new TestModel() { a=2, b=2 },
+                                            new TestModel() { a=3, b=1 } }.AsQueryable();
+        totalItems = 3;
+        switch (state.SortLabel)
+        {
+            case "a":
+                data = data.OrderByDirection(state.SortDirection, x => x.a);
+                break;
+            case "b":
+                data = data.OrderByDirection(state.SortDirection, x => x.b);
+                break;
+            default:
+                break;
+        }
+        return new TableData<TestModel>() { TotalItems = totalItems, Items = data };
+    }
+
+}

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -738,12 +738,33 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
-        /// The server-side loaded table should reload when mobile sort if performed.
+        /// The server-side loaded table should reload when mobile sort if performed
+        /// (IEnumerable variation).
         /// </summary>
         [Test]
         public async Task TableServerSideDataTest4()
         {
             var comp = ctx.RenderComponent<TableServerSideDataTest4>();
+            Console.WriteLine(comp.Markup);
+            comp.FindAll("tr").Count.Should().Be(4); // three rows + header row
+            comp.FindAll("td")[0].TextContent.Trim().Should().Be("1");
+            comp.FindAll("td")[2].TextContent.Trim().Should().Be("2");
+            comp.FindAll("td")[4].TextContent.Trim().Should().Be("3");
+            comp.FindAll("div.mud-select-input")[0].Click(); // mobile sort drop down
+            comp.FindAll("div.mud-list-item-clickable")[1].Click(); // sort b column
+            comp.FindAll("td")[0].TextContent.Trim().Should().Be("3");
+            comp.FindAll("td")[2].TextContent.Trim().Should().Be("2");
+            comp.FindAll("td")[4].TextContent.Trim().Should().Be("1");
+        }
+
+        /// <summary>
+        /// The server-side loaded table should reload when mobile sort if performed
+        /// (IQueryable variation).
+        /// </summary>
+        [Test]
+        public async Task TableServerSideDataTest4b()
+        {
+            var comp = ctx.RenderComponent<TableServerSideDataTest4b>();
             Console.WriteLine(comp.Markup);
             comp.FindAll("tr").Count.Should().Be(4); // three rows + header row
             comp.FindAll("td")[0].TextContent.Trim().Should().Be("1");

--- a/src/MudBlazor/Extensions/TableExtensions.cs
+++ b/src/MudBlazor/Extensions/TableExtensions.cs
@@ -1,12 +1,20 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 
 namespace MudBlazor
 {
     public static class TableExtensions
     {
         public static IOrderedEnumerable<TSource> OrderByDirection<TSource, TKey>(this IEnumerable<TSource> source, SortDirection direction, Func<TSource, TKey> keySelector)
+        {
+            if (direction == SortDirection.Descending)
+                return source.OrderByDescending(keySelector);
+            return source.OrderBy(keySelector);
+        }
+
+        public static IOrderedQueryable<TSource> OrderByDirection<TSource, TKey>(this IQueryable<TSource> source, SortDirection direction, Expression<Func<TSource, TKey>> keySelector)
         {
             if (direction == SortDirection.Descending)
                 return source.OrderByDescending(keySelector);


### PR DESCRIPTION
I would like to add a unit test for this variation but that would require an IQueryable source to apply it against, and there doesn't seem to be support for that in the code base.  Any suggestions?
