### PR TITLE
Snackbar docs: Added a counter to the "HTML in messages" example

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Snackbar/Examples/SnackbarHtmlInMessageExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Snackbar/Examples/SnackbarHtmlInMessageExample.razor
@@ -2,6 +2,11 @@
 
 @inject ISnackbar Snackbar
 
-<MudButton Variant="Variant.Filled" Color="Color.Primary" @onclick="@(() => Snackbar.Add("<ul><li>Item 1</li><li>Item 2</li></ul>"))">
+<MudButton Variant="Variant.Filled" Color="Color.Primary" @onclick="@(() => Snackbar.Add($"<ul><li>Item {++count}</li><li>Item {++count}</li></ul>"))">
     Open Snackbar
 </MudButton>
+
+@code
+{
+    private int count = 0;
+}


### PR DESCRIPTION
Added a counter to see the order of snackbars when button is clicked multiple times.
![image](https://user-images.githubusercontent.com/10358198/124888050-44c14400-dfc5-11eb-9346-c23bcda9aecb.png)
