### PR TITLE
MudAlert: add TextPosition and Close option

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Alert/AlertPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Alert/AlertPage.razor
@@ -7,7 +7,7 @@
             <SectionHeader Title="Simple alerts">
                 <Description>There are five severity levels that each set a different icon and a color. Set the <CodeInline>TextPosition</CodeInline> property to define the text position. 
                 Set the <CodeInline>ShowCloseIcon</CodeInline> property to <CodeInline>True</CodeInline> to display a Close icon. 
-                <CodeInline>CloseIconClicked</CodeInline> provides the EventCallback when clicking on the Close icon of the alert.</Description>
+                <CodeInline>CloseIconClicked</CodeInline> provides the EventCallback when clicking on the Close icon of the alert</Description>
             </SectionHeader>
             <SectionContent Outlined="true" FullWidth="true">
                 <AlertSimpleExample />

--- a/src/MudBlazor.Docs/Pages/Components/Alert/AlertPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Alert/AlertPage.razor
@@ -17,7 +17,7 @@
         <DocsPageSection>
             <SectionHeader Title="Text Position">
                 <Description>
-                    Set the <CodeInline>TextPosition</CodeInline> property to define the text position.
+                    Set the <CodeInline>AlertTextPosition</CodeInline> property to define the text position.
                 </Description>
             </SectionHeader>
             <SectionContent Outlined="true" FullWidth="true">

--- a/src/MudBlazor.Docs/Pages/Components/Alert/AlertPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Alert/AlertPage.razor
@@ -5,7 +5,9 @@
     <DocsPageContent>
         <DocsPageSection>
             <SectionHeader Title="Simple alerts">
-                <Description>There are five severity levels that each set a different icon and a color.</Description>
+                <Description>There are five severity levels that each set a different icon and a color. Set the <CodeInline>TextPosition</CodeInline> property to define the text position. 
+                Set the <CodeInline>CanClose</CodeInline> property to <CodeInline>True</CodeInline> to display a Close icon. 
+                <CodeInline>Close</CodeInline> provides the EventCallback when clicking on the Close icon of the alert.</Description>
             </SectionHeader>
             <SectionContent Outlined="true" FullWidth="true">
                 <AlertSimpleExample />

--- a/src/MudBlazor.Docs/Pages/Components/Alert/AlertPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Alert/AlertPage.razor
@@ -5,14 +5,37 @@
     <DocsPageContent>
         <DocsPageSection>
             <SectionHeader Title="Simple alerts">
-                <Description>There are five severity levels that each set a different icon and a color. Set the <CodeInline>TextPosition</CodeInline> property to define the text position. 
-                Set the <CodeInline>ShowCloseIcon</CodeInline> property to <CodeInline>True</CodeInline> to display a Close icon. 
-                <CodeInline>CloseIconClicked</CodeInline> provides the EventCallback when clicking on the Close icon of the alert</Description>
+                <Description>
+                    There are five severity levels that each set a different icon and a color. Set the <CodeInline>TextPosition</CodeInline> property to define the text position.
+                </Description>
             </SectionHeader>
             <SectionContent Outlined="true" FullWidth="true">
                 <AlertSimpleExample />
             </SectionContent>
-            <SectionSource Code="AlertSimpleExample" GitHubFolderName="Alert"  />
+            <SectionSource Code="AlertSimpleExample" GitHubFolderName="Alert" />
+        </DocsPageSection>
+        <DocsPageSection>
+            <SectionHeader Title="Text Position">
+                <Description>
+                    Set the <CodeInline>TextPosition</CodeInline> property to define the text position.
+                </Description>
+            </SectionHeader>
+            <SectionContent Outlined="true" FullWidth="true">
+                <AlertPositionExample />
+            </SectionContent>
+            <SectionSource Code="AlertPositionExample" GitHubFolderName="Alert" />
+        </DocsPageSection>
+        <DocsPageSection>
+            <SectionHeader Title="Close Icon and Event">
+                <Description>
+                    Set the <CodeInline>ShowCloseIcon</CodeInline> property to <CodeInline>True</CodeInline> to display a Close icon.
+                    <CodeInline>CloseIconClicked</CodeInline> provides the EventCallback when clicking on the Close icon of the alert
+                </Description>
+            </SectionHeader>
+            <SectionContent Outlined="true" FullWidth="true">
+                <AlertCloseExample />
+            </SectionContent>
+            <SectionSource Code="AlertCloseExample" GitHubFolderName="Alert" />
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader Title="Variants">
@@ -24,14 +47,14 @@
             <SectionContent Outlined="true" FullWidth="true">
                 <AlertOutlinedExample />
             </SectionContent>
-            <SectionSource Code="AlertOutlinedExample" GitHubFolderName="Alert"  />
+            <SectionSource Code="AlertOutlinedExample" GitHubFolderName="Alert" />
             <SectionHeader>
                 <SubTitle>Filled</SubTitle>
             </SectionHeader>
             <SectionContent Outlined="true" FullWidth="true">
                 <AlertFilledExample />
             </SectionContent>
-            <SectionSource Code="AlertFilledExample" GitHubFolderName="Alert"  />
+            <SectionSource Code="AlertFilledExample" GitHubFolderName="Alert" />
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader Title="Dense">
@@ -40,23 +63,23 @@
             <SectionContent Outlined="true" FullWidth="true">
                 <AlertDenseExample />
             </SectionContent>
-            <SectionSource Code="AlertDenseExample" ShowCode="false" GitHubFolderName="Alert"  />
+            <SectionSource Code="AlertDenseExample" ShowCode="false" GitHubFolderName="Alert" />
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader Title="No Icons">
                 <Description>You can disable the alert icons with the bool <CodeInline>NoIcon</CodeInline> set to true.</Description>
             </SectionHeader>
             <SectionContent Outlined="true" FullWidth="true">
-                <AlertNoIconExample/>
+                <AlertNoIconExample />
             </SectionContent>
-            <SectionSource Code="AlertNoIconExample" ShowCode="false" GitHubFolderName="Alert"  />
+            <SectionSource Code="AlertNoIconExample" ShowCode="false" GitHubFolderName="Alert" />
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader Title="Rounded and Square">
                 <Description>By default, the alert is set to rounded corners by your theme's default value. If you need a square Alert but don't want to change the theme, you can set the <CodeInline>Square</CodeInline> property to true.</Description>
             </SectionHeader>
             <SectionContent Outlined="true" FullWidth="true">
-                <AlertSquareExample/>
+                <AlertSquareExample />
             </SectionContent>
             <SectionSource Code="AlertSquareExample" ShowCode="false" GitHubFolderName="Alert" />
         </DocsPageSection>
@@ -67,7 +90,7 @@
             <SectionContent Outlined="true" FullWidth="true">
                 <AlertElevationExample />
             </SectionContent>
-            <SectionSource Code="AlertElevationExample" ShowCode="true" GitHubFolderName="Alert"  />
+            <SectionSource Code="AlertElevationExample" ShowCode="true" GitHubFolderName="Alert" />
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader Title="Snackbar Alerts">

--- a/src/MudBlazor.Docs/Pages/Components/Alert/AlertPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Alert/AlertPage.razor
@@ -6,8 +6,8 @@
         <DocsPageSection>
             <SectionHeader Title="Simple alerts">
                 <Description>There are five severity levels that each set a different icon and a color. Set the <CodeInline>TextPosition</CodeInline> property to define the text position. 
-                Set the <CodeInline>CanClose</CodeInline> property to <CodeInline>True</CodeInline> to display a Close icon. 
-                <CodeInline>Close</CodeInline> provides the EventCallback when clicking on the Close icon of the alert.</Description>
+                Set the <CodeInline>ShowCloseIcon</CodeInline> property to <CodeInline>True</CodeInline> to display a Close icon. 
+                <CodeInline>CloseIconClicked</CodeInline> provides the EventCallback when clicking on the Close icon of the alert.</Description>
             </SectionHeader>
             <SectionContent Outlined="true" FullWidth="true">
                 <AlertSimpleExample />

--- a/src/MudBlazor.Docs/Pages/Components/Alert/Examples/AlertCloseExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Alert/Examples/AlertCloseExample.razor
@@ -1,0 +1,39 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+@if (showLeaveAlert)
+{
+    <MudAlert Severity="Severity.Info" AlertTextPosition="AlertTextPosition.Center" ShowCloseIcon="true" CloseIconClicked="(() => CloseMe(true))">Time to leave. Please close me!</MudAlert>
+}
+@if (showCallAlert)
+{
+    <MudAlert Severity="Severity.Success" AlertTextPosition="AlertTextPosition.Center" ShowCloseIcon="true" CloseIconClicked="(() => CloseMe(false))">Time to call. Please close me!</MudAlert>
+}
+@if (!showLeaveAlert && !showCallAlert)
+{
+    <div style="display: flex; justify-content: center;" class="mt-6">
+        <MudButton @onclick="ShowAlerts" Variant="Variant.Filled" Color="Color.Primary">Show Alerts</MudButton>
+    </div>
+}
+
+@code { 
+    private bool showCallAlert = true;
+    private bool showLeaveAlert = true;
+
+    private void CloseMe(bool value)
+    {
+        if (value)
+        {
+            showLeaveAlert = false;
+        }
+        else
+        {
+            showCallAlert = false;
+        }
+    }
+
+    private void ShowAlerts()
+    {
+        showCallAlert = true;
+        showLeaveAlert = true;
+    }
+}

--- a/src/MudBlazor.Docs/Pages/Components/Alert/Examples/AlertPositionExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Alert/Examples/AlertPositionExample.razor
@@ -1,0 +1,7 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudAlert Severity="Severity.Normal" AlertTextPosition="AlertTextPosition.Left">Left</MudAlert>
+<MudAlert Severity="Severity.Info" AlertTextPosition="AlertTextPosition.Center">Center</MudAlert>
+<MudAlert Severity="Severity.Success" AlertTextPosition="AlertTextPosition.Right">Right</MudAlert>
+<MudAlert Severity="Severity.Warning" AlertTextPosition="AlertTextPosition.Start">Start</MudAlert>
+<MudAlert Severity="Severity.Error" AlertTextPosition="AlertTextPosition.End">End</MudAlert>

--- a/src/MudBlazor.Docs/Pages/Components/Alert/Examples/AlertSimpleExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Alert/Examples/AlertSimpleExample.razor
@@ -1,7 +1,35 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudAlert Severity="Severity.Normal">The reactor type is RBMK-1000</MudAlert>
-<MudAlert Severity="Severity.Info">The reactor was fired up successfully</MudAlert>
-<MudAlert Severity="Severity.Success">The reactor is running at optimum temperature</MudAlert>
-<MudAlert Severity="Severity.Warning">The reactor temperature exceeds the optimal range</MudAlert>
-<MudAlert Severity="Severity.Error">Meltdown is imminent</MudAlert>
+<MudAlert Severity="Severity.Normal" TextPosition="Position.Left">The reactor type is RBMK-1000</MudAlert>
+<MudAlert Severity="Severity.Info" TextPosition="Position.Center">The reactor was fired up successfully</MudAlert>
+<MudAlert Severity="Severity.Success" TextPosition="Position.Right">The reactor is running at optimum temperature</MudAlert>
+
+@foreach (var alert in Alerts)
+{
+    <MudAlert Severity="@alert.Severity" TextPosition="@alert.TextPosition" CanClose="@alert.CanClose" Close="@alert.DoSomething" Tag="@alert.Tag">@alert.Text</MudAlert>
+}
+
+@code { 
+    private List<Alert> Alerts = new();
+
+    private void SaveHumanity(MudAlert mudAlert)
+    {
+        Alerts.RemoveAll(x => x.Tag == Convert.ToInt32(mudAlert.Tag));
+    }
+
+    protected override void OnInitialized()
+    {
+        Alerts.Add(new Alert { Severity = Severity.Warning, TextPosition = Position.Center, Text = "The reactor temperature exceeds the optimal range", Tag=1 });
+        Alerts.Add(new Alert { Severity = Severity.Error, TextPosition = Position.Left, Text = "Meltdown is imminent", CanClose = true, DoSomething = SaveHumanity, Tag=2 });
+    }
+
+    class Alert
+    {
+        public int Tag { get; set; }
+        public string Text { get; set; }
+        public bool CanClose { get; set; }
+        public Severity Severity { get; set; }
+        public Position TextPosition { get; set; }
+        public Action<MudAlert> DoSomething {get; set; }
+    }
+}

--- a/src/MudBlazor.Docs/Pages/Components/Alert/Examples/AlertSimpleExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Alert/Examples/AlertSimpleExample.razor
@@ -1,35 +1,7 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudAlert Severity="Severity.Normal" TextPosition="Position.Left">The reactor type is RBMK-1000</MudAlert>
-<MudAlert Severity="Severity.Info" TextPosition="Position.Center">The reactor was fired up successfully</MudAlert>
-<MudAlert Severity="Severity.Success" TextPosition="Position.Right">The reactor is running at optimum temperature</MudAlert>
-
-@foreach (var alert in Alerts)
-{
-    <MudAlert Severity="@alert.Severity" TextPosition="@alert.TextPosition" ShowCloseIcon="@alert.ShowCloseIcon" CloseIconClicked="@alert.DoSomething" Tag="@alert.Tag">@alert.Text</MudAlert>
-}
-
-@code { 
-    private List<Alert> Alerts = new();
-
-    private void SaveHumanity(MudAlert mudAlert)
-    {
-        Alerts.RemoveAll(x => x.Tag == Convert.ToInt32(mudAlert.Tag));
-    }
-
-    protected override void OnInitialized()
-    {
-        Alerts.Add(new Alert { Severity = Severity.Warning, TextPosition = Position.Center, Text = "The reactor temperature exceeds the optimal range", Tag=1 });
-        Alerts.Add(new Alert { Severity = Severity.Error, TextPosition = Position.Left, Text = "Meltdown is imminent", ShowCloseIcon = true, DoSomething = SaveHumanity, Tag=2 });
-    }
-
-    class Alert
-    {
-        public int Tag { get; set; }
-        public string Text { get; set; }
-        public Severity Severity { get; set; }
-        public bool ShowCloseIcon { get; set; }
-        public Position TextPosition { get; set; }
-        public Action<MudAlert> DoSomething {get; set; }
-    }
-}
+<MudAlert Severity="Severity.Normal">The reactor type is RBMK-1000</MudAlert>
+<MudAlert Severity="Severity.Info">The reactor was fired up successfully</MudAlert>
+<MudAlert Severity="Severity.Success">The reactor is running at optimum temperature</MudAlert>
+<MudAlert Severity="Severity.Warning">The reactor temperature exceeds the optimal range</MudAlert>
+<MudAlert Severity="Severity.Error">Meltdown is imminent</MudAlert>

--- a/src/MudBlazor.Docs/Pages/Components/Alert/Examples/AlertSimpleExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Alert/Examples/AlertSimpleExample.razor
@@ -6,7 +6,7 @@
 
 @foreach (var alert in Alerts)
 {
-    <MudAlert Severity="@alert.Severity" TextPosition="@alert.TextPosition" CanClose="@alert.CanClose" Close="@alert.DoSomething" Tag="@alert.Tag">@alert.Text</MudAlert>
+    <MudAlert Severity="@alert.Severity" TextPosition="@alert.TextPosition" ShowCloseIcon="@alert.ShowCloseIcon" CloseIconClicked="@alert.DoSomething" Tag="@alert.Tag">@alert.Text</MudAlert>
 }
 
 @code { 
@@ -20,15 +20,15 @@
     protected override void OnInitialized()
     {
         Alerts.Add(new Alert { Severity = Severity.Warning, TextPosition = Position.Center, Text = "The reactor temperature exceeds the optimal range", Tag=1 });
-        Alerts.Add(new Alert { Severity = Severity.Error, TextPosition = Position.Left, Text = "Meltdown is imminent", CanClose = true, DoSomething = SaveHumanity, Tag=2 });
+        Alerts.Add(new Alert { Severity = Severity.Error, TextPosition = Position.Left, Text = "Meltdown is imminent", ShowCloseIcon = true, DoSomething = SaveHumanity, Tag=2 });
     }
 
     class Alert
     {
         public int Tag { get; set; }
         public string Text { get; set; }
-        public bool CanClose { get; set; }
         public Severity Severity { get; set; }
+        public bool ShowCloseIcon { get; set; }
         public Position TextPosition { get; set; }
         public Action<MudAlert> DoSomething {get; set; }
     }

--- a/src/MudBlazor.sln
+++ b/src/MudBlazor.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.0.31410.414
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31424.327
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MudBlazor", "MudBlazor\MudBlazor.csproj", "{FE5531F3-55F6-403D-BF48-3C904089B91D}"
 EndProject

--- a/src/MudBlazor.sln
+++ b/src/MudBlazor.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31424.327
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31410.414
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MudBlazor", "MudBlazor\MudBlazor.csproj", "{FE5531F3-55F6-403D-BF48-3C904089B91D}"
 EndProject

--- a/src/MudBlazor/Components/Alert/AlertTextPosition.cs
+++ b/src/MudBlazor/Components/Alert/AlertTextPosition.cs
@@ -1,0 +1,19 @@
+﻿using System.ComponentModel;
+
+
+namespace MudBlazor
+{
+    public enum AlertTextPosition
+    {
+        [Description("center")]
+        Center,
+        [Description("left")]
+        Left,
+        [Description("right")]
+        Right,
+        [Description("start")]
+        Start,
+        [Description("end")]
+        End
+    }
+}

--- a/src/MudBlazor/Components/Alert/MudAlert.razor
+++ b/src/MudBlazor/Components/Alert/MudAlert.razor
@@ -8,7 +8,7 @@
         <div class="@ClassPosition">
             @if (!NoIcon)
             {
-                <div class="mud-alert-icon">
+                <div class="mud-alert-icon mud-alert-icon-left">
                     <MudIcon Icon="@_icon" />
                 </div>
             }
@@ -37,7 +37,7 @@
             </div>
             @if (!NoIcon)
             {
-                <div class="mud-alert-icon">
+                <div class="mud-alert-icon mud-alert-icon-right">
                     <MudIcon Icon="@_icon" />
                 </div>
             }

--- a/src/MudBlazor/Components/Alert/MudAlert.razor
+++ b/src/MudBlazor/Components/Alert/MudAlert.razor
@@ -2,14 +2,22 @@
 
 @inherits MudComponentBase
 
-<div @attributes="UserAttributes" role="alert" class="@Classname" Style="@Style" @onclick="OnClick" >
-    @if (!NoIcon)
+<div @attributes="UserAttributes" role="alert" class="@Classname" Style="@Style" @onclick="OnClick">
+    <div class="@ClassPosition">
+        @if (!NoIcon)
+        {
+            <div class="mud-alert-icon">
+                <MudIcon Icon="@_icon" />
+            </div>
+        }
+        <div class="mud-alert-message">
+            @ChildContent
+        </div>
+    </div>
+    @if (CanClose)
     {
-        <div class="mud-alert-icon">
-            <MudIcon Icon="@_icon" />
+        <div class="mud-alert-close">
+            <MudIcon Icon="@CloseIcon" @onclick="EventCallback.Factory.Create<MouseEventArgs>(this, () => Close.InvokeAsync(this))" />
         </div>
     }
-    <div class="mud-alert-message">
-        @ChildContent
-    </div>
 </div>

--- a/src/MudBlazor/Components/Alert/MudAlert.razor
+++ b/src/MudBlazor/Components/Alert/MudAlert.razor
@@ -3,21 +3,44 @@
 @inherits MudComponentBase
 
 <div @attributes="UserAttributes" role="alert" class="@Classname" Style="@Style" @onclick="OnClick">
-    <div class="@ClassPosition">
-        @if (!NoIcon)
+    @if (!RightToLeft)
+    {
+        <div class="@ClassPosition">
+            @if (!NoIcon)
+            {
+                <div class="mud-alert-icon">
+                    <MudIcon Icon="@_icon" />
+                </div>
+            }
+            <div class="mud-alert-message">
+                @ChildContent
+            </div>
+        </div>
+        @if (ShowCloseIcon)
         {
-            <div class="mud-alert-icon">
-                <MudIcon Icon="@_icon" />
+            <div class="mud-alert-close">
+                <MudIcon Icon="@CloseIcon" @onclick="OnCloseIconClickAsync" Size="Size.Small" />
             </div>
         }
-        <div class="mud-alert-message">
-            @ChildContent
-        </div>
-    </div>
-    @if (ShowCloseIcon)
-    {
-        <div class="mud-alert-close">
-            <MudIcon Icon="@CloseIcon" @onclick="OnCloseIconClickAsync" Size="Size.Small" />
+    }
+    else
+    { 
+        @if (ShowCloseIcon)
+        {
+            <div class="mud-alert-close">
+                <MudIcon Icon="@CloseIcon" @onclick="OnCloseIconClickAsync" Size="Size.Small" />
+            </div>
+        }
+        <div class="@ClassPosition">
+            <div class="mud-alert-message">
+                @ChildContent
+            </div>
+            @if (!NoIcon)
+            {
+                <div class="mud-alert-icon">
+                    <MudIcon Icon="@_icon" />
+                </div>
+            }
         </div>
     }
 </div>

--- a/src/MudBlazor/Components/Alert/MudAlert.razor
+++ b/src/MudBlazor/Components/Alert/MudAlert.razor
@@ -3,44 +3,21 @@
 @inherits MudComponentBase
 
 <div @attributes="UserAttributes" role="alert" class="@Classname" Style="@Style" @onclick="OnClick">
-    @if (!RightToLeft)
+<div class="@ClassPosition">
+    @if (!NoIcon)
     {
-        <div class="@ClassPosition">
-            @if (!NoIcon)
-            {
-                <div class="mud-alert-icon mud-alert-icon-left">
-                    <MudIcon Icon="@_icon" />
-                </div>
-            }
-            <div class="mud-alert-message">
-                @ChildContent
-            </div>
-        </div>
-        @if (ShowCloseIcon)
-        {
-            <div class="mud-alert-close">
-                <MudIcon Icon="@CloseIcon" @onclick="OnCloseIconClickAsync" Size="Size.Small" />
-            </div>
-        }
-    }
-    else
-    { 
-        @if (ShowCloseIcon)
-        {
-            <div class="mud-alert-close">
-                <MudIcon Icon="@CloseIcon" @onclick="OnCloseIconClickAsync" Size="Size.Small" />
-            </div>
-        }
-        <div class="@ClassPosition">
-            <div class="mud-alert-message">
-                @ChildContent
-            </div>
-            @if (!NoIcon)
-            {
-                <div class="mud-alert-icon mud-alert-icon-right">
-                    <MudIcon Icon="@_icon" />
-                </div>
-            }
+        <div class="mud-alert-icon mud-alert-icon-left">
+            <MudIcon Icon="@_icon" />
         </div>
     }
+    <div class="mud-alert-message">
+        @ChildContent
+    </div>
+</div>
+@if (ShowCloseIcon)
+{
+    <div class="mud-alert-close">
+        <MudToggleIconButton Icon="@CloseIcon" @onclick="OnCloseIconClickAsync" Size="Size.Small" />
+    </div>
+}
 </div>

--- a/src/MudBlazor/Components/Alert/MudAlert.razor
+++ b/src/MudBlazor/Components/Alert/MudAlert.razor
@@ -14,10 +14,10 @@
             @ChildContent
         </div>
     </div>
-    @if (CanClose)
+    @if (ShowCloseIcon)
     {
         <div class="mud-alert-close">
-            <MudIcon Icon="@CloseIcon" @onclick="EventCallback.Factory.Create<MouseEventArgs>(this, () => Close.InvokeAsync(this))" />
+            <MudIcon Icon="@CloseIcon" @onclick="OnCloseIconClickAsync" Size="Size.Small" />
         </div>
     }
 </div>

--- a/src/MudBlazor/Components/Alert/MudAlert.razor.cs
+++ b/src/MudBlazor/Components/Alert/MudAlert.razor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Extensions;
@@ -42,7 +43,7 @@ namespace MudBlazor
         /// <summary>
         /// The callback, when the close button has been clicked.
         /// </summary>
-        [Parameter] public EventCallback<MudAlert> Close { get; set; }
+        [Parameter] public EventCallback<MudAlert> CloseIconClicked { get; set; }
 
         /// <summary>
         /// Define the icon used for the close button.
@@ -50,9 +51,9 @@ namespace MudBlazor
         [Parameter] public string CloseIcon { get; set; } = Icons.Material.Filled.Close;
 
         /// <summary>
-        /// Sets if the alert has a close icon.
+        /// Sets if the alert shows a close icon.
         /// </summary>
-        [Parameter] public bool CanClose { get; set; }
+        [Parameter] public bool ShowCloseIcon { get; set; }
 
         /// <summary>
         /// The higher the number, the heavier the drop-shadow. 0 for no shadow.
@@ -95,6 +96,14 @@ namespace MudBlazor
         [Parameter] public string Icon { get; set; }
 
         protected string _icon;
+
+        private async Task OnCloseIconClickAsync()
+        {
+            if (CloseIconClicked.HasDelegate)
+            {
+                await CloseIconClicked.InvokeAsync(this);
+            }
+        }
 
         protected override void OnParametersSet()
         {

--- a/src/MudBlazor/Components/Alert/MudAlert.razor.cs
+++ b/src/MudBlazor/Components/Alert/MudAlert.razor.cs
@@ -27,17 +27,22 @@ namespace MudBlazor
         {
             return position switch
             {
-                Position.Bottom => Position.End,
-                Position.Left => Position.Start,
-                Position.Top => Position.Start,
-                Position.Right => Position.End,
+                Position.Right => RightToLeft ? Position.Start : Position.End,
+                Position.Bottom => RightToLeft ? Position.Start : Position.End,
+                Position.End => RightToLeft ? Position.Start : Position.End,
+                Position.Left => RightToLeft ? Position.End : Position.Start,
+                Position.Top => RightToLeft ? Position.End : Position.Start,
+                Position.Start => RightToLeft ? Position.End : Position.Start,
                 _ => position
             };
         }
 
+        [CascadingParameter] public bool RightToLeft { get; set; }
+
         /// <summary>
-        /// Sets the position of the text. By default, the position is the Left/Start position.
+        /// Sets the position of the text to the start (Left in LTR and right in RTL).
         /// </summary>
+        [Parameter] public bool Start { get; set; }
         [Parameter] public Position TextPosition { get; set; } = Position.Start;
 
         /// <summary>

--- a/src/MudBlazor/Components/Alert/MudAlert.razor.cs
+++ b/src/MudBlazor/Components/Alert/MudAlert.razor.cs
@@ -17,6 +17,43 @@ namespace MudBlazor
           .AddClass(Class)
         .Build();
 
+        protected string ClassPosition =>
+        new CssBuilder("mud-alert-position")
+            .AddClass($"justify-sm-{ConvertTextPosition(TextPosition).ToDescriptionString()}")
+        .Build();
+
+        private Position ConvertTextPosition(Position position)
+        {
+            return position switch
+            {
+                Position.Bottom => Position.End,
+                Position.Left => Position.Start,
+                Position.Top => Position.Start,
+                Position.Right => Position.End,
+                _ => position
+            };
+        }
+
+        /// <summary>
+        /// Sets the position of the text. By default, the position is the Left/Start position.
+        /// </summary>
+        [Parameter] public Position TextPosition { get; set; } = Position.Start;
+
+        /// <summary>
+        /// The callback, when the close button has been clicked.
+        /// </summary>
+        [Parameter] public EventCallback<MudAlert> Close { get; set; }
+
+        /// <summary>
+        /// Define the icon used for the close button.
+        /// </summary>
+        [Parameter] public string CloseIcon { get; set; } = Icons.Material.Filled.Close;
+
+        /// <summary>
+        /// Sets if the alert has a close icon.
+        /// </summary>
+        [Parameter] public bool CanClose { get; set; }
+
         /// <summary>
         /// The higher the number, the heavier the drop-shadow. 0 for no shadow.
         /// </summary>

--- a/src/MudBlazor/Components/Alert/MudAlert.razor.cs
+++ b/src/MudBlazor/Components/Alert/MudAlert.razor.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Extensions;
 using MudBlazor.Utilities;
 
+
 namespace MudBlazor
 {
     public partial class MudAlert : MudComponentBase
@@ -20,20 +21,16 @@ namespace MudBlazor
 
         protected string ClassPosition =>
         new CssBuilder("mud-alert-position")
-            .AddClass($"justify-sm-{ConvertTextPosition(TextPosition).ToDescriptionString()}")
+            .AddClass($"justify-sm-{ConvertAlertTextPosition(AlertTextPosition).ToDescriptionString()}")
         .Build();
 
-        private Position ConvertTextPosition(Position position)
+        private AlertTextPosition ConvertAlertTextPosition(AlertTextPosition alertTextPosition)
         {
-            return position switch
+            return alertTextPosition switch
             {
-                Position.Right => RightToLeft ? Position.Start : Position.End,
-                Position.Bottom => RightToLeft ? Position.Start : Position.End,
-                Position.End => RightToLeft ? Position.Start : Position.End,
-                Position.Left => RightToLeft ? Position.End : Position.Start,
-                Position.Top => RightToLeft ? Position.End : Position.Start,
-                Position.Start => RightToLeft ? Position.End : Position.Start,
-                _ => position
+                AlertTextPosition.Right => RightToLeft ? AlertTextPosition.Start : AlertTextPosition.End,
+                AlertTextPosition.Left => RightToLeft ? AlertTextPosition.End : AlertTextPosition.Start,
+                _ => alertTextPosition
             };
         }
 
@@ -42,8 +39,7 @@ namespace MudBlazor
         /// <summary>
         /// Sets the position of the text to the start (Left in LTR and right in RTL).
         /// </summary>
-        [Parameter] public bool Start { get; set; }
-        [Parameter] public Position TextPosition { get; set; } = Position.Start;
+        [Parameter] public AlertTextPosition AlertTextPosition { get; set; } = AlertTextPosition.Left;
 
         /// <summary>
         /// The callback, when the close button has been clicked.

--- a/src/MudBlazor/Styles/components/_alert.scss
+++ b/src/MudBlazor/Styles/components/_alert.scss
@@ -76,21 +76,22 @@
     margin-right: 12px;
     margin-inline-end: 12px;
     margin-inline-start: unset;
+
+    &.mud-alert-icon-left {
+        margin-right: 12px;
+        margin-inline-end: 12px;
+        margin-inline-start: unset;
+    }
+
+    &.mud-alert-icon-right {
+        margin-left: 12px;
+        margin-inline-start: 12px;
+        margin-inline-end: unset;
+    }
 }
 
 .mud-alert-message {
     padding: 9px 0;
-}
-
-.mud-alert-action {
-    display: flex;
-    align-items: center;
-    margin-left: auto;
-    margin-right: -8px;
-    padding-left: 16px;
-    margin-inline-start: auto;
-    margin-inline-end: -8px;
-    padding-inline-start: 16px;
 }
 
 .mud-alert-position {

--- a/src/MudBlazor/Styles/components/_alert.scss
+++ b/src/MudBlazor/Styles/components/_alert.scss
@@ -102,6 +102,5 @@
     display: flex;
     flex: 0;
     align-items: center;
-    margin-right: 8px;
     margin-left: 8px;
 }

--- a/src/MudBlazor/Styles/components/_alert.scss
+++ b/src/MudBlazor/Styles/components/_alert.scss
@@ -92,3 +92,16 @@
     margin-inline-end: -8px;
     padding-inline-start: 16px;
 }
+
+.mud-alert-position {
+    flex: 1;
+    display: flex;
+}
+
+.mud-alert-close {
+    display: flex;
+    flex: 0;
+    align-items: center;
+    margin-right: 8px;
+    margin-left: 8px;
+}


### PR DESCRIPTION
Here is a PR proposing the following for the _MudAlert_ component:

* Different ```AlertTextPosition``` : _Center, Start, End, Left and Right_
* Close option with ```ShowCloseIcon```
* ```CloseIconClicked``` EventCallback can be used to get the event when the _Close Icon_ is clicked
* ```CloseIcon``` parameter gives the possibility to define the icon for the _Close Icon_
* The official documentation has been updated to propose examples. See the screenshot below.

![image](https://user-images.githubusercontent.com/16502423/125572589-74fbbbec-3062-4342-8b60-91606e9c4448.png)