### PR TITLE
Changed method MudPortal.OnWindowResize to async to avoid Task.Run

### DIFF
--- a/src/MudBlazor/Components/Portal/MudPortal.razor.cs
+++ b/src/MudBlazor/Components/Portal/MudPortal.razor.cs
@@ -73,14 +73,11 @@ namespace MudBlazor
         /// <summary>
         /// If the window is resized, calculate the new coordinates of the PortalItem
         /// </summary>
-        private void OnWindowResize(object sender, BrowserWindowSize e)
+        private async void OnWindowResize(object sender, BrowserWindowSize e)
         {
             if (!IsRendered) return;
-            Task.Run(async () =>
-            {
-                await ConfigurePortalItem();
-                Portal.AddOrUpdate(_portalItem);
-            });
+            await ConfigurePortalItem();
+            Portal.AddOrUpdate(_portalItem);
         }
 
         protected virtual void Dispose(bool disposing)


### PR DESCRIPTION
This PR changes changes method `MudPortal.OnWindowResize()` to `async void` (which is allowed for events),
in order to prevent the usage of `Task.Run()`, which is not recommended in single thread scenario's.