### PR TITLE
Autocomplete: Remove unnecessary Task.Delay

### DIFF
--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -12,7 +12,6 @@ using System.Threading.Tasks;
 using AngleSharp.Html.Dom;
 using Bunit;
 using FluentAssertions;
-using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
@@ -54,13 +53,9 @@ namespace MudBlazor.UnitTests.Components
             // check initial state
             autocomplete.Value.Should().Be("Alabama");
             autocomplete.Text.Should().Be("Alabama");
-            await Task.Delay(100);
-
 
             // now let's type a different state to see the popup open
             autocompletecomp.Find("input").Input("Calif");
-            await Task.Delay(100);
-            
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
             Console.WriteLine(comp.Markup);
             var items = comp.FindComponents<MudListItem>().ToArray();
@@ -71,7 +66,6 @@ namespace MudBlazor.UnitTests.Components
             // check state
             autocomplete.Value.Should().Be("California");
             autocomplete.Text.Should().Be("California");
-            
         }
 
         /// <summary>
@@ -96,7 +90,6 @@ namespace MudBlazor.UnitTests.Components
 
             // type 3 characters and check if it has toggled the menu
             select.Find("input").Input("ala");
-            await Task.Delay(200);
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
 
             // type 2 characters and check if it has toggled the menu
@@ -397,7 +390,6 @@ namespace MudBlazor.UnitTests.Components
 
             // Lets type something to cause it to open
             autocompletecomp.Find("input").Input("Calif");
-            await Task.Delay(100);
             comp.WaitForAssertion(() => autocomplete.IsOpen.Should().BeTrue());
 
             // Lets call blur on the input and confirm that it closed
@@ -424,7 +416,6 @@ namespace MudBlazor.UnitTests.Components
 
             // Lets type something to cause it to open
             autocompletecomp.Find("input").Input("Calif");
-            await Task.Delay(100);
             comp.WaitForAssertion(() => autocomplete.IsOpen.Should().BeTrue());
 
             // Lets call blur on the input and confirm that it closed
@@ -459,12 +450,9 @@ namespace MudBlazor.UnitTests.Components
             // check initial state
             autocomplete.Value.Should().Be("Alabama");
             autocomplete.Text.Should().Be("Alabama");
-            await Task.Delay(100);
-
 
             // now let's type a different state to see the popup open
             autocompletecomp.Find("input").Input("Calif");
-            await Task.Delay(100);
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
             var items = comp.FindComponents<MudListItem>().ToArray();
             items.Length.Should().Be(1);
@@ -472,7 +460,6 @@ namespace MudBlazor.UnitTests.Components
 
             // now, we blur the input and assert that the popover is still open.
             autocompletecomp.Find("input").Blur();
-            await Task.Delay(100);
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
         }
     }


### PR DESCRIPTION
Task.Delay is covered by WaitForAssertion