### PR TITLE
Changed method ScrollListener.Subscribe to async to avoid Task.Run

### DIFF
--- a/src/MudBlazor/Services/Scroll/ScrollListener.cs
+++ b/src/MudBlazor/Services/Scroll/ScrollListener.cs
@@ -46,7 +46,7 @@ namespace MudBlazor
         }
 
 
-        private void Subscribe(EventHandler<ScrollEventArgs> value)
+        private async void Subscribe(EventHandler<ScrollEventArgs> value)
         {
             if (_onScroll == null)
             {

--- a/src/MudBlazor/Services/Scroll/ScrollListener.cs
+++ b/src/MudBlazor/Services/Scroll/ScrollListener.cs
@@ -50,7 +50,7 @@ namespace MudBlazor
         {
             if (_onScroll == null)
             {
-                Task.Run(async () => await Start());
+                await Start();
             }
             _onScroll += value;
         }


### PR DESCRIPTION
This PR changes changes method `ScrollListener.Subscribe()` to `async void` (which is allowed for events),
in order to prevent the usage of `Task.Run()`, which is not recommended in single thread scenario's.
