### PR TITLE
MudTabs: HiddenLayout option

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsHiddenLayoutExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsHiddenLayoutExample.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudTabs Invisible="invisibleTabs" PanelClass="pa-6" @ref="tabs" Style="@TabsStyle" Elevation="2" Rounded="true" ApplyEffectsToContainer="true">
+<MudTabs HiddenLayout="hiddenLayout" PanelClass="pa-6" @ref="tabs" Style="@TabsStyle" Elevation="2" Rounded="true" ApplyEffectsToContainer="true">
     <MudTabPanel Text="Tab 1" OnClick="() => Activate(0)">
         <div style="display: flex; align-items: center; justify-content: space-around; height: 80px;">
             <div style="min-width: 400px;">
@@ -25,7 +25,7 @@
 </MudTabs>
 
 <div class="mt-2 mb-2">
-    <MudSwitch @bind-Checked="@invisibleTabs" Label="Invisible Tabs and TabPanels" Color="Color.Info" />
+    <MudSwitch @bind-Checked="@hiddenLayout" Label="Hide the layout of the Tabs and the Tab Panels" Color="Color.Info" />
 </div>
 
 <MudText GutterBottom="true" Align="Align.Center" Class="mt-4"><b>Select the tab</b></MudText>
@@ -37,7 +37,7 @@
 
 @code { 
     private MudTabs tabs;
-    private bool invisibleTabs = true;
+    private bool hiddenLayout = true;
     private string TabsStyle = "background-color: #F4F4F4;";
     private string text = "I am on TabPanel 1 and I am a TextField!";
 

--- a/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsInvisibleExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsInvisibleExample.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudTabs Invisible="invisibleTabs" PanelClass="pa-6" @ref="tabs" Style="@TabsStyle">
+<MudTabs Invisible="invisibleTabs" PanelClass="pa-6" @ref="tabs" Style="@TabsStyle" Elevation="2" Rounded="true" ApplyEffectsToContainer="true">
     <MudTabPanel Text="Tab 1" OnClick="() => Activate(0)">
         <div style="display: flex; align-items: center; justify-content: space-around; height: 80px;">
             <div style="min-width: 400px;">

--- a/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsInvisibleExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsInvisibleExample.razor
@@ -1,0 +1,60 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudTabs Invisible="invisibleTabs" PanelClass="pa-6" @ref="tabs" Style="@TabsStyle">
+    <MudTabPanel Text="Tab 1" OnClick="() => Activate(0)">
+        <div style="display: flex; align-items: center; justify-content: space-around; height: 80px;">
+            <div style="min-width: 400px;">
+                <MudTextField T="string" @bind-Text="@text" Variant="Variant.Text"
+                 Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.BeachAccess" AdornmentColor="Color.Surface"/>
+            </div>
+            <MudAvatar Variant="Variant.Filled">1</MudAvatar>
+        </div>
+    </MudTabPanel>
+    <MudTabPanel Text="Tab 2" OnClick="() => Activate(1)">
+        <div style="display: flex; align-items: center; justify-content: space-around; height: 80px;">
+            <MudCheckBox T="bool" Label="I am on TabPanel 2 and I am a Checkbox!" Color="Color.Info" Style="color: #467FE2;" Checked="true"/>
+            <MudAvatar Variant="Variant.Filled" Color="Color.Info">2</MudAvatar>
+        </div>
+    </MudTabPanel>
+    <MudTabPanel Text="Tab 3" OnClick="() => Activate(2)">
+        <div style="display: flex; align-items: center; justify-content: space-around; height: 80px;">
+            <MudSwitch T="bool" Label="I am on TabPanel  3 and I am a Switch!" Color="Color.Success" Style="color: #51A288;" Checked="true"/>
+            <MudAvatar Variant="Variant.Filled" Color="Color.Success">3</MudAvatar>
+        </div>
+    </MudTabPanel>
+</MudTabs>
+
+<div class="mt-2 mb-2">
+    <MudSwitch @bind-Checked="@invisibleTabs" Label="Invisible Tabs and TabPanels" Color="Color.Info" />
+</div>
+
+<MudText GutterBottom="true" Align="Align.Center" Class="mt-4"><b>Select the tab</b></MudText>
+<div class="d-flex justify-center">
+    <MudButton Variant="@Variant.Filled" Color="Color.Default" OnClick="() => Activate(0)">Tab 1</MudButton>
+    <MudButton Variant="@Variant.Filled" Color="Color.Info" OnClick="() => Activate(1)" Class="mx-2">Tab 2</MudButton>
+    <MudButton Variant="@Variant.Filled" Color="Color.Success" OnClick="() => Activate(2)">Tab 3</MudButton>
+</div>
+
+@code { 
+    private MudTabs tabs;
+    private bool invisibleTabs = true;
+    private string TabsStyle = "background-color: #F4F4F4;";
+    private string text = "I am on TabPanel 1 and I am a TextField!";
+
+    void Activate(int index)
+    {
+        switch (index)
+        {
+            case 0:
+                TabsStyle = "background-color: #F4F4F4;";
+                break;
+            case 1:
+                TabsStyle = "background-color: #F3F9FE;";
+                break;
+            case 2:
+                TabsStyle = "background-color: #F0FCF5;";
+                break;
+        };
+        tabs.ActivatePanel(index);
+    }
+}

--- a/src/MudBlazor.Docs/Pages/Components/Tabs/TabsPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/TabsPage.razor
@@ -75,6 +75,17 @@
             <SectionSource Code="TabsToolTipExample" GitHubFolderName="Tabs" />
         </DocsPageSection>
         <DocsPageSection>
+            <SectionHeader Title="Invisible Tabs">
+                <Description>
+                    Sstting the <CodeInline>Invisible</CodeInline> property to <CodeInline>true</CodeInline> will hide the Tabs and the TabPanels.
+                </Description>
+            </SectionHeader>
+            <SectionContent Outlined="true" FullWidth="true">
+                <TabsInvisibleExample />
+            </SectionContent>
+            <SectionSource Code="TabsInvisibleExample" GitHubFolderName="Tabs" />
+        </DocsPageSection>
+        <DocsPageSection>
             <SectionHeader Title="Set Active Panel">
             </SectionHeader>
             <SectionContent Outlined="true" FullWidth="true">
@@ -99,17 +110,17 @@
             </SectionContent>
             <SectionSource Code="DynamicTabsSimpleExample" GitHubFolderName="Tabs" ShowCode="false" />
         </DocsPageSection>
-		 <DocsPageSection>
+        <DocsPageSection>
             <SectionHeader Title="Advanced Dynamic Tabs">
                 <Description>
-					<MudText Typo="Typo.body2">
-						Allthough MudDynamicTabs allows a basic browser like tab experience, the way the style can be influenced is limited 
-					</MudText>
-					<MudText Typo="Typo.body2">
-						 The Property Header and TabPanelHeader allows you to add any RenderFragement to the tab (Header) 
-						 and to each tab panel (TabPanelHeader). The placement can be influenced by setting values to HeaderPosition or TabPanelHeaderPosition
-					</MudText>
-				</Description>
+                    <MudText Typo="Typo.body2">
+                        Allthough MudDynamicTabs allows a basic browser like tab experience, the way the style can be influenced is limited
+                    </MudText>
+                    <MudText Typo="Typo.body2">
+                        The Property Header and TabPanelHeader allows you to add any RenderFragement to the tab (Header)
+                        and to each tab panel (TabPanelHeader). The placement can be influenced by setting values to HeaderPosition or TabPanelHeaderPosition
+                    </MudText>
+                </Description>
             </SectionHeader>
             <SectionContent Outlined="true" FullWidth="true" Class="demo-tabs">
                 <CustomDynamicTabsExample />

--- a/src/MudBlazor.Docs/Pages/Components/Tabs/TabsPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/TabsPage.razor
@@ -77,7 +77,7 @@
         <DocsPageSection>
             <SectionHeader Title="Invisible Tabs">
                 <Description>
-                    Sstting the <CodeInline>Invisible</CodeInline> property to <CodeInline>true</CodeInline> will hide the Tabs and the TabPanels.
+                    Setting the <CodeInline>Invisible</CodeInline> property to <CodeInline>true</CodeInline> will hide the Tabs and the TabPanels.
                 </Description>
             </SectionHeader>
             <SectionContent Outlined="true" FullWidth="true">

--- a/src/MudBlazor.Docs/Pages/Components/Tabs/TabsPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/TabsPage.razor
@@ -77,7 +77,7 @@
         <DocsPageSection>
             <SectionHeader Title="Invisible Tabs">
                 <Description>
-                    Setting the <CodeInline>Invisible</CodeInline> property to <CodeInline>true</CodeInline> will hide the Tabs and the TabPanels.
+                    By setting the <CodeInline>Invisible</CodeInline> property to <CodeInline>true</CodeInline>, the layout of the Tabs and the Tab Panels will be hidden.
                 </Description>
             </SectionHeader>
             <SectionContent Outlined="true" FullWidth="true">

--- a/src/MudBlazor.Docs/Pages/Components/Tabs/TabsPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/TabsPage.razor
@@ -75,15 +75,15 @@
             <SectionSource Code="TabsToolTipExample" GitHubFolderName="Tabs" />
         </DocsPageSection>
         <DocsPageSection>
-            <SectionHeader Title="Invisible Tabs">
+            <SectionHeader Title="Tabs with hidden layout">
                 <Description>
-                    By setting the <CodeInline>Invisible</CodeInline> property to <CodeInline>true</CodeInline>, the layout of the Tabs and the Tab Panels will be hidden.
+                    By setting the <CodeInline>HiddenLayout</CodeInline> property to <CodeInline>true</CodeInline>, the layout of the Tabs and the Tab Panels will be hidden.
                 </Description>
             </SectionHeader>
             <SectionContent Outlined="true" FullWidth="true">
-                <TabsInvisibleExample />
+                <TabsHiddenLayoutExample />
             </SectionContent>
-            <SectionSource Code="TabsInvisibleExample" GitHubFolderName="Tabs" />
+            <SectionSource Code="TabsHiddenLayoutExample" GitHubFolderName="Tabs" />
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader Title="Set Active Panel">

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor
@@ -22,7 +22,7 @@
                         @foreach (MudTabPanel panel in _panels)
                         {
                             <MudTooltip Placement="@GetTooltipPlacement()" Text="@panel.ToolTip">
-                                <div @ref="panel.PanelRef" class="@GetTabClass(panel)" style="@GetTabStyle(panel)" @onclick=@(e => ActivatePanel(panel, e, false) )>
+                                <div @ref="panel.PanelRef" class="@GetTabClass(panel)" style="@GetTabStyle(panel)" @onclick=@(e => ActivatePanelClick(panel, e, false))>
                                     @if(TabPanelHeaderPosition == TabHeaderPosition.Before && TabPanelHeader != null)
                                     {
                                         <div class="mud-tabs-panel-header mud-tabs-panel-header-before">

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor
@@ -5,13 +5,13 @@
     <CascadingValue Value="this" IsFixed="true">
         <div class="@ToolbarClassnames">
             <div class="mud-tabs-toolbar-inner" style="@MaxHeightStyles">
-                @if(HeaderPosition == TabHeaderPosition.Before && Header != null)
+                @if(HeaderPosition == TabHeaderPosition.Before && Header != null && !Invisible)
                 {
                     <div class="mud-tabs-header mud-tabs-header-before">
                        @Header(this)
                     </div>
                 }
-                @if(_showScrollButtons)
+                @if(_showScrollButtons && !Invisible)
                 {
                     <div class="mud-tabs-scroll-button">
                         <MudIconButton Icon="@_prevIcon" Color="@ScrollIconColor" OnClick="@((e) => ScrollPrev())" Disabled="@_prevButtonDisabled" />
@@ -22,29 +22,32 @@
                         @foreach (MudTabPanel panel in _panels)
                         {
                             <MudTooltip Placement="@GetTooltipPlacement()" Text="@panel.ToolTip">
-                                <div @ref="panel.PanelRef" class="@GetTabClass(panel)" style="@GetTabStyle(panel)" @onclick=@( e => ActivatePanel(panel, e, false) )>
+                                <div @ref="panel.PanelRef" class="@GetTabClass(panel)" style="@GetTabStyle(panel)" @onclick=@(e => ActivatePanel(panel, e, false) )>
                                     @if(TabPanelHeaderPosition == TabHeaderPosition.Before && TabPanelHeader != null)
                                     {
                                         <div class="mud-tabs-panel-header mud-tabs-panel-header-before">
                                             @TabPanelHeader(panel)
                                         </div>
                                     }
-                                    @if (!String.IsNullOrEmpty(panel.Text) && String.IsNullOrEmpty(panel.Icon))
+                                    @if (!Invisible)
                                     {
-                                        @((MarkupString)panel.Text)
-                                    }
-                                    else if (String.IsNullOrEmpty(panel.Text) && !String.IsNullOrEmpty(panel.Icon))
-                                    {
-                                        <MudIcon Icon="@panel.Icon" Color="@IconColor" />
-                                    }
-                                    else if (!String.IsNullOrEmpty(panel.Text) && !String.IsNullOrEmpty(panel.Icon))
-                                    {
-                                        <MudIcon Icon="@panel.Icon" Color="@IconColor" Class="mud-tab-icon-text" />
-                                        @((MarkupString)panel.Text)
-                                    }
-                                    @if (panel.BadgeData != null || panel.BadgeDot)
-                                    {
-                                        <MudBadge Dot="@panel.BadgeDot" Content="@panel.BadgeData" Color="@panel.BadgeColor" Class="mud-tab-badge" />
+                                        @if (!String.IsNullOrEmpty(panel.Text) && String.IsNullOrEmpty(panel.Icon))
+                                        {
+                                            @((MarkupString)panel.Text)
+                                        }
+                                        else if (String.IsNullOrEmpty(panel.Text) && !String.IsNullOrEmpty(panel.Icon))
+                                        {
+                                            <MudIcon Icon="@panel.Icon" Color="@IconColor" />
+                                        }
+                                        else if (!String.IsNullOrEmpty(panel.Text) && !String.IsNullOrEmpty(panel.Icon))
+                                        {
+                                            <MudIcon Icon="@panel.Icon" Color="@IconColor" Class="mud-tab-icon-text" />
+                                            @((MarkupString)panel.Text)
+                                        }
+                                        @if (panel.BadgeData != null || panel.BadgeDot)
+                                        {
+                                            <MudBadge Dot="@panel.BadgeDot" Content="@panel.BadgeData" Color="@panel.BadgeColor" Class="mud-tab-badge" />
+                                        }
                                     }
                                     @if(TabPanelHeaderPosition == TabHeaderPosition.After && TabPanelHeader != null)
                                     {
@@ -55,19 +58,19 @@
                                 </div>
                             </MudTooltip>
                         }
-                        @if (!HideSlider)
+                        @if (!HideSlider && !Invisible)
                         {
                             <div class="@SliderClass" style="@SliderStyle"></div>
                         }
                     </div>
                 </div>
-                @if(_showScrollButtons)
+                @if(_showScrollButtons && !Invisible)
                 {
                     <div class="mud-tabs-scroll-button">
                         <MudIconButton Icon="@_nextIcon" Color="@ScrollIconColor" OnClick="@((e) => ScrollNext())" Disabled="@_nextButtonDisabled" />
                     </div>
                 }
-                @if(HeaderPosition == TabHeaderPosition.After && Header != null)
+                @if(HeaderPosition == TabHeaderPosition.After && Header != null && !Invisible)
                 {
                     <div class="mud-tabs-header mud-tabs-header-after">
                         @Header(this)

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor
@@ -5,13 +5,13 @@
     <CascadingValue Value="this" IsFixed="true">
         <div class="@ToolbarClassnames">
             <div class="mud-tabs-toolbar-inner" style="@MaxHeightStyles">
-                @if(HeaderPosition == TabHeaderPosition.Before && Header != null && !Invisible)
+                @if(HeaderPosition == TabHeaderPosition.Before && Header != null && !HiddenLayout)
                 {
                     <div class="mud-tabs-header mud-tabs-header-before">
                        @Header(this)
                     </div>
                 }
-                @if(_showScrollButtons && !Invisible)
+                @if(_showScrollButtons && !HiddenLayout)
                 {
                     <div class="mud-tabs-scroll-button">
                         <MudIconButton Icon="@_prevIcon" Color="@ScrollIconColor" OnClick="@((e) => ScrollPrev())" Disabled="@_prevButtonDisabled" />
@@ -29,7 +29,7 @@
                                             @TabPanelHeader(panel)
                                         </div>
                                     }
-                                    @if (!Invisible)
+                                    @if (!HiddenLayout)
                                     {
                                         @if (!String.IsNullOrEmpty(panel.Text) && String.IsNullOrEmpty(panel.Icon))
                                         {
@@ -58,19 +58,19 @@
                                 </div>
                             </MudTooltip>
                         }
-                        @if (!HideSlider && !Invisible)
+                        @if (!HideSlider && !HiddenLayout)
                         {
                             <div class="@SliderClass" style="@SliderStyle"></div>
                         }
                     </div>
                 </div>
-                @if(_showScrollButtons && !Invisible)
+                @if(_showScrollButtons && !HiddenLayout)
                 {
                     <div class="mud-tabs-scroll-button">
                         <MudIconButton Icon="@_nextIcon" Color="@ScrollIconColor" OnClick="@((e) => ScrollNext())" Disabled="@_nextButtonDisabled" />
                     </div>
                 }
-                @if(HeaderPosition == TabHeaderPosition.After && Header != null && !Invisible)
+                @if(HeaderPosition == TabHeaderPosition.After && Header != null && !HiddenLayout)
                 {
                     <div class="mud-tabs-header mud-tabs-header-after">
                         @Header(this)

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -308,6 +308,12 @@ namespace MudBlazor
             StateHasChanged();
         }
 
+        private void ActivatePanelClick(MudTabPanel panel, MouseEventArgs ev, bool ignoreDisabledState = false)
+        {
+            if (!Invisible)
+                ActivatePanel(panel, ev, ignoreDisabledState);
+        }
+
         public void ActivatePanel(MudTabPanel panel, bool ignoreDisabledState = false)
         {
             ActivatePanel(panel, null, ignoreDisabledState);

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -43,9 +43,9 @@ namespace MudBlazor
         [Parameter] public bool Rounded { get; set; }
 
         /// <summary>
-        /// Show or hide the tabs and the tabPanels. They are shown by default.
+        /// Show or hide the layouts of the tabs and the tabPanels. They are shown by default.
         /// </summary>
-        [Parameter] public bool Invisible { get; set; }
+        [Parameter] public bool HiddenLayout { get; set; }
 
         /// <summary>
         /// If true, sets a border betwen the content and the toolbar depending on the position.
@@ -310,7 +310,7 @@ namespace MudBlazor
 
         private void ActivatePanelClick(MudTabPanel panel, MouseEventArgs ev, bool ignoreDisabledState = false)
         {
-            if (!Invisible)
+            if (!HiddenLayout)
                 ActivatePanel(panel, ev, ignoreDisabledState);
         }
 
@@ -354,9 +354,9 @@ namespace MudBlazor
 
         protected string TabsClassnames =>
             new CssBuilder("mud-tabs")
-            .AddClass($"mud-tabs-rounded", ApplyEffectsToContainer && Rounded & !Invisible)
-            .AddClass($"mud-paper-outlined", ApplyEffectsToContainer && Outlined & !Invisible)
-            .AddClass($"mud-elevation-{Elevation}", ApplyEffectsToContainer && Elevation != 0 & !Invisible)
+            .AddClass($"mud-tabs-rounded", ApplyEffectsToContainer && Rounded & !HiddenLayout)
+            .AddClass($"mud-paper-outlined", ApplyEffectsToContainer && Outlined & !HiddenLayout)
+            .AddClass($"mud-elevation-{Elevation}", ApplyEffectsToContainer && Elevation != 0 & !HiddenLayout)
             .AddClass($"mud-tabs-reverse", Position == Position.Bottom)
             .AddClass($"mud-tabs-vertical", IsVerticalTabs())
             .AddClass($"mud-tabs-vertical-reverse", Position == Position.Right && !RightToLeft || (Position == Position.Left) && RightToLeft || Position == Position.End)
@@ -366,12 +366,12 @@ namespace MudBlazor
 
         protected string ToolbarClassnames =>
             new CssBuilder("mud-tabs-toolbar")
-            .AddClass($"mud-tabs-rounded", !ApplyEffectsToContainer && Rounded & !Invisible)
+            .AddClass($"mud-tabs-rounded", !ApplyEffectsToContainer && Rounded & !HiddenLayout)
             .AddClass($"mud-tabs-vertical", IsVerticalTabs())
-            .AddClass($"mud-tabs-toolbar-{Color.ToDescriptionString()}", Color != Color.Default & !Invisible)
-            .AddClass($"mud-tabs-border-{ConvertPosition(Position).ToDescriptionString()}", Border & !Invisible)
-            .AddClass($"mud-paper-outlined", !ApplyEffectsToContainer && Outlined & !Invisible)
-            .AddClass($"mud-elevation-{Elevation}", !ApplyEffectsToContainer && Elevation != 0 & !Invisible)
+            .AddClass($"mud-tabs-toolbar-{Color.ToDescriptionString()}", Color != Color.Default & !HiddenLayout)
+            .AddClass($"mud-tabs-border-{ConvertPosition(Position).ToDescriptionString()}", Border & !HiddenLayout)
+            .AddClass($"mud-paper-outlined", !ApplyEffectsToContainer && Outlined & !HiddenLayout)
+            .AddClass($"mud-elevation-{Elevation}", !ApplyEffectsToContainer && Elevation != 0 & !HiddenLayout)
             .Build();
 
         protected string WrapperClassnames =>
@@ -438,10 +438,10 @@ namespace MudBlazor
         string GetTabClass(MudTabPanel panel)
         {
             var tabClass = new CssBuilder("mud-tab")
-              .AddClass($"mud-tab-hover", !Invisible)
-              .AddClass($"mud-tab-active", when: () => panel == ActivePanel && !Invisible)
-              .AddClass($"mud-disabled", panel.Disabled && !Invisible)
-              .AddClass($"mud-ripple", !DisableRipple && !Invisible)
+              .AddClass($"mud-tab-hover", !HiddenLayout)
+              .AddClass($"mud-tab-active", when: () => panel == ActivePanel && !HiddenLayout)
+              .AddClass($"mud-disabled", panel.Disabled && !HiddenLayout)
+              .AddClass($"mud-ripple", !DisableRipple && !HiddenLayout)
               .AddClass(TabPanelClass)
               .AddClass(panel.Class)
               .Build();

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -41,6 +41,11 @@ namespace MudBlazor
         /// If true, sets the border-radius to theme default.
         /// </summary>
         [Parameter] public bool Rounded { get; set; }
+
+        /// <summary>
+        /// Show or hide the tabs and the tabPanels. They are shown by default.
+        /// </summary>
+        [Parameter] public bool Invisible { get; set; }
 
         /// <summary>
         /// If true, sets a border betwen the content and the toolbar depending on the position.
@@ -343,9 +348,9 @@ namespace MudBlazor
 
         protected string TabsClassnames =>
             new CssBuilder("mud-tabs")
-            .AddClass($"mud-tabs-rounded", ApplyEffectsToContainer && Rounded)
-            .AddClass($"mud-paper-outlined", ApplyEffectsToContainer && Outlined)
-            .AddClass($"mud-elevation-{Elevation}", ApplyEffectsToContainer && Elevation != 0)
+            .AddClass($"mud-tabs-rounded", ApplyEffectsToContainer && Rounded & !Invisible)
+            .AddClass($"mud-paper-outlined", ApplyEffectsToContainer && Outlined & !Invisible)
+            .AddClass($"mud-elevation-{Elevation}", ApplyEffectsToContainer && Elevation != 0 & !Invisible)
             .AddClass($"mud-tabs-reverse", Position == Position.Bottom)
             .AddClass($"mud-tabs-vertical", IsVerticalTabs())
             .AddClass($"mud-tabs-vertical-reverse", Position == Position.Right && !RightToLeft || (Position == Position.Left) && RightToLeft || Position == Position.End)
@@ -355,12 +360,12 @@ namespace MudBlazor
 
         protected string ToolbarClassnames =>
             new CssBuilder("mud-tabs-toolbar")
-            .AddClass($"mud-tabs-rounded", !ApplyEffectsToContainer && Rounded)
+            .AddClass($"mud-tabs-rounded", !ApplyEffectsToContainer && Rounded & !Invisible)
             .AddClass($"mud-tabs-vertical", IsVerticalTabs())
-            .AddClass($"mud-tabs-toolbar-{Color.ToDescriptionString()}", Color != Color.Default)
-            .AddClass($"mud-tabs-border-{ConvertPosition(Position).ToDescriptionString()}", Border)
-            .AddClass($"mud-paper-outlined", !ApplyEffectsToContainer && Outlined)
-            .AddClass($"mud-elevation-{Elevation}", !ApplyEffectsToContainer && Elevation != 0)
+            .AddClass($"mud-tabs-toolbar-{Color.ToDescriptionString()}", Color != Color.Default & !Invisible)
+            .AddClass($"mud-tabs-border-{ConvertPosition(Position).ToDescriptionString()}", Border & !Invisible)
+            .AddClass($"mud-paper-outlined", !ApplyEffectsToContainer && Outlined & !Invisible)
+            .AddClass($"mud-elevation-{Elevation}", !ApplyEffectsToContainer && Elevation != 0 & !Invisible)
             .Build();
 
         protected string WrapperClassnames =>
@@ -427,9 +432,10 @@ namespace MudBlazor
         string GetTabClass(MudTabPanel panel)
         {
             var tabClass = new CssBuilder("mud-tab")
-              .AddClass($"mud-tab-active", when: () => panel == ActivePanel)
-              .AddClass($"mud-disabled", panel.Disabled)
-              .AddClass($"mud-ripple", !DisableRipple)
+              .AddClass($"mud-tab-hover", !Invisible)
+              .AddClass($"mud-tab-active", when: () => panel == ActivePanel && !Invisible)
+              .AddClass($"mud-disabled", panel.Disabled && !Invisible)
+              .AddClass($"mud-ripple", !DisableRipple && !Invisible)
               .AddClass(TabPanelClass)
               .AddClass(panel.Class)
               .Build();

--- a/src/MudBlazor/Styles/components/_tabs.scss
+++ b/src/MudBlazor/Styles/components/_tabs.scss
@@ -140,7 +140,7 @@
     justify-content: center;
     transition: background-color 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 
-    &:hover {
+    &.mud-tab-hover:hover {
         cursor: pointer;
         background-color: var(--mud-palette-action-default-hover);
     }


### PR DESCRIPTION
It may be necessary to display different information and easily switch from one to another, while remaining on the same screen. This can be done with the Tabs component without displaying the MudTabs layout and the MudTabPanels layouts with the ```HiddenLayout``` option.

![image](https://user-images.githubusercontent.com/16502423/126034774-c4723dfe-b828-4ea7-896f-d556624cc96f.png)