### PR TITLE
MudPageContentNavigation

### DIFF
--- a/src/MudBlazor.Docs/Components/DocsPage.razor
+++ b/src/MudBlazor.Docs/Components/DocsPage.razor
@@ -4,22 +4,9 @@
             @ChildContent
         </CascadingValue>
     </div>
-    @if(_sections != null)
-        {
-            <div class="docs-contents">
-                <MudDrawer Open="true" Anchor="Anchor.End" Variant="DrawerVariant.Temporary" DisableOverlay="true" ClipMode="DrawerClipMode.Always" Elevation="0" Color="Color.Transparent" Class="pt-6" Width="220px">
-                    <MudText Typo="Typo.h6" GutterBottom="true">
-                        Contents
-                    </MudText>
-                    <MudNavMenu Class="pl-4">
-                        @foreach(var section in _sections)
-                        {
-                            <MudNavLink Match="NavLinkMatch.All" Class="@GetNavLinkClass(section.Active)" @onclick="@(e => OnNavLinkClick(section.Id))">
-                                @section.Title
-                            </MudNavLink>
-                        }
-                    </MudNavMenu>
-                </MudDrawer>
-            </div>
-        }
+    <div class="docs-contents">
+        <MudDrawer Open="true" Anchor="Anchor.End" Variant="DrawerVariant.Temporary" DisableOverlay="true" ClipMode="DrawerClipMode.Always" Elevation="0" Color="Color.Transparent" Class="pt-6" Width="220px">
+            <MudPageContentNavigation SectionClassSelector="docs-section-header" @ref="_contentNavigation" />
+        </MudDrawer>
+    </div>
 </MudContainer>

--- a/src/MudBlazor.Docs/Components/DocsPage.razor.cs
+++ b/src/MudBlazor.Docs/Components/DocsPage.razor.cs
@@ -5,87 +5,48 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Routing;
 using MudBlazor.Docs.Models;
-using MudBlazor.Docs.Extensions;
-using MudBlazor.Services;
 using System.Threading.Tasks;
 using System.Linq;
-using Microsoft.JSInterop;
 
 namespace MudBlazor.Docs.Components
 {
-    public partial class DocsPage : ComponentBase, IAsyncDisposable
+    public partial class DocsPage : ComponentBase
     {
-        [Inject] IScrollSpy ScrollSpy { get; set; }
+        private Queue<DocsSectionLink> _bufferedSections = new();
+        private MudPageContentNavigation _contentNavigation;
+
         [Inject] NavigationManager NavigationManager { get; set; }
 
         [Parameter] public MaxWidth MaxWidth { get; set; } = MaxWidth.Medium;
         [Parameter] public RenderFragment ChildContent { get; set; }
 
-        private List<DocsSectionLink> _sections = new();
-
-
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
             if (firstRender)
             {
-                ScrollSpy.ScrollSectionSectionCentered += ScrollSpy_ScrollSectionSectionCentered;
-
-                await ScrollSpy.ScrollToSection(new Uri(NavigationManager.Uri));
-                await ScrollSpy.StartSpying("docs-section-header");
-                SelectActiveSection(ScrollSpy.CenteredSection);
+                await _contentNavigation.ScrollToSection(new Uri(NavigationManager.Uri));
             }
         }
 
         internal void AddSection(DocsSectionLink section)
         {
-            _sections.Add(section);
-            if (section.Id == ScrollSpy.CenteredSection)
+            _bufferedSections.Enqueue(section);
+
+            if (_contentNavigation != null)
             {
-                section.Active = true;
+                while (_bufferedSections.Count > 0)
+                {
+                    var item = _bufferedSections.Dequeue();
+
+                    if (_contentNavigation.Sections.FirstOrDefault(x => x.Id == section.Id) == default)
+                    {
+                        _contentNavigation.AddSection(item.Title, item.Id, false);
+                    }
+                }
+
+                _contentNavigation.Update();
             }
-
-            StateHasChanged();
-        }
-
-        private void SelectActiveSection(string id)
-        {
-            if (string.IsNullOrEmpty(id)) 
-              return;
-            var activelink = _sections.FirstOrDefault(x => x.Id == id);
-            if (activelink == null) 
-              return; 
-            _sections.ToList().ForEach(item => item.Active = false);
-            activelink.Active = true;
-            StateHasChanged();
-        }
-
-        private void ScrollSpy_ScrollSectionSectionCentered(object sender, ScrollSectionCenteredEventArgs e)
-        {
-            SelectActiveSection(e.Id);
-        }
-
-        private async Task OnNavLinkClick(string id)
-        {
-            _sections.ToList().ForEach(item => item.Active = false);
-            var activelink = _sections.FirstOrDefault(item => item.Id == id);
-            activelink.Active = true;
-            await ScrollSpy.ScrollToSection(id);
-        }
-
-        public async ValueTask DisposeAsync()
-        {
-            ScrollSpy.ScrollSectionSectionCentered -= ScrollSpy_ScrollSectionSectionCentered;
-            await ScrollSpy.DisposeAsync();
-        }
-
-        private string GetNavLinkClass(bool active)
-        {
-            if (active)
-                return $"docs-contents-navlink active";
-            else
-                return $"docs-contents-navlink";
         }
     }
 }

--- a/src/MudBlazor.Docs/Styles/components/_docspage.scss
+++ b/src/MudBlazor.Docs/Styles/components/_docspage.scss
@@ -19,7 +19,6 @@
 }
 
 .docs-page-content {
-
 }
 
 .docs-page-section {
@@ -81,33 +80,6 @@
 
 .docs-contents {
     display: none;
-
-    .docs-contents-navlink {
-        &.active {
-            .mud-nav-link {
-                color: var(--mud-palette-primary);
-                border-color: var(--mud-palette-primary);
-                background-color: transparent;
-            }
-        }
-
-        .mud-nav-link {
-            padding: 4px 16px 4px 16px;
-            color: var(--mud-palette-text-disabled);
-            border-left: 2px solid var(--mud-palette-action-disabled-background);
-
-            &.active {
-                color: var(--mud-palette-primary);
-                border-color: var(--mud-palette-primary);
-                background-color: transparent;
-            }
-
-            .mud-nav-link-text {
-                margin-left: 0px;
-                margin-inline-start: 0px;
-            }
-        }
-    }
 }
 
 @media only screen and (min-width: 1640px) {

--- a/src/MudBlazor.UnitTests/Components/PageContentNavigationTests.cs
+++ b/src/MudBlazor.UnitTests/Components/PageContentNavigationTests.cs
@@ -50,7 +50,8 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.Headline.Should().Be("Contents");
             comp.Instance.SectionClassSelector.Should().BeNullOrEmpty();
 
-            comp.Nodes.Should().BeEmpty();
+            comp.Nodes.Should().ContainSingle();
+            comp.Nodes[0].ChildNodes.Should().BeEmpty();
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/PageContentNavigationTests.cs
+++ b/src/MudBlazor.UnitTests/Components/PageContentNavigationTests.cs
@@ -1,0 +1,205 @@
+﻿#pragma warning disable CS1998 // async without await
+#pragma warning disable IDE1006 // leading underscore
+#pragma warning disable BL0005 // Set parameter outside component
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using AngleSharp.Html.Dom;
+using Bunit;
+using FluentAssertions;
+using FluentValidation;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using MudBlazor.UnitTests.Mocks;
+using MudBlazor.UnitTests.TestComponents;
+using NUnit.Framework;
+using static Bunit.ComponentParameterFactory;
+
+namespace MudBlazor.UnitTests.Components
+{
+
+    [TestFixture]
+    public class PageContentNavigationTests
+    {
+        private Bunit.TestContext ctx;
+
+        [SetUp]
+        public void Setup()
+        {
+            ctx = new Bunit.TestContext();
+        }
+
+        [TearDown]
+        public void TearDown() => ctx.Dispose();
+
+        [Test]
+        public void DefaultValues()
+        {
+            ctx.Services.Add(new ServiceDescriptor(typeof(IScrollSpy), new MockScrollSpy()));
+
+            var comp = ctx.RenderComponent<MudPageContentNavigation>();
+
+            comp.Instance.ActiveSection.Should().BeNull();
+            comp.Instance.Sections.Should().BeEmpty();
+            comp.Instance.Headline.Should().Be("Contents");
+            comp.Instance.SectionClassSelector.Should().BeNullOrEmpty();
+
+            comp.Nodes.Should().BeEmpty();
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task AddSection(bool withUpdate)
+        {
+            ctx.Services.Add(new ServiceDescriptor(typeof(IScrollSpy), new MockScrollSpy()));
+
+            var comp = ctx.RenderComponent<MudPageContentNavigation>();
+
+            var section = new MudPageContenSection("my section", "my-id");
+
+            if (withUpdate == true)
+            {
+                await comp.InvokeAsync(() => comp.Instance.AddSection(section, true));
+            }
+            else
+            {
+                comp.Instance.AddSection(section, false);
+                await comp.InvokeAsync(() => comp.Instance.Update());
+            }
+
+            comp.RenderCount.Should().Be(2);
+
+            comp.Instance.ActiveSection.Should().BeNull();
+            comp.Instance.Sections.Should().BeEquivalentTo(new[] { section });
+
+            comp.Nodes.Should().ContainSingle();
+
+            var navLinks = comp.FindComponents<MudNavLink>();
+            navLinks.Should().ContainSingle();
+            navLinks[0].Instance.Class.Should().Be("page-content-navigation-navlink");
+
+            var linkText = navLinks[0].Find(".mud-nav-link-text");
+            linkText.TextContent.Should().Be("my section");
+
+        }
+
+        [Test]
+        public async Task AddSection_WhichIsActiveByScrollSpy()
+        {
+            var mockedScrollSpy = new MockScrollSpy
+            {
+                CenteredSection = "my-id"
+            };
+
+            ctx.Services.Add(new ServiceDescriptor(typeof(IScrollSpy), mockedScrollSpy));
+
+            var comp = ctx.RenderComponent<MudPageContentNavigation>();
+
+            var section = new MudPageContenSection("my section", "my-id");
+
+            await comp.InvokeAsync(() => comp.Instance.AddSection(section, true));
+
+            comp.RenderCount.Should().Be(2);
+
+            comp.Instance.ActiveSection.Should().Be(section);
+            comp.Instance.Sections.Should().BeEquivalentTo(new[] { section });
+            comp.Nodes.Should().ContainSingle();
+
+            var navLinks = comp.FindComponents<MudNavLink>();
+            navLinks.Should().ContainSingle();
+            navLinks[0].Instance.Class.Should().Be("page-content-navigation-navlink active");
+            var linkText = navLinks[0].Find(".mud-nav-link-text");
+
+            linkText.TextContent.Should().Be("my section");
+        }
+
+        [Test]
+        public void NavigateBySections()
+        {
+            var spyMock = new MockScrollSpy();
+
+            ctx.Services.Add(new ServiceDescriptor(typeof(IScrollSpy), spyMock));
+
+            var comp = ctx.RenderComponent<MudPageContentNavigation>();
+
+            var section1 = new MudPageContenSection("my first section", "my-id1");
+            var section2 = new MudPageContenSection("my second section", "my-id2");
+            var section3 = new MudPageContenSection("my third section", "my-id3");
+            var sections = new[] { section1, section2, section3 };
+
+            comp.Instance.AddSection(section1, false);
+            comp.Instance.AddSection(section2, false);
+            comp.Instance.AddSection(section3, false);
+
+            comp.InvokeAsync(() => comp.Instance.Update());
+
+            for (int i = 0; i < 3; i++)
+            {
+                var navLinks = comp.FindComponents<MudNavLink>();
+                navLinks[i].Find(".mud-nav-link").Click();
+
+                comp.Instance.ActiveSection.Should().Be(sections[i]);
+                navLinks = comp.FindComponents<MudNavLink>();
+
+                for (int j = 0; j < 3; j++)
+                {
+                    navLinks[j].Instance.Class.Should().Be(i == j ? "page-content-navigation-navlink active" : "page-content-navigation-navlink");
+                }
+            }
+
+            spyMock.ScrollHistory.Should().BeEquivalentTo(new[] { "my-id1", "my-id2", "my-id3" });
+        }
+
+        [Test]
+        public async Task ObserverScrollAndHandlingEvent()
+        {
+            var spyMock = new MockScrollSpy();
+
+            ctx.Services.Add(new ServiceDescriptor(typeof(IScrollSpy), spyMock));
+
+            var comp = ctx.RenderComponent<MudPageContentNavigation>(x => x.Add(y => y.SectionClassSelector, "my-section-class"));
+
+            spyMock.SpyingInitiated.Should().BeTrue();
+            spyMock.SpyingClassSelector.Should().Be("my-section-class");
+
+            var section1 = new MudPageContenSection("my first section", "my-id1");
+            var section2 = new MudPageContenSection("my second section", "my-id2");
+            var section3 = new MudPageContenSection("my third section", "my-id3");
+
+            var sections = new[] { section1, section2, section3 };
+
+            comp.Instance.AddSection(section1, false);
+            comp.Instance.AddSection(section2, false);
+            comp.Instance.AddSection(section3, false);
+
+            await comp.InvokeAsync(() => comp.Instance.Update());
+
+            //active second section
+            await comp.InvokeAsync(() => spyMock.FireScrollSectionSectionCenteredEvent(section2.Id));
+            comp.Instance.ActiveSection.Should().Be(section2);
+
+            //active third section
+            await comp.InvokeAsync(() => spyMock.FireScrollSectionSectionCenteredEvent(section3.Id));
+            comp.Instance.ActiveSection.Should().Be(section3);
+
+            //active first section
+            await comp.InvokeAsync(() => spyMock.FireScrollSectionSectionCenteredEvent(section1.Id));
+            comp.Instance.ActiveSection.Should().Be(section1);
+
+            //active non existing section
+            await comp.InvokeAsync(() => spyMock.FireScrollSectionSectionCenteredEvent("non-exisiting-section"));
+            comp.Instance.ActiveSection.Should().Be(section1);
+
+            //active empty section
+            await comp.InvokeAsync(() => spyMock.FireScrollSectionSectionCenteredEvent(null));
+            comp.Instance.ActiveSection.Should().Be(section1);
+        }
+    }
+}

--- a/src/MudBlazor.UnitTests/Mocks/MockScrollSpy.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockScrollSpy.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace MudBlazor.UnitTests.Mocks
@@ -8,14 +9,30 @@ namespace MudBlazor.UnitTests.Mocks
     /// </summary>
     public class MockScrollSpy : IScrollSpy
     {
-        public string CenteredSection => "my-item";
+        public bool SpyingInitiated { get; private set; }
+        public string SpyingClassSelector { get; private set; }
+
+        private List<string> _scrollHistory = new();
+        public IReadOnlyList<string> ScrollHistory => _scrollHistory.AsReadOnly();
+
+        public string CenteredSection { get; set; } = "my-item";
 
         public event EventHandler<ScrollSectionCenteredEventArgs> ScrollSectionSectionCentered;
 
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
-        public Task ScrollToSection(string id) => Task.FromResult(true);
+        public Task ScrollToSection(string id)
+        {
+            _scrollHistory.Add(id);
+            return Task.FromResult(true);
+        }
         public Task ScrollToSection(Uri uri) => Task.FromResult(false);
-        public Task StartSpying(string elementsSelector) => Task.FromResult(false);
+        public Task StartSpying(string elementsSelector)
+        {
+            SpyingInitiated = true;
+            SpyingClassSelector = elementsSelector;
+
+            return Task.FromResult(false);
+        }
 
         public void FireScrollSectionSectionCenteredEvent(string centeredElementId) => ScrollSectionSectionCentered?.Invoke(this, new(centeredElementId));
     }

--- a/src/MudBlazor.sln
+++ b/src/MudBlazor.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.0.31410.414
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31424.327
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MudBlazor", "MudBlazor\MudBlazor.csproj", "{FE5531F3-55F6-403D-BF48-3C904089B91D}"
 EndProject

--- a/src/MudBlazor/Components/PageContentNavigation/MudPageContenSection.cs
+++ b/src/MudBlazor/Components/PageContentNavigation/MudPageContenSection.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+
+namespace MudBlazor
+{
+    public class MudPageContenSection
+    {
+        public MudPageContenSection(string title, string id)
+        {
+            Title = title;
+            Id = id;
+        }
+
+        public string Title { get; set; }
+        public string Id { get; set; }
+        public bool IsActive { get; private set; }
+
+        public void Activate() => IsActive = true;
+        public void Deactive() => IsActive = false;
+    }
+}

--- a/src/MudBlazor/Components/PageContentNavigation/MudPageContentNavigation.razor
+++ b/src/MudBlazor/Components/PageContentNavigation/MudPageContentNavigation.razor
@@ -2,9 +2,10 @@
 @inherits MudComponentBase
 @using Microsoft.AspNetCore.Components.Routing
 
-@if (_sections.Any())
-{
-    <div class="@GetPanelClass()">
+<div class="@GetPanelClass()" @attributes="UserAttributes">
+
+    @if (_sections.Any())
+    {
         <MudText Typo="Typo.h6" GutterBottom="true">
             @Headline
         </MudText>
@@ -13,11 +14,9 @@
             {
                 <MudNavLink Match="NavLinkMatch.All" Class="@GetNavLinkClass(section.IsActive)" @onclick="@(e => OnNavLinkClick(section.Id))">
                     @section.Title
-                </MudNavLink>
-            }
+                </MudNavLink>}
         </MudNavMenu>
+    }
+</div>
 
-    </div>
-}
-
-@code { }
+    @code { }

--- a/src/MudBlazor/Components/PageContentNavigation/MudPageContentNavigation.razor
+++ b/src/MudBlazor/Components/PageContentNavigation/MudPageContentNavigation.razor
@@ -1,0 +1,23 @@
+﻿@namespace MudBlazor
+@inherits MudComponentBase
+@using Microsoft.AspNetCore.Components.Routing
+
+@if (_sections.Any())
+{
+    <div class="@GetPanelClass()">
+        <MudText Typo="Typo.h6" GutterBottom="true">
+            @Headline
+        </MudText>
+        <MudNavMenu Class="pl-4">
+            @foreach (var section in _sections)
+            {
+                <MudNavLink Match="NavLinkMatch.All" Class="@GetNavLinkClass(section.IsActive)" @onclick="@(e => OnNavLinkClick(section.Id))">
+                    @section.Title
+                </MudNavLink>
+            }
+        </MudNavMenu>
+
+    </div>
+}
+
+@code { }

--- a/src/MudBlazor/Components/PageContentNavigation/MudPageContentNavigation.razor.cs
+++ b/src/MudBlazor/Components/PageContentNavigation/MudPageContentNavigation.razor.cs
@@ -1,0 +1,100 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using MudBlazor.Utilities;
+
+namespace MudBlazor
+{
+    public partial class MudPageContentNavigation : IAsyncDisposable
+    {
+        private List<MudPageContenSection> _sections = new();
+
+        [Inject] IScrollSpy ScrollSpy { get; set; }
+
+        public IEnumerable<MudPageContenSection> Sections => _sections.AsEnumerable();
+        public MudPageContenSection ActiveSection => _sections.FirstOrDefault(x => x.IsActive == true);
+
+        [Parameter] public string Headline { get; set; } = "Contents";
+        [Parameter] public string SectionClassSelector { get; set; } = string.Empty;
+
+        private async Task OnNavLinkClick(string id)
+        {
+            SelectActiveSection(id);
+            await ScrollSpy.ScrollToSection(id);
+        }
+
+        private void ScrollSpy_ScrollSectionSectionCentered(object sender, ScrollSectionCenteredEventArgs e) =>
+             SelectActiveSection(e.Id);
+
+        private void SelectActiveSection(string id)
+        {
+            if (string.IsNullOrEmpty(id))
+            {
+                return;
+            }
+
+            var activelink = _sections.FirstOrDefault(x => x.Id == id);
+            if (activelink == null)
+            {
+                return;
+            }
+
+            _sections.ToList().ForEach(item => item.Deactive());
+            activelink.Activate();
+
+            StateHasChanged();
+        }
+
+        private string GetNavLinkClass(bool active) => new CssBuilder("page-content-navigation-navlink").AddClass("active", active).Build();
+        private string GetPanelClass() => new CssBuilder("page-content-navigation").AddClass(Class).Build();
+
+        public async Task ScrollToSection(Uri uri) => await ScrollSpy.ScrollToSection(uri);
+
+        public void AddSection(string sectionName, string sectionId, bool forceUpdate) => AddSection(new(sectionName, sectionId), forceUpdate);
+
+        public void AddSection(MudPageContenSection section, bool forceUpdate)
+        {
+            _sections.Add(section);
+
+            if (section.Id == ScrollSpy.CenteredSection)
+            {
+                section.Activate();
+            }
+
+            if (forceUpdate == true)
+            {
+                StateHasChanged();
+            }
+        }
+
+        public void Update() => StateHasChanged();
+
+        protected override async Task OnAfterRenderAsync(bool firstRender)
+        {
+            if (firstRender)
+            {
+                ScrollSpy.ScrollSectionSectionCentered += ScrollSpy_ScrollSectionSectionCentered;
+
+                if (string.IsNullOrEmpty(SectionClassSelector) == false)
+                {
+                    await ScrollSpy.StartSpying(SectionClassSelector);
+                }
+
+                SelectActiveSection(ScrollSpy.CenteredSection);
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            ScrollSpy.ScrollSectionSectionCentered -= ScrollSpy_ScrollSectionSectionCentered;
+            await ScrollSpy.DisposeAsync();
+        }
+    }
+}

--- a/src/MudBlazor/Styles/MudBlazor.scss
+++ b/src/MudBlazor/Styles/MudBlazor.scss
@@ -44,6 +44,7 @@
 @import 'components/_menu';
 @import 'components/_link';
 @import 'components/_navmenu';
+@import 'components/_pagecontentnavigation';
 @import 'components/_picker';
 @import 'components/_pickerdate';
 @import 'components/_pickertime';

--- a/src/MudBlazor/Styles/components/_pagecontentnavigation.scss
+++ b/src/MudBlazor/Styles/components/_pagecontentnavigation.scss
@@ -1,0 +1,31 @@
+﻿@import '../abstracts/variables';
+
+.page-content-navigation {
+
+    .page-content-navigation-navlink {
+        &.active {
+            .mud-nav-link {
+                color: var(--mud-palette-primary);
+                border-color: var(--mud-palette-primary);
+                background-color: transparent;
+            }
+        }
+
+        .mud-nav-link {
+            padding: 4px 16px 4px 16px;
+            color: var(--mud-palette-text-disabled);
+            border-left: 2px solid var(--mud-palette-action-disabled-background);
+
+            &.active {
+                color: var(--mud-palette-primary);
+                border-color: var(--mud-palette-primary);
+                background-color: transparent;
+            }
+
+            .mud-nav-link-text {
+                margin-left: 0px;
+                margin-inline-start: 0px;
+            }
+        }
+    }
+}


### PR DESCRIPTION
In the current version, the "Table of Contents" component within the ``DocPages``, each time a new section scrolls into the middle of the screen, the entire page is forced to reload ( ``StateHasChanged`` ). Usually, this is a cheap operation. However, within the API documentation and in WASM, reflection takes time, so this change becomes quite costly and results in a visual bug (scroll sputtering).

This PR addresses this issue by introducing a new component, ``MudPageContentNavigation``. In essence, this component represents the menu, so updates only force this menu to reload and not the entire page. 

I see use cases outside of the documentation for MudBlazor users, so I created it as a new component while knowing that the current state is not enough to be really useful for others.  

I've updated the ``DocsPage`` to use this new component and reused the created CSS. 

@henon It would be great if you can check if the bug is gone or not
@Garderoben It would be great if you check that I haven't broken any styling