### PR TITLE
MudBlazor.Utilities:ComponentTimer Class

### DIFF
--- a/src/MudBlazor.UnitTests/Utilities/ComponentTimerTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/ComponentTimerTests.cs
@@ -1,0 +1,566 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MudBlazor.Utilities;
+using NUnit.Framework;
+
+namespace UtilityTests
+{
+    public class ComponentTimerTests
+    {
+        private static readonly TimeSpan _1msTimeSpan = TimeSpan.FromMilliseconds(1);
+        private static readonly TimeSpan _3msTimeSpan = TimeSpan.FromMilliseconds(3);
+        private static readonly TimeSpan _delayMs = TimeSpan.FromMilliseconds(50);
+        private static readonly object _locker = new();
+        private CallbackExecuteTest _testCallback;
+        private CallbackExecuteTest _testCallbackAsync;
+        private class CallbackExecuteTest { public int ExecuteCount { get; set; } = -1; public bool HasExecuted { get; set; } }
+        private void CallbackMethod<T>(T state) { CallbackCore(state); }
+        private async ValueTask CallbackMethodAsync<T>(T state) { await new ValueTask(); CallbackCore(state); }
+        private static void CallbackCore<T>(T state, [CallerMemberName] string methodName = "???")
+        {
+            if (state is CallbackExecuteTest executeTest)
+            {
+                lock (_locker)
+                {
+                    executeTest.ExecuteCount++;
+                    executeTest.HasExecuted = true;
+                }
+                Console.WriteLine($"{methodName}: {executeTest.ExecuteCount}");
+            }
+            else
+                Console.WriteLine($"{methodName}: {nameof(state)} = {state}");
+        }
+
+        [SetUp]
+        public void Setup()
+        {
+            _testCallback = new CallbackExecuteTest { ExecuteCount = 0 };
+            _testCallbackAsync = new CallbackExecuteTest { ExecuteCount = 0 };
+        }
+
+
+        [Test]
+        public void Constructor_ConcreteClass()
+        {
+            using var timer = new ComponentTimer(CallbackMethod, state: _testCallback);
+            timer.Should().As<ComponentTimer>();
+            _testCallback.HasExecuted.Should().BeFalse();
+            _testCallback.ExecuteCount.Should().Be(0);
+
+
+            using var timerAsync = new ComponentTimer(CallbackMethodAsync, state: _testCallbackAsync);
+            timerAsync.Should().As<ComponentTimer>();
+            _testCallbackAsync.HasExecuted.Should().BeFalse();
+            _testCallbackAsync.ExecuteCount.Should().Be(0);
+        }
+
+        [Test]
+        public void Constructor_Interface()
+        {
+            using IComponentTimer timer = new ComponentTimer(CallbackMethod, state: _testCallback);
+            timer.Should().As<IComponentTimer>();
+            _testCallback.HasExecuted.Should().BeFalse();
+            _testCallback.ExecuteCount.Should().Be(0);
+
+
+            using IComponentTimer timerAsync = new ComponentTimer(CallbackMethodAsync, state: _testCallbackAsync);
+            timerAsync.Should().As<IComponentTimer>();
+            _testCallbackAsync.HasExecuted.Should().BeFalse();
+            _testCallbackAsync.ExecuteCount.Should().Be(0);
+        }
+
+
+        [Test]
+        public async ValueTask Property_Enabled()
+        {
+            using IComponentTimer timer = new ComponentTimer(CallbackMethod, period: _1msTimeSpan, state: _testCallback);
+            timer.Enabled.Should().BeFalse();
+            timer.Enabled = true;
+            timer.Enabled.Should().BeTrue();
+            await Task.Delay(_delayMs);
+            timer.Enabled = false;
+            timer.Enabled.Should().BeFalse();
+            _testCallback.HasExecuted.Should().BeTrue();
+            _testCallback.ExecuteCount.Should().BeGreaterThan(0);
+
+
+            using IComponentTimer timerAsync = new ComponentTimer(CallbackMethodAsync, period: _1msTimeSpan, state: _testCallbackAsync);
+            timerAsync.Enabled.Should().BeFalse();
+            timerAsync.Enabled = true;
+            timerAsync.Enabled.Should().BeTrue();
+            await Task.Delay(_delayMs);
+            timerAsync.Enabled = false;
+            timerAsync.Enabled.Should().BeFalse();
+            _testCallbackAsync.HasExecuted.Should().BeTrue();
+            _testCallbackAsync.ExecuteCount.Should().BeGreaterThan(0);
+        }
+
+        [Test]
+        public async ValueTask Property_IsTicking()
+        {
+            using IComponentTimer timer = new ComponentTimer(CallbackMethod, true, period: _1msTimeSpan, state: _testCallback);
+            timer.IsTicking.Should().BeTrue();
+            await Task.Delay(_delayMs);
+            timer.Stop();
+            timer.IsTicking.Should().BeFalse();
+            _testCallback.HasExecuted.Should().BeTrue();
+            _testCallback.ExecuteCount.Should().BeGreaterThan(0);
+
+
+            using IComponentTimer timerAsync = new ComponentTimer(CallbackMethodAsync, true, period: _1msTimeSpan, state: _testCallbackAsync);
+            timerAsync.IsTicking.Should().BeTrue();
+            await Task.Delay(_delayMs);
+            await timerAsync.StopAsync();
+            timerAsync.IsTicking.Should().BeFalse();
+            _testCallbackAsync.HasExecuted.Should().BeTrue();
+            _testCallbackAsync.ExecuteCount.Should().BeGreaterThan(0);
+        }
+
+        [Test]
+        public void Property_IsTicking_With_InfiniteTimeSpan()
+        {
+            var interval = Timeout.InfiniteTimeSpan;
+
+            using IComponentTimer timer = new ComponentTimer(CallbackMethod, true, period: interval, state: _testCallback);
+            timer.IsTicking.Should().BeFalse();
+            _testCallback.HasExecuted.Should().BeFalse();
+            _testCallback.ExecuteCount.Should().Be(0);
+
+
+            using IComponentTimer timerAsync = new ComponentTimer(CallbackMethodAsync, true, period: interval, state: _testCallbackAsync);
+            timerAsync.IsTicking.Should().BeFalse();
+            _testCallbackAsync.HasExecuted.Should().BeFalse();
+            _testCallbackAsync.ExecuteCount.Should().Be(0);
+        }
+
+        [Test]
+        public void Property_IsTicking_With_TimeSpanZero()
+        {
+            var interval = TimeSpan.Zero;
+
+            using IComponentTimer timer = new ComponentTimer(CallbackMethod, true, period: interval, state: _testCallback);
+            timer.IsTicking.Should().BeFalse();
+            _testCallback.HasExecuted.Should().BeFalse();
+            _testCallback.ExecuteCount.Should().Be(0);
+
+
+            using IComponentTimer timerAsync = new ComponentTimer(CallbackMethodAsync, true, period: interval, state: _testCallbackAsync);
+            timerAsync.IsTicking.Should().BeFalse();
+            _testCallbackAsync.HasExecuted.Should().BeFalse();
+            _testCallbackAsync.ExecuteCount.Should().Be(0);
+        }
+
+        [Test]
+        public void Property_DueTime()
+        {
+            using IComponentTimer timer = new ComponentTimer(CallbackMethod, dueTime: _1msTimeSpan, state: _testCallback);
+            timer.DueTime.Should().NotBe(TimeSpan.Zero);
+            timer.DueTime.Should().NotBe(Timeout.InfiniteTimeSpan);
+            timer.DueTime.TotalMilliseconds.Should().Be(1);
+            _testCallback.HasExecuted.Should().BeFalse();
+            _testCallback.ExecuteCount.Should().Be(0);
+
+
+            using IComponentTimer timerAsync = new ComponentTimer(CallbackMethodAsync, dueTime: _1msTimeSpan, state: _testCallbackAsync);
+            timerAsync.DueTime.Should().NotBe(TimeSpan.Zero);
+            timerAsync.DueTime.Should().NotBe(Timeout.InfiniteTimeSpan);
+            timerAsync.DueTime.TotalMilliseconds.Should().Be(1);
+            _testCallbackAsync.HasExecuted.Should().BeFalse();
+            _testCallbackAsync.ExecuteCount.Should().Be(0);
+        }
+
+        [Test]
+        public void Property_DueTime_With_InfiniteTimeSpan()
+        {
+            var startDelay = Timeout.InfiniteTimeSpan;
+
+            using IComponentTimer timer = new ComponentTimer(CallbackMethod, dueTime: startDelay, state: _testCallback);
+            timer.DueTime.Should().Be(TimeSpan.Zero);
+            timer.DueTime.TotalMilliseconds.Should().Be(0);
+            _testCallback.HasExecuted.Should().BeFalse();
+            _testCallback.ExecuteCount.Should().Be(0);
+
+
+            using IComponentTimer timerAsync = new ComponentTimer(CallbackMethodAsync, dueTime: startDelay, state: _testCallbackAsync);
+            timerAsync.DueTime.Should().Be(TimeSpan.Zero);
+            timerAsync.DueTime.TotalMilliseconds.Should().Be(0);
+            _testCallbackAsync.HasExecuted.Should().BeFalse();
+            _testCallbackAsync.ExecuteCount.Should().Be(0);
+        }
+
+        [Test]
+        public void Property_DueTime_With_TimeSpanZero()
+        {
+            var startDelay = TimeSpan.Zero;
+
+            using IComponentTimer timer = new ComponentTimer(CallbackMethod, dueTime: startDelay, state: _testCallback);
+            timer.DueTime.Should().Be(TimeSpan.Zero);
+            timer.DueTime.TotalMilliseconds.Should().Be(0);
+            _testCallback.HasExecuted.Should().BeFalse();
+            _testCallback.ExecuteCount.Should().Be(0);
+
+
+            using IComponentTimer timerAsync = new ComponentTimer(CallbackMethodAsync, dueTime: startDelay, state: _testCallbackAsync);
+            timerAsync.DueTime.Should().Be(TimeSpan.Zero);
+            timerAsync.DueTime.TotalMilliseconds.Should().Be(0);
+            _testCallbackAsync.HasExecuted.Should().BeFalse();
+            _testCallbackAsync.ExecuteCount.Should().Be(0);
+        }
+
+        [Test]
+        public void Property_Period()
+        {
+            using IComponentTimer timer = new ComponentTimer(CallbackMethod, period: _1msTimeSpan, state: _testCallback);
+            timer.Period.Should().NotBe(TimeSpan.Zero);
+            timer.Period.Should().NotBe(Timeout.InfiniteTimeSpan);
+            timer.Period.TotalMilliseconds.Should().Be(1);
+            _testCallback.HasExecuted.Should().BeFalse();
+            _testCallback.ExecuteCount.Should().Be(0);
+
+
+            using IComponentTimer timerAsync = new ComponentTimer(CallbackMethodAsync, period: _1msTimeSpan, state: _testCallbackAsync);
+            timerAsync.Period.Should().NotBe(TimeSpan.Zero);
+            timerAsync.Period.Should().NotBe(Timeout.InfiniteTimeSpan);
+            timerAsync.Period.TotalMilliseconds.Should().Be(1);
+            _testCallbackAsync.HasExecuted.Should().BeFalse();
+            _testCallbackAsync.ExecuteCount.Should().Be(0);
+        }
+
+        [Test]
+        public void Property_Period_With_InfiniteTimeSpan()
+        {
+            using IComponentTimer timer = new ComponentTimer(CallbackMethod, period: _1msTimeSpan, state: _testCallback);
+            timer.Period.Should().NotBe(TimeSpan.Zero);
+            timer.Period.TotalMilliseconds.Should().Be(1);
+            _testCallback.HasExecuted.Should().BeFalse();
+            _testCallback.ExecuteCount.Should().Be(0);
+
+
+            using IComponentTimer timerAsync = new ComponentTimer(CallbackMethodAsync, period: _1msTimeSpan, state: _testCallbackAsync);
+            timerAsync.Period.Should().NotBe(TimeSpan.Zero);
+            timerAsync.Period.TotalMilliseconds.Should().Be(1);
+            _testCallbackAsync.HasExecuted.Should().BeFalse();
+            _testCallbackAsync.ExecuteCount.Should().Be(0);
+        }
+
+        [Test]
+        public void Property_Period_With_TimeSpanZero()
+        {
+            var interval = TimeSpan.Zero;
+
+            using IComponentTimer timer = new ComponentTimer(CallbackMethod, period: interval, state: _testCallback);
+            timer.Period.Should().Be(TimeSpan.Zero);
+            timer.Period.TotalMilliseconds.Should().Be(0);
+            _testCallback.HasExecuted.Should().BeFalse();
+            _testCallback.ExecuteCount.Should().Be(0);
+
+
+            using IComponentTimer timerAsync = new ComponentTimer(CallbackMethodAsync, period: interval, state: _testCallbackAsync);
+            timerAsync.Period.Should().Be(TimeSpan.Zero);
+            timerAsync.Period.TotalMilliseconds.Should().Be(0);
+            _testCallbackAsync.HasExecuted.Should().BeFalse();
+            _testCallbackAsync.ExecuteCount.Should().Be(0);
+        }
+
+        [Test]
+        public async ValueTask Property_Elapsed()
+        {
+            using IComponentTimer timer = new ComponentTimer(CallbackMethod, period: _1msTimeSpan, state: _testCallback);
+            timer.Elapsed.Should().Be(TimeSpan.Zero);
+            timer.Start();
+            await Task.Delay(_delayMs);
+            timer.Stop();
+            timer.Elapsed.TotalMilliseconds.Should().BeGreaterThan(0);
+            _testCallback.HasExecuted.Should().BeTrue();
+            _testCallback.ExecuteCount.Should().BeGreaterThan(0);
+
+
+            using IComponentTimer timerAsync = new ComponentTimer(CallbackMethodAsync, period: _1msTimeSpan, state: _testCallbackAsync);
+            timerAsync.Elapsed.Should().Be(TimeSpan.Zero);
+            await timerAsync.StartAsync();
+            await Task.Delay(_delayMs);
+            await timerAsync.StopAsync();
+            timerAsync.Elapsed.TotalMilliseconds.Should().BeGreaterThan(0);
+            _testCallbackAsync.HasExecuted.Should().BeTrue();
+            _testCallbackAsync.ExecuteCount.Should().BeGreaterThan(0);
+        }
+
+
+        [Test]
+        public async ValueTask Method_Start_MultipleCalls_Return_Initial_DateTimeOffset()
+        {
+            using IComponentTimer timer = new ComponentTimer(CallbackMethod, period: _1msTimeSpan, state: _testCallback);
+            var initialTimestamp = timer.Start();
+            await Task.Delay(_delayMs);
+            var newerTimestamp = timer.Start();
+            timer.Stop();
+            newerTimestamp.Should().BeSameDateAs((DateTimeOffset)initialTimestamp);
+
+
+            using IComponentTimer timerAsync = new ComponentTimer(CallbackMethodAsync, period: _1msTimeSpan, state: _testCallbackAsync);
+            var initialTimestampAsync = await timerAsync.StartAsync();
+            await Task.Delay(_delayMs);
+            var newerTimestampAsync = await timerAsync.StartAsync();
+            await timerAsync.StopAsync();
+            newerTimestamp.Should().BeSameDateAs((DateTimeOffset)initialTimestamp);
+        }
+
+        [Test]
+        public async ValueTask Method_Start_Sets_Enabled_True()
+        {
+            using IComponentTimer timer = new ComponentTimer(CallbackMethod, period: _1msTimeSpan, state: _testCallback);
+            timer.Start();
+            timer.Enabled.Should().BeTrue();
+            await Task.Delay(_delayMs);
+            timer.Stop();
+            _testCallback.HasExecuted.Should().BeTrue();
+            _testCallback.ExecuteCount.Should().BeGreaterThan(0);
+
+
+            using IComponentTimer timerAsync = new ComponentTimer(CallbackMethodAsync, period: _1msTimeSpan, state: _testCallbackAsync);
+            await timerAsync.StartAsync();
+            timerAsync.Enabled.Should().BeTrue();
+            await Task.Delay(_delayMs);
+            await timerAsync.StopAsync();
+            _testCallbackAsync.HasExecuted.Should().BeTrue();
+            _testCallbackAsync.ExecuteCount.Should().BeGreaterThan(0);
+        }
+
+        [Test]
+        public async ValueTask Method_Start_Updates_DueTime()
+        {
+            using IComponentTimer timer = new ComponentTimer(CallbackMethod, dueTime: _1msTimeSpan, period: _1msTimeSpan, state: _testCallback);
+            timer.DueTime.TotalMilliseconds.Should().Be(1);
+            timer.Start(_3msTimeSpan);
+            timer.DueTime.TotalMilliseconds.Should().Be(1);
+            timer.Stop();
+            timer.Start(_3msTimeSpan, true);
+            timer.DueTime.TotalMilliseconds.Should().Be(3);
+            _testCallback.HasExecuted.Should().BeFalse();
+            _testCallback.ExecuteCount.Should().Be(0);
+
+
+            using IComponentTimer timerAsync = new ComponentTimer(CallbackMethodAsync, dueTime: _1msTimeSpan, period: _1msTimeSpan, state: _testCallbackAsync);
+            timerAsync.DueTime.TotalMilliseconds.Should().Be(1);
+            await timerAsync.StartAsync(_3msTimeSpan);
+            timerAsync.DueTime.TotalMilliseconds.Should().Be(1);
+            await timerAsync.StopAsync();
+            await timerAsync.StartAsync(_3msTimeSpan, true);
+            timerAsync.DueTime.TotalMilliseconds.Should().Be(3);
+            _testCallbackAsync.HasExecuted.Should().BeFalse();
+            _testCallbackAsync.ExecuteCount.Should().Be(0);
+        }
+
+
+        [Test]
+        public async ValueTask Method_Stop_MultipleCalls_Return_Last_DateTimeOffset()
+        {
+            using IComponentTimer timer = new ComponentTimer(CallbackMethod, true, period: _1msTimeSpan, state: _testCallback);
+            await Task.Delay(_delayMs);
+            var initialTimestamp = timer.Stop();
+            Console.WriteLine($"{nameof(initialTimestamp)}: {initialTimestamp}");
+            await Task.Delay(_delayMs);
+            var newerTimestamp = timer.Stop();
+            Console.WriteLine($"{nameof(newerTimestamp)}: {newerTimestamp}");
+            newerTimestamp.Should().BeSameDateAs((DateTimeOffset)initialTimestamp);
+
+
+            using IComponentTimer timerAsync = new ComponentTimer(CallbackMethodAsync, true, period: _1msTimeSpan, state: _testCallbackAsync);
+            await Task.Delay(_delayMs);
+            var initialTimestampAsync = await timerAsync.StopAsync();
+            Console.WriteLine($"{nameof(initialTimestampAsync)}: {initialTimestampAsync}");
+            await Task.Delay(_delayMs);
+            var newerTimestampAsync = await timerAsync.StopAsync();
+            Console.WriteLine($"{nameof(newerTimestampAsync)}: {newerTimestampAsync}");
+            newerTimestampAsync.Should().BeSameDateAs((DateTimeOffset)initialTimestampAsync);
+        }
+
+        [Test]
+        public async ValueTask Method_Stop_Sets_Enabled_False()
+        {
+            using IComponentTimer timer = new ComponentTimer(CallbackMethod, true, period: _1msTimeSpan, state: _testCallback);
+            await Task.Delay(_delayMs);
+            timer.Stop();
+            timer.Enabled.Should().BeFalse();
+            _testCallback.HasExecuted.Should().BeTrue();
+            _testCallback.ExecuteCount.Should().BeGreaterThan(0);
+
+
+            using IComponentTimer timerAsync = new ComponentTimer(CallbackMethodAsync, true, period: _1msTimeSpan, state: _testCallbackAsync);
+            await Task.Delay(_delayMs);
+            await timerAsync.StopAsync();
+            timerAsync.Enabled.Should().BeFalse();
+            _testCallbackAsync.HasExecuted.Should().BeTrue();
+            _testCallbackAsync.ExecuteCount.Should().BeGreaterThan(0);
+        }
+
+        [Test]
+        public async ValueTask Method_Stop_TimerNeverRan_Returns_DefaultDateTimeOffset()
+        {
+            using IComponentTimer timer = new ComponentTimer(CallbackMethod, period: _1msTimeSpan, state: _testCallback);
+            timer.Stop().Should().Be(default(DateTimeOffset));
+            _testCallback.HasExecuted.Should().BeFalse();
+            _testCallback.ExecuteCount.Should().Be(0);
+
+
+            using IComponentTimer timerAsync = new ComponentTimer(CallbackMethodAsync, period: _1msTimeSpan, state: _testCallbackAsync);
+            (await timerAsync.StopAsync()).Should().Be(default(DateTimeOffset));
+            _testCallbackAsync.HasExecuted.Should().BeFalse();
+            _testCallbackAsync.ExecuteCount.Should().Be(0);
+        }
+
+        [Test]
+        public async ValueTask Method_Stop_With_Enabled_True()
+        {
+            using IComponentTimer timer = new ComponentTimer(CallbackMethod, true, period: _1msTimeSpan, state: _testCallback);
+            timer.Enabled.Should().BeTrue();
+            await Task.Delay(_delayMs);
+            timer.Stop();
+            timer.Enabled.Should().BeFalse();
+            _testCallback.HasExecuted.Should().BeTrue();
+            _testCallback.ExecuteCount.Should().BeGreaterThan(0);
+
+
+            using IComponentTimer timerAsync = new ComponentTimer(CallbackMethodAsync, true, period: _1msTimeSpan, state: _testCallbackAsync);
+            timerAsync.Enabled.Should().BeTrue();
+            await Task.Delay(_delayMs);
+            await timerAsync.StopAsync();
+            timerAsync.Enabled.Should().BeFalse();
+            _testCallbackAsync.HasExecuted.Should().BeTrue();
+            _testCallbackAsync.ExecuteCount.Should().BeGreaterThan(0);
+        }
+
+
+        [Test]
+        public async ValueTask Method_Restart_Sets_Restarts()
+        {
+            using IComponentTimer timer = new ComponentTimer(CallbackMethod, period: _1msTimeSpan, state: _testCallback);
+            timer.Restarts.Should().Be(0);
+            timer.Restart();
+            timer.Restart();
+            timer.Stop();
+            timer.Restarts.Should().Be(2);
+            timer.Start();
+            await Task.Delay(_delayMs);
+            timer.Stop();
+            timer.Restarts.Should().Be(2);
+            _testCallback.HasExecuted.Should().BeTrue();
+            _testCallback.ExecuteCount.Should().BeGreaterThan(0);
+
+
+            using IComponentTimer timerAsync = new ComponentTimer(CallbackMethodAsync, period: _1msTimeSpan, state: _testCallbackAsync);
+            timerAsync.Restarts.Should().Be(0);
+            await timerAsync.RestartAsync();
+            await timerAsync.RestartAsync();
+            await timerAsync.StopAsync();
+            timerAsync.Restarts.Should().Be(2);
+            await timerAsync.StartAsync();
+            await Task.Delay(_delayMs);
+            await timerAsync.StopAsync();
+            timerAsync.Restarts.Should().Be(2);
+            _testCallbackAsync.HasExecuted.Should().BeTrue();
+            _testCallbackAsync.ExecuteCount.Should().BeGreaterThan(0);
+        }
+
+        [Test]
+        public async ValueTask Method_Restart_With_Enabled_False()
+        {
+            using IComponentTimer timer = new ComponentTimer(CallbackMethod, period: _1msTimeSpan, state: _testCallback);
+            timer.Restart();
+            timer.Enabled.Should().BeTrue();
+            await Task.Delay(_delayMs);
+            _testCallback.HasExecuted.Should().BeTrue();
+            _testCallback.ExecuteCount.Should().BeGreaterThan(0);
+
+
+            using IComponentTimer timerAsync = new ComponentTimer(CallbackMethodAsync, period: _1msTimeSpan, state: _testCallbackAsync);
+            await timerAsync.RestartAsync();
+            timer.Enabled.Should().BeTrue();
+            await Task.Delay(_delayMs);
+            _testCallbackAsync.HasExecuted.Should().BeTrue();
+            _testCallbackAsync.ExecuteCount.Should().BeGreaterThan(0);
+        }
+
+        [Test]
+        public async ValueTask Method_Restart_Updates_DueTime()
+        {
+            using IComponentTimer timer = new ComponentTimer(CallbackMethodAsync, dueTime: _1msTimeSpan, state: _testCallback);
+            timer.DueTime.TotalMilliseconds.Should().Be(1);
+            timer.Restart(_3msTimeSpan);
+            timer.DueTime.TotalMilliseconds.Should().Be(1);
+            timer.Restart(_3msTimeSpan, true);
+            timer.DueTime.TotalMilliseconds.Should().Be(3);
+            _testCallback.HasExecuted.Should().BeFalse();
+            _testCallback.ExecuteCount.Should().Be(0);
+
+
+            using IComponentTimer timerAsync = new ComponentTimer(CallbackMethodAsync, dueTime: _1msTimeSpan, state: _testCallbackAsync);
+            timerAsync.DueTime.TotalMilliseconds.Should().Be(1);
+            await timerAsync.RestartAsync(_3msTimeSpan);
+            timerAsync.DueTime.TotalMilliseconds.Should().Be(1);
+            await timerAsync.RestartAsync(_3msTimeSpan, true);
+            timerAsync.DueTime.TotalMilliseconds.Should().Be(3);
+            _testCallbackAsync.HasExecuted.Should().BeFalse();
+            _testCallbackAsync.ExecuteCount.Should().Be(0);
+        }
+
+
+        [Test]
+        public async ValueTask Method_Dispose()
+        {
+            using IComponentTimer timer = new ComponentTimer(CallbackMethod, state: _testCallback);
+            timer.Dispose();
+            timer.DueTime.Should().Be(Timeout.InfiniteTimeSpan);
+            timer.Period.Should().Be(Timeout.InfiniteTimeSpan);
+            timer.Elapsed.TotalMilliseconds.Should().Be(Timeout.Infinite);
+            timer.Enabled.Should().BeFalse();
+            timer.IsTicking.Should().BeFalse();
+            _testCallback.HasExecuted.Should().BeFalse();
+            _testCallback.ExecuteCount.Should().Be(0);
+
+            using IComponentTimer timerAsync = new ComponentTimer(CallbackMethodAsync, state: _testCallbackAsync);
+            await timerAsync.DisposeAsync();
+            timerAsync.DueTime.Should().Be(Timeout.InfiniteTimeSpan);
+            timerAsync.Period.Should().Be(Timeout.InfiniteTimeSpan);
+            timerAsync.Elapsed.TotalMilliseconds.Should().Be(Timeout.Infinite);
+            timerAsync.Enabled.Should().BeFalse();
+            timerAsync.IsTicking.Should().BeFalse();
+            _testCallbackAsync.HasExecuted.Should().BeFalse();
+            _testCallbackAsync.ExecuteCount.Should().Be(0);
+        }
+
+        [Test]
+        public async ValueTask Method_Dispose_StartedTimer()
+        {
+            var startTimer = true;
+
+            using IComponentTimer timer = new ComponentTimer(CallbackMethod, startTimer, state: _testCallback);
+            timer.Dispose();
+            timer.DueTime.Should().Be(Timeout.InfiniteTimeSpan);
+            timer.Period.Should().Be(Timeout.InfiniteTimeSpan);
+            timer.Elapsed.TotalMilliseconds.Should().Be(Timeout.Infinite);
+            timer.Enabled.Should().BeFalse();
+            timer.IsTicking.Should().BeFalse();
+            timer.Enabled.Should().BeFalse();
+            timer.IsTicking.Should().BeFalse();
+            _testCallback.HasExecuted.Should().BeFalse();
+            _testCallback.ExecuteCount.Should().Be(0);
+
+
+            using IComponentTimer timerAsync = new ComponentTimer(CallbackMethod, startTimer, state: _testCallbackAsync);
+            await timerAsync.DisposeAsync();
+            timerAsync.DueTime.Should().Be(Timeout.InfiniteTimeSpan);
+            timerAsync.Period.Should().Be(Timeout.InfiniteTimeSpan);
+            timerAsync.Elapsed.TotalMilliseconds.Should().Be(Timeout.Infinite);
+            timerAsync.Enabled.Should().BeFalse();
+            timerAsync.IsTicking.Should().BeFalse();
+            timerAsync.Enabled.Should().BeFalse();
+            timerAsync.IsTicking.Should().BeFalse();
+            _testCallbackAsync.HasExecuted.Should().BeFalse();
+            _testCallbackAsync.ExecuteCount.Should().Be(0);
+        }
+    }
+}

--- a/src/MudBlazor/Utilities/ComponentTimer.cs
+++ b/src/MudBlazor/Utilities/ComponentTimer.cs
@@ -1,0 +1,548 @@
+﻿// Copyright © 2021 Jeffrey Jangli
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MudBlazor.Utilities
+{
+    /// <summary>
+    /// Provides a mechanism for executing a method on a thread pool thread at specified intervals.
+    /// </summary>
+    public interface IComponentTimer : IAsyncDisposable, IDisposable
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether the timer is enabled.
+        /// </summary>
+        /// <remarks>
+        /// Setting the value to <c>true</c> is the same as calling the <see cref="Start()"/> method.
+        /// Setting the value to <c>false</c> is the same as calling the <see cref="Stop()"/> method.
+        /// </remarks>
+        /// <returns>
+        /// <c>true</c> if the timer is enabled; otherwise, <c>false</c>.
+        /// </returns>
+        bool Enabled { get; set; }
+
+        /// <summary>
+        /// Gets a value indicating whether the timer is running.
+        /// </summary>
+        /// <remarks>
+        /// <c>true</c> is returned when <see cref="Enabled"/> is <c>true</c> and <see cref="DueTime"/> and <see cref="Period"/> have valid values.
+        /// </remarks>
+        /// <returns>
+        /// A value indicating whether the timer is running.
+        /// </returns>
+        bool IsTicking { get; }
+
+        /// <summary>
+        /// Gets the number of times that the timer was restarted.
+        /// </summary>
+        /// <remarks>
+        /// This information is available even when the timer is already disposed.
+        /// </remarks>
+        /// <returns>
+        /// The number of times that the timer was restarted.
+        /// </returns>
+        int Restarts { get; }
+
+        /// <summary>
+        /// Gets or sets the timer delay before executing the callback method.
+        /// </summary>
+        /// <remarks>
+        /// The timer needs to be restarted to effectuate the new value.
+        /// </remarks>
+        /// <returns>
+        /// The timer delay before executing the callback method.
+        /// </returns>
+        TimeSpan DueTime { get; set; }
+
+        /// <summary>
+        /// Gets or sets the amount of time to wait between subsequent executions.
+        /// </summary>
+        /// <remarks>
+        /// The timer needs to be restarted to effectuate the new value.
+        /// </remarks>
+        /// <returns>
+        /// The amount of time to wait between subsequent executions.
+        /// </returns>
+        TimeSpan Period { get; set; }
+
+        /// <summary>
+        /// Gets the total elapsed time since the timer was last started.
+        /// </summary>
+        /// <returns>
+        /// The total elapsed time since the timer was last started.
+        /// </returns>
+        TimeSpan Elapsed { get; }
+
+
+        /// <summary>
+        /// Starts the timer.
+        /// </summary>
+        /// <remarks>
+        /// The timer will only start when <see cref="Enabled"/> is <c>false</c>.
+        /// Calling this method is the same as setting <see cref="Enabled"/> to <c>true</c>.
+        /// </remarks>
+        /// <returns>
+        /// A UTC <see cref="DateTimeOffset"/> that references a point in time when the timer was started.
+        /// <c>null</c> is returned if the timer failed to start.
+        /// </returns>
+        DateTimeOffset? Start();
+
+        /// <summary>
+        /// Starts the timer specifying a due time (start delay).
+        /// </summary>
+        /// <remarks>
+        /// The timer will only start when <see cref="Enabled"/> is <c>false</c>.
+        /// </remarks>
+        /// <param name="dueTime">The amount of time to delay before invoking the callback method specified when the Timer was constructed, in milliseconds. Specify Infinite to prevent the timer from restarting. Specify zero (0) to restart the timer immediately.</param>
+        /// <param name="update">When <c>true</c> the instance property is updated when the timer is started successfully.</param>
+        /// <returns>
+        /// A UTC <see cref="DateTimeOffset"/> that references a point in time when the timer was started.
+        /// <c>null</c> is returned if the timer failed to start.
+        /// </returns>
+        DateTimeOffset? Start(int dueTime, bool update = false);
+
+        /// <summary>
+        /// Starts the timer specifying a due time (start delay).
+        /// </summary>
+        /// <remarks>
+        /// The timer will only start when <see cref="Enabled"/> is <c>false</c>.
+        /// </remarks>
+        /// <param name="dueTime">The amount of time to delay before invoking the callback method specified when the Timer was constructed, in milliseconds. Specify Infinite to prevent the timer from restarting. Specify zero (0) to restart the timer immediately.</param>
+        /// <param name="update">When <c>true</c> the instance property is updated when the timer is started successfully.</param>
+        /// <returns>
+        /// A UTC <see cref="DateTimeOffset"/> that references a point in time when the timer was started.
+        /// <c>null</c> is returned if the timer failed to start.
+        /// </returns>
+        DateTimeOffset? Start(TimeSpan dueTime, bool update = false);
+
+        /// <summary>
+        /// Asynchronously starts the timer.
+        /// </summary>
+        /// <remarks>
+        /// The timer will only start when <see cref="Enabled"/> is <c>false</c>.
+        /// Calling this method is the same as setting <see cref="Enabled"/> to <c>true</c>.
+        /// </remarks>
+        /// <returns>
+        /// A UTC <see cref="DateTimeOffset"/> that references a point in time when the timer was started.
+        /// <c>null</c> is returned if the timer failed to start.
+        /// </returns>
+        ValueTask<DateTimeOffset?> StartAsync();
+
+        /// <summary>
+        /// Asynchronously starts the timer specifying a due time (start delay).
+        /// </summary>
+        /// <remarks>
+        /// The timer will only start when <see cref="Enabled"/> is <c>false</c>.
+        /// </remarks>
+        /// <param name="dueTime">The amount of time to delay before invoking the callback method specified when the Timer was constructed, in milliseconds. Specify Infinite to prevent the timer from restarting. Specify zero (0) to restart the timer immediately.</param>
+        /// <param name="update">When <c>true</c> the instance property is updated when the timer is started successfully.</param>
+        /// <returns>
+        /// A UTC <see cref="DateTimeOffset"/> that references a point in time when the timer was started.
+        /// <c>null</c> is returned if the timer failed to start.
+        /// </returns>
+        ValueTask<DateTimeOffset?> StartAsync(int dueTime, bool update = false);
+
+        /// <summary>
+        /// Asynchronously starts the timer specifying a due time (start delay).
+        /// </summary>
+        /// <remarks>
+        /// The timer will only start when <see cref="Enabled"/> is <c>false</c>.
+        /// </remarks>
+        /// <param name="dueTime">The amount of time to delay before invoking the callback method specified when the Timer was constructed, in milliseconds. Specify Infinite to prevent the timer from restarting. Specify zero (0) to restart the timer immediately.</param>
+        /// <param name="update">When <c>true</c> the instance property is updated when the timer is started successfully.</param>
+        /// <returns>
+        /// A UTC <see cref="DateTimeOffset"/> that references a point in time when the timer was started.
+        /// <c>null</c> is returned if the timer failed to start.
+        /// </returns>
+        ValueTask<DateTimeOffset?> StartAsync(TimeSpan dueTime, bool update = false);
+
+        /// <summary>
+        /// Stops the timer.
+        /// </summary>
+        /// <remarks>
+        /// The timer will only stop when <see cref="Enabled"/> is <c>true</c>.
+        /// Calling this method is the same as setting the value of <see cref="Enabled"/> to <c>false</c>.
+        /// </remarks>
+        /// <returns>
+        /// A UTC <see cref="DateTimeOffset"/> that references a point in time when the timer was stopped.
+        /// A default <see cref="DateTimeOffset"/> is returned when the timer never ran.
+        /// <c>null</c> is returned if the timer failed to stop.
+        /// </returns>
+        DateTimeOffset? Stop();
+
+        /// <summary>
+        /// Asynchronously stops the timer.
+        /// </summary>
+        /// <remarks>
+        /// The timer will only stop when <see cref="Enabled"/> is <c>true</c>.
+        /// Calling this method is the same as setting the value of <see cref="Enabled"/> to <c>false</c>.
+        /// </remarks>
+        /// <returns>
+        /// A UTC <see cref="DateTimeOffset"/> that references a point in time when the timer was stopped.
+        /// A default <see cref="DateTimeOffset"/> is returned when the timer never ran.
+        /// <c>null</c> is returned if the timer failed to stop.
+        /// </returns>
+        ValueTask<DateTimeOffset?> StopAsync();
+
+        /// <summary>
+        /// Restarts the timer.
+        /// </summary>
+        /// <remarks>
+        /// This method ignores <see cref="Enabled"/> and is always executed.
+        /// </remarks>
+        /// <returns>
+        /// A UTC <see cref="DateTimeOffset"/> that references a point in time when the timer was restarted.
+        /// <c>null</c> is returned if the timer failed to restart.
+        /// </returns>
+        DateTimeOffset? Restart();
+
+        /// <summary>
+        /// Restarts the timer specifying a due time (start delay).
+        /// </summary>
+        /// <remarks>
+        /// This method ignores <see cref="Enabled"/> and is always executed.
+        /// </remarks>
+        /// <param name="dueTime">The amount of time to delay before invoking the callback method specified when the Timer was constructed, in milliseconds. Specify Infinite to prevent the timer from restarting. Specify zero (0) to restart the timer immediately.</param>
+        /// <param name="update">When <c>true</c> the instance property is updated when the timer is started successfully.</param>
+        /// <returns>
+        /// A UTC <see cref="DateTimeOffset"/> that references a point in time when the timer was restarted.
+        /// <c>null</c> is returned if the timer failed to restart.
+        /// </returns>
+        DateTimeOffset? Restart(int dueTime, bool update = false);
+
+        /// <summary>
+        /// Restarts the timer specifying a due time (start delay).
+        /// </summary>
+        /// <remarks>
+        /// This method ignores <see cref="Enabled"/> and is always executed.
+        /// </remarks>
+        /// <param name="dueTime">A <see cref="TimeSpan"/> representing the amount of time to delay before invoking the callback method specified when the Timer was constructed. Specify <see cref="Timeout.InfiniteTimeSpan"/> to prevent the timer from restarting. Specify Zero to restart the timer immediately.</param>
+        /// <param name="update">When <c>true</c> the instance property is updated when the timer is started successfully.</param>
+        /// <returns>
+        /// A UTC <see cref="DateTimeOffset"/> that references a point in time when the timer was restarted.
+        /// <c>null</c> is returned if the timer failed to restart.
+        /// </returns>
+        DateTimeOffset? Restart(TimeSpan dueTime, bool update = false);
+
+        /// <summary>
+        /// Asynchronously restarts the timer.
+        /// </summary>
+        /// <remarks>
+        /// This method ignores <see cref="Enabled"/> and is always executed.
+        /// </remarks>
+        /// <returns>
+        /// A UTC <see cref="DateTimeOffset"/> that references a point in time when the timer was restarted.
+        /// <c>null</c> is returned if the timer failed to restart.
+        /// </returns>
+        ValueTask<DateTimeOffset?> RestartAsync();
+
+        /// <summary>
+        /// Asynchronously restarts the timer specifying a due time (start delay).
+        /// </summary>
+        /// <remarks>
+        /// This method ignores <see cref="Enabled"/> and is always executed.
+        /// </remarks>
+        /// <param name="dueTime">The amount of time to delay before invoking the callback method specified when the Timer was constructed, in milliseconds. Specify Infinite to prevent the timer from restarting. Specify zero (0) to restart the timer immediately.</param>
+        /// <param name="update">When <c>true</c> the instance property is updated when the timer is started successfully.</param>
+        /// <returns>
+        /// A UTC <see cref="DateTimeOffset"/> that references a point in time when the timer was restarted.
+        /// <c>null</c> is returned if the timer failed to restart.
+        /// </returns>
+        ValueTask<DateTimeOffset?> RestartAsync(int dueTime, bool update = false);
+
+        /// <summary>
+        /// Asynchronously restarts the timer specifying a due time (start delay).
+        /// </summary>
+        /// <remarks>
+        /// This method ignores <see cref="Enabled"/> and is always executed.
+        /// </remarks>
+        /// <param name="dueTime">A <see cref="TimeSpan"/> representing the amount of time to delay before invoking the callback method specified when the Timer was constructed. Specify <see cref="Timeout.InfiniteTimeSpan"/> to prevent the timer from restarting. Specify Zero to restart the timer immediately.</param>
+        /// <param name="update">When <c>true</c> the instance property is updated when the timer is started successfully.</param>
+        /// <returns>
+        /// A UTC <see cref="DateTimeOffset"/> that references a point in time when the timer was restarted.
+        /// <c>null</c> is returned if the timer failed to restart.
+        /// </returns>
+        ValueTask<DateTimeOffset?> RestartAsync(TimeSpan dueTime, bool update = false);
+
+        /// <summary>
+        /// Releases all resources used by the current instance of <see cref="IComponentTimer"/>.
+        /// </summary>
+        new void Dispose();
+
+        /// <summary>
+        /// Asynchronously releases all resources used by the current instance of <see cref="IComponentTimer"/>.
+        /// </summary>
+        new ValueTask DisposeAsync();
+    }
+
+
+    /// <summary>
+    /// Provides a mechanism for executing a method on a thread pool thread at specified intervals. This class cannot be inherited.
+    /// </summary>
+    public sealed class ComponentTimer : IComponentTimer
+    {
+        private enum TimerAction { Start, Stop, Restart }
+        private Timer _timer;
+        private long _startUtcTicks;
+        private bool? _enabled;
+        private int _restarts;
+
+
+        private ComponentTimer(TimeSpan? dueTime = null, TimeSpan? period = null)
+        {
+            DueTime = HasStartDelay(dueTime) ? (TimeSpan) dueTime : TimeSpan.Zero;
+            Period = HasInterval(period) ? (TimeSpan)period : TimeSpan.Zero;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ComponentTimer"/> class.
+        /// </summary>
+        /// <param name="callback">A delegate representing a method to be executed.</param>
+        /// <param name="enabled">When <c>true</c>, starts the timer.</param>
+        /// <param name="dueTime">The amount of time to delay before the callback is invoked. The default is <see cref="TimeSpan.Zero"/>).</param>
+        /// <param name="period">The time interval between invocations of callback. The default is <see cref="TimeSpan.Zero"/>.</param>
+        /// <param name="state">An object containing information to be used by the callback method, or <c>null</c>.</param>
+        public ComponentTimer(Action<object> callback, bool enabled = false, TimeSpan? dueTime = null, TimeSpan? period = null, object state = null) : this(dueTime, period)
+        {
+            _timer = new Timer(async (_state) => { await TimerCallbackAsync(callback, _state); }, state, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+
+            if (enabled)
+                Enabled = true;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ComponentTimer"/> class.
+        /// </summary>
+        /// <param name="callback">An async delegate representing a method to be executed.</param>
+        /// <param name="enabled">When <c>true</c>, starts the timer.</param>
+        /// <param name="dueTime">The amount of time to delay before the callback is invoked. The default is <see cref="TimeSpan.Zero"/>).</param>
+        /// <param name="period">The time interval between invocations of callback. The default is <see cref="TimeSpan.Zero"/>.</param>
+        /// <param name="state">An object containing information to be used by the callback method, or <c>null</c>.</param>
+        public ComponentTimer(Func<object, ValueTask> callback, bool enabled = false, TimeSpan? dueTime = null, TimeSpan? period = null, object state = null) : this(dueTime, period)
+        {
+            _timer = new Timer(async (_state) => { await TimerCallbackAsync(callback, _state); }, state, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+
+            if (enabled)
+                Enabled = true;
+        }
+
+
+        public bool Enabled
+        {
+            get => _enabled != null ? _enabled.Value : false;
+            set => _enabled = value ? Start() != null : Stop() == null;
+        }
+
+        public int Restarts => _restarts;
+
+        public TimeSpan DueTime { get; set; }
+
+        public TimeSpan Period { get; set; }
+
+        public TimeSpan Elapsed => _timer == null ? Timeout.InfiniteTimeSpan : GetElapsedUtcTime();
+
+        public bool IsTicking => _timer != null && Enabled && HasStartDelay(DueTime) && HasInterval(Period);
+
+
+        private bool Change(TimerAction timerAction, TimeSpan? dueTime = null, TimeSpan? period = null, bool update = false)
+        {
+            var success = false;
+
+            switch (timerAction)
+            {
+                case TimerAction.Start:
+                    if (!Enabled)
+                    {
+                        dueTime = null != dueTime && HasStartDelay(dueTime) ? dueTime : DueTime;
+
+                        success = HasStartDelay(dueTime) && HasInterval(Period) && _timer != null && _timer.Change(DueTime, Period);
+                        if (success)
+                        {
+                            if (update)
+                                DueTime = (TimeSpan) dueTime;
+
+                            _enabled = true;
+                            _startUtcTicks = GetNowUtcTicks();
+                        }
+                        else
+                            _enabled = null;
+                    }
+                    break;
+
+                case TimerAction.Restart:
+                    _enabled = false;
+
+                    if (null == dueTime)
+                        dueTime = TimeSpan.Zero;
+
+                    success = HasStartDelay(dueTime) && _timer != null && _timer.Change((TimeSpan) dueTime, Timeout.InfiniteTimeSpan);
+                    if (success)
+                    {
+                        if (update)
+                            DueTime = (TimeSpan) dueTime;
+
+                        Interlocked.Increment(ref _restarts);
+
+                        _enabled = true;
+                        _startUtcTicks = GetNowUtcTicks();
+                    }
+                    else
+                        _enabled = null;
+                    break;
+
+                case TimerAction.Stop:
+                    if (Enabled)
+                    {
+                        success = _timer != null && _timer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+                        _enabled = success ? false : null;
+                    }
+                    break;
+            }
+
+            return success;
+        }
+
+
+        public DateTimeOffset? Start() { Change(TimerAction.Start); return GetStartUtcTime(); }
+
+        public DateTimeOffset? Start(int dueTime, bool update = false) { Change(TimerAction.Start, TimeSpan.FromMilliseconds(dueTime), update: update); return GetStartUtcTime(); }
+
+        public DateTimeOffset? Start(TimeSpan dueTime, bool update = false) { Change(TimerAction.Start, dueTime, update: update); return GetStartUtcTime(); }
+
+        public async ValueTask<DateTimeOffset?> StartAsync()
+        {
+            await ValueTask.CompletedTask;
+            return Start();
+        }
+
+        public async ValueTask<DateTimeOffset?> StartAsync(int dueTime, bool update = false)
+        {
+            await ValueTask.CompletedTask;
+            return Start(dueTime, update);
+        }
+
+        public async ValueTask<DateTimeOffset?> StartAsync(TimeSpan dueTime, bool update = false)
+        {
+            await ValueTask.CompletedTask;
+            return Start(dueTime, update);
+        }
+
+
+        public DateTimeOffset? Restart() { Change(TimerAction.Restart); return GetStartUtcTime(); }
+
+        public DateTimeOffset? Restart(int dueTime, bool update = false) { Change(TimerAction.Restart, TimeSpan.FromMilliseconds(dueTime), update: update); return GetStartUtcTime(); }
+
+        public DateTimeOffset? Restart(TimeSpan dueTime, bool update = false) { Change(TimerAction.Restart, dueTime, update: update); return GetStartUtcTime(); }
+
+        public async ValueTask<DateTimeOffset?> RestartAsync()
+        {
+            await ValueTask.CompletedTask;
+            return Restart();
+        }
+
+        public async ValueTask<DateTimeOffset?> RestartAsync(int dueTime, bool update = false)
+        {
+            await ValueTask.CompletedTask;
+            return Restart(dueTime, update);
+        }
+
+        public async ValueTask<DateTimeOffset?> RestartAsync(TimeSpan dueTime, bool update = false)
+        {
+            await ValueTask.CompletedTask;
+            return Restart(dueTime, update);
+        }
+
+
+        public DateTimeOffset? Stop()
+        {
+            var success = Change(TimerAction.Stop);
+
+            if (success)
+                return _startUtcTicks > 0 ? GetStopUtcTime() : default(DateTimeOffset);
+
+            else
+            {
+                var neverRan = _enabled == null && _startUtcTicks == 0;
+
+                return neverRan ? default(DateTimeOffset) : GetStopUtcTime();
+            }
+        }
+
+        public async ValueTask<DateTimeOffset?> StopAsync()
+        {
+            await ValueTask.CompletedTask;
+            return Stop();
+        }
+
+
+        private static async ValueTask TimerCallbackAsync<T>(Action<T> callback, T state) { await ValueTask.CompletedTask; callback.Invoke(state); }
+
+        private static async ValueTask TimerCallbackAsync<T>(Func<T, ValueTask> callback, T state) { await callback.Invoke(state); }
+
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (!disposing) return;
+
+            var timer = _timer;
+            if (timer != null)
+            {
+                DisposeCleanup();
+                timer?.Dispose();
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await DisposeAsync(true);
+            GC.SuppressFinalize(this);
+        }
+
+        private async ValueTask DisposeAsync(bool disposing)
+        {
+            if (!disposing) return;
+
+            var timer = _timer;
+            if (timer != null)
+            {
+                DisposeCleanup();
+                await timer.DisposeAsync();
+            }
+        }
+
+        private void DisposeCleanup()
+        {
+            _enabled = null;
+            _timer = null;
+
+            DueTime = Timeout.InfiniteTimeSpan;
+            Period = Timeout.InfiniteTimeSpan;
+        }
+
+
+        private static bool HasDueTime(TimeSpan? dueTime = null) => dueTime != null && dueTime.Value != Timeout.InfiniteTimeSpan;
+
+        private static bool HasPeriod(TimeSpan? period = null) => period != null && period.Value != Timeout.InfiniteTimeSpan;
+
+        private static bool HasStartDelay(TimeSpan? dueTime = null) => HasDueTime(dueTime) && dueTime.Value.TotalMilliseconds >= 0;
+
+        private static bool HasInterval(TimeSpan? period = null) => HasPeriod(period) && period.Value != TimeSpan.Zero;
+
+
+        private static long GetNowUtcTicks() => DateTime.UtcNow.Ticks;
+
+        private TimeSpan GetElapsedUtcTime() => TimeSpan.FromTicks(_startUtcTicks > 0 ? GetNowUtcTicks() - _startUtcTicks : 0);
+
+        private DateTimeOffset? GetStartUtcTime() => _startUtcTicks > 0 ? new DateTime(_startUtcTicks, DateTimeKind.Utc) : null;
+
+        private static DateTimeOffset? GetStopUtcTime() => new DateTime(GetNowUtcTicks(), DateTimeKind.Utc);
+    }
+}


### PR DESCRIPTION
With this PR I would like to contribute: `ComponentTimer`, a helper class that utilizes the `System.Threading.Threads.Timer` class.
Usage of `System.Threading.Threads.Timer` is simple and the addition of this class is to:

- Make it a bit easier for new components and MudBlazor developers that need a timer;
- Increase consistency in used timer type and implementation;
- Alleviate the necessary plumbing for methods such as `Start()`, `Stop()`, `Restart()` and proper disposal;
- Offer these plumbing-methods as `sync` and `async` methods (although only `DisposeAsync` is truly `async`);
- Implement basic idempotent logic when starting/stopping the timer, e.g.: calling `Start()` repeatedly has no effect;

So far I have tested extensively with `MudCarousel` and `Snackbar` and it all works beautifully.
Next on my list are `MudAutocomplete` and `MudForm`.

That is, of course, if this PR is accepted, I'd really like to hear if you think this helper class is worthwhile.

Finally, I will blatantly post the `IComponentTimer` interface that shows what this class has to offer.


```c#
    /// <summary>
    /// Provides a mechanism for executing a method on a thread pool thread at specified intervals.
    /// </summary>
    public interface IComponentTimer : IAsyncDisposable, IDisposable
    {
        /// <summary>
        /// Gets or sets a value indicating whether the timer is enabled.
        /// </summary>
        /// <remarks>
        /// Setting the value to <c>true</c> is the same as calling the <see cref="Start()"/> method.
        /// Setting the value to <c>false</c> is the same as calling the <see cref="Stop()"/> method.
        /// </remarks>
        /// <returns>
        /// <c>true</c> if the timer is enabled; otherwise, <c>false</c>.
        /// </returns>
        bool Enabled { get; set; }

        /// <summary>
        /// Gets a value indicating whether the timer is running.
        /// </summary>
        /// <remarks>
        /// <c>true</c> is returned when <see cref="Enabled"/> is <c>true</c> and <see cref="DueTime"/> and <see cref="Period"/> have valid values.
        /// </remarks>
        /// <returns>
        /// A value indicating whether the timer is running.
        /// </returns>
        bool IsTicking { get; }

        /// <summary>
        /// Gets the number of times that the timer was restarted.
        /// </summary>
        /// <remarks>
        /// This information is available even when the timer is already disposed.
        /// </remarks>
        /// <returns>
        /// The number of times that the timer was restarted.
        /// </returns>
        int Restarts { get; }

        /// <summary>
        /// Gets or sets the timer delay before executing the callback method.
        /// </summary>
        /// <remarks>
        /// The timer needs to be restarted to effectuate the new value.
        /// </remarks>
        /// <returns>
        /// The timer delay before executing the callback method.
        /// </returns>
        TimeSpan DueTime { get; set; }

        /// <summary>
        /// Gets or sets the amount of time to wait between subsequent executions.
        /// </summary>
        /// <remarks>
        /// The timer needs to be restarted to effectuate the new value.
        /// </remarks>
        /// <returns>
        /// The amount of time to wait between subsequent executions.
        /// </returns>
        TimeSpan Period { get; set; }

        /// <summary>
        /// Gets the total elapsed time since the timer was last started.
        /// </summary>
        /// <returns>
        /// The total elapsed time since the timer was last started.
        /// </returns>
        TimeSpan Elapsed { get; }


        /// <summary>
        /// Starts the timer.
        /// </summary>
        /// <remarks>
        /// The timer will only start when <see cref="Enabled"/> is <c>false</c>.
        /// Calling this method is the same as setting <see cref="Enabled"/> to <c>true</c>.
        /// </remarks>
        /// <returns>
        /// A UTC <see cref="DateTimeOffset"/> that references a point in time when the timer was started.
        /// <c>null</c> is returned if the timer failed to start.
        /// </returns>
        DateTimeOffset? Start();

        /// <summary>
        /// Starts the timer specifying a due time (start delay).
        /// </summary>
        /// <remarks>
        /// The timer will only start when <see cref="Enabled"/> is <c>false</c>.
        /// </remarks>
        /// <param name="dueTime">The amount of time to delay before invoking the callback method specified when the Timer was constructed, in milliseconds. Specify Infinite to prevent the timer from restarting. Specify zero (0) to restart the timer immediately.</param>
        /// <param name="update">When <c>true</c> the instance property is updated when the timer is started successfully.</param>
        /// <returns>
        /// A UTC <see cref="DateTimeOffset"/> that references a point in time when the timer was started.
        /// <c>null</c> is returned if the timer failed to start.
        /// </returns>
        DateTimeOffset? Start(int dueTime, bool update = false);

        /// <summary>
        /// Starts the timer specifying a due time (start delay).
        /// </summary>
        /// <remarks>
        /// The timer will only start when <see cref="Enabled"/> is <c>false</c>.
        /// </remarks>
        /// <param name="dueTime">The amount of time to delay before invoking the callback method specified when the Timer was constructed, in milliseconds. Specify Infinite to prevent the timer from restarting. Specify zero (0) to restart the timer immediately.</param>
        /// <param name="update">When <c>true</c> the instance property is updated when the timer is started successfully.</param>
        /// <returns>
        /// A UTC <see cref="DateTimeOffset"/> that references a point in time when the timer was started.
        /// <c>null</c> is returned if the timer failed to start.
        /// </returns>
        DateTimeOffset? Start(TimeSpan dueTime, bool update = false);

        /// <summary>
        /// Asynchronously starts the timer.
        /// </summary>
        /// <remarks>
        /// The timer will only start when <see cref="Enabled"/> is <c>false</c>.
        /// Calling this method is the same as setting <see cref="Enabled"/> to <c>true</c>.
        /// </remarks>
        /// <returns>
        /// A UTC <see cref="DateTimeOffset"/> that references a point in time when the timer was started.
        /// <c>null</c> is returned if the timer failed to start.
        /// </returns>
        ValueTask<DateTimeOffset?> StartAsync();

        /// <summary>
        /// Asynchronously starts the timer specifying a due time (start delay).
        /// </summary>
        /// <remarks>
        /// The timer will only start when <see cref="Enabled"/> is <c>false</c>.
        /// </remarks>
        /// <param name="dueTime">The amount of time to delay before invoking the callback method specified when the Timer was constructed, in milliseconds. Specify Infinite to prevent the timer from restarting. Specify zero (0) to restart the timer immediately.</param>
        /// <param name="update">When <c>true</c> the instance property is updated when the timer is started successfully.</param>
        /// <returns>
        /// A UTC <see cref="DateTimeOffset"/> that references a point in time when the timer was started.
        /// <c>null</c> is returned if the timer failed to start.
        /// </returns>
        ValueTask<DateTimeOffset?> StartAsync(int dueTime, bool update = false);

        /// <summary>
        /// Asynchronously starts the timer specifying a due time (start delay).
        /// </summary>
        /// <remarks>
        /// The timer will only start when <see cref="Enabled"/> is <c>false</c>.
        /// </remarks>
        /// <param name="dueTime">The amount of time to delay before invoking the callback method specified when the Timer was constructed, in milliseconds. Specify Infinite to prevent the timer from restarting. Specify zero (0) to restart the timer immediately.</param>
        /// <param name="update">When <c>true</c> the instance property is updated when the timer is started successfully.</param>
        /// <returns>
        /// A UTC <see cref="DateTimeOffset"/> that references a point in time when the timer was started.
        /// <c>null</c> is returned if the timer failed to start.
        /// </returns>
        ValueTask<DateTimeOffset?> StartAsync(TimeSpan dueTime, bool update = false);

        /// <summary>
        /// Stops the timer.
        /// </summary>
        /// <remarks>
        /// The timer will only stop when <see cref="Enabled"/> is <c>true</c>.
        /// Calling this method is the same as setting the value of <see cref="Enabled"/> to <c>false</c>.
        /// </remarks>
        /// <returns>
        /// A UTC <see cref="DateTimeOffset"/> that references a point in time when the timer was stopped.
        /// A default <see cref="DateTimeOffset"/> is returned when the timer never ran.
        /// <c>null</c> is returned if the timer failed to stop.
        /// </returns>
        DateTimeOffset? Stop();

        /// <summary>
        /// Asynchronously stops the timer.
        /// </summary>
        /// <remarks>
        /// The timer will only stop when <see cref="Enabled"/> is <c>true</c>.
        /// Calling this method is the same as setting the value of <see cref="Enabled"/> to <c>false</c>.
        /// </remarks>
        /// <returns>
        /// A UTC <see cref="DateTimeOffset"/> that references a point in time when the timer was stopped.
        /// A default <see cref="DateTimeOffset"/> is returned when the timer never ran.
        /// <c>null</c> is returned if the timer failed to stop.
        /// </returns>
        ValueTask<DateTimeOffset?> StopAsync();

        /// <summary>
        /// Restarts the timer.
        /// </summary>
        /// <remarks>
        /// This method ignores <see cref="Enabled"/> and is always executed.
        /// </remarks>
        /// <returns>
        /// A UTC <see cref="DateTimeOffset"/> that references a point in time when the timer was restarted.
        /// <c>null</c> is returned if the timer failed to restart.
        /// </returns>
        DateTimeOffset? Restart();

        /// <summary>
        /// Restarts the timer specifying a due time (start delay).
        /// </summary>
        /// <remarks>
        /// This method ignores <see cref="Enabled"/> and is always executed.
        /// </remarks>
        /// <param name="dueTime">The amount of time to delay before invoking the callback method specified when the Timer was constructed, in milliseconds. Specify Infinite to prevent the timer from restarting. Specify zero (0) to restart the timer immediately.</param>
        /// <param name="update">When <c>true</c> the instance property is updated when the timer is started successfully.</param>
        /// <returns>
        /// A UTC <see cref="DateTimeOffset"/> that references a point in time when the timer was restarted.
        /// <c>null</c> is returned if the timer failed to restart.
        /// </returns>
        DateTimeOffset? Restart(int dueTime, bool update = false);

        /// <summary>
        /// Restarts the timer specifying a due time (start delay).
        /// </summary>
        /// <remarks>
        /// This method ignores <see cref="Enabled"/> and is always executed.
        /// </remarks>
        /// <param name="dueTime">A <see cref="TimeSpan"/> representing the amount of time to delay before invoking the callback method specified when the Timer was constructed. Specify <see cref="Timeout.InfiniteTimeSpan"/> to prevent the timer from restarting. Specify Zero to restart the timer immediately.</param>
        /// <param name="update">When <c>true</c> the instance property is updated when the timer is started successfully.</param>
        /// <returns>
        /// A UTC <see cref="DateTimeOffset"/> that references a point in time when the timer was restarted.
        /// <c>null</c> is returned if the timer failed to restart.
        /// </returns>
        DateTimeOffset? Restart(TimeSpan dueTime, bool update = false);

        /// <summary>
        /// Asynchronously restarts the timer.
        /// </summary>
        /// <remarks>
        /// This method ignores <see cref="Enabled"/> and is always executed.
        /// </remarks>
        /// <returns>
        /// A UTC <see cref="DateTimeOffset"/> that references a point in time when the timer was restarted.
        /// <c>null</c> is returned if the timer failed to restart.
        /// </returns>
        ValueTask<DateTimeOffset?> RestartAsync();

        /// <summary>
        /// Asynchronously restarts the timer specifying a due time (start delay).
        /// </summary>
        /// <remarks>
        /// This method ignores <see cref="Enabled"/> and is always executed.
        /// </remarks>
        /// <param name="dueTime">The amount of time to delay before invoking the callback method specified when the Timer was constructed, in milliseconds. Specify Infinite to prevent the timer from restarting. Specify zero (0) to restart the timer immediately.</param>
        /// <param name="update">When <c>true</c> the instance property is updated when the timer is started successfully.</param>
        /// <returns>
        /// A UTC <see cref="DateTimeOffset"/> that references a point in time when the timer was restarted.
        /// <c>null</c> is returned if the timer failed to restart.
        /// </returns>
        ValueTask<DateTimeOffset?> RestartAsync(int dueTime, bool update = false);

        /// <summary>
        /// Asynchronously restarts the timer specifying a due time (start delay).
        /// </summary>
        /// <remarks>
        /// This method ignores <see cref="Enabled"/> and is always executed.
        /// </remarks>
        /// <param name="dueTime">A <see cref="TimeSpan"/> representing the amount of time to delay before invoking the callback method specified when the Timer was constructed. Specify <see cref="Timeout.InfiniteTimeSpan"/> to prevent the timer from restarting. Specify Zero to restart the timer immediately.</param>
        /// <param name="update">When <c>true</c> the instance property is updated when the timer is started successfully.</param>
        /// <returns>
        /// A UTC <see cref="DateTimeOffset"/> that references a point in time when the timer was restarted.
        /// <c>null</c> is returned if the timer failed to restart.
        /// </returns>
        ValueTask<DateTimeOffset?> RestartAsync(TimeSpan dueTime, bool update = false);

        /// <summary>
        /// Releases all resources used by the current instance of <see cref="IComponentTimer"/>.
        /// </summary>
        new void Dispose();

        /// <summary>
        /// Asynchronously releases all resources used by the current instance of <see cref="IComponentTimer"/>.
        /// </summary>
        new ValueTask DisposeAsync();
    }

```