### PR TITLE
Changed method ResizeListenerService.Start to async to avoid Task.Run

### DIFF
--- a/src/MudBlazor/Services/ResizeListener/ResizeListenerService.cs
+++ b/src/MudBlazor/Services/ResizeListener/ResizeListenerService.cs
@@ -72,11 +72,11 @@ namespace MudBlazor.Services
         }
 #nullable disable
 
-        private void Start()
+        private async void Start()
         {
             if (_onResized == null || _onBreakpointChanged == null)
             {
-                _ = Task.Run(async () => await _jsRuntime.InvokeVoidAsync($"mudResizeListener.listenForResize", _dotNetRef, _options));
+                await _jsRuntime.InvokeVoidAsync($"mudResizeListener.listenForResize", _dotNetRef, _options);
             }
         }
 


### PR DESCRIPTION
This PR changes changes method `ResizeListenerService.Start()` to `async void` (which is allowed for events),
in order to prevent the usage of `Task.Run()`, which is not recommended in single thread scenario's.