### PR TITLE
MudTimeline: Add rtl support

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Timeline/Examples/TimelineModeExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Timeline/Examples/TimelineModeExample.razor
@@ -1,10 +1,12 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudSelect T="TimelineMode" @bind-Value="@mode" Label="TimelineMode" Dense="true" Variant="Variant.Outlined" Class="mb-4">
+    <MudSelectItem T="TimelineMode" Value="TimelineMode.Start">Start</MudSelectItem>
     <MudSelectItem T="TimelineMode" Value="TimelineMode.Left">Left</MudSelectItem>
     <MudSelectItem T="TimelineMode" Value="TimelineMode.Default">Default</MudSelectItem>
     <MudSelectItem T="TimelineMode" Value="TimelineMode.Reverse">Reverse</MudSelectItem>
     <MudSelectItem T="TimelineMode" Value="TimelineMode.Right">Right</MudSelectItem>
+    <MudSelectItem T="TimelineMode" Value="TimelineMode.End">End</MudSelectItem>
 </MudSelect>
 
 <MudTimeline TimelineMode="@mode">
@@ -21,5 +23,5 @@
 
 
 @code {
-    private TimelineMode mode { get; set; } = TimelineMode.Left;
+    private TimelineMode mode { get; set; } = TimelineMode.Start;
 }

--- a/src/MudBlazor/Components/Timeline/MudTimeline.razor.cs
+++ b/src/MudBlazor/Components/Timeline/MudTimeline.razor.cs
@@ -15,10 +15,23 @@ namespace MudBlazor
     {
         protected string Classnames =>
             new CssBuilder("mud-timeline")
-                .AddClass($"mud-timeline-mode-{TimelineMode.ToDescriptionString()}")
+                .AddClass($"mud-timeline-mode-{ConvertTimelineMode(TimelineMode).ToDescriptionString()}")
+                .AddClass("mud-timeline-rtl", RightToLeft)
                 .AddClass(Class)
                 .Build();
-
+        
+        private TimelineMode ConvertTimelineMode(TimelineMode timelineMode)
+        {
+            return timelineMode switch
+            {
+                TimelineMode.Left => RightToLeft ? TimelineMode.End : TimelineMode.Start,
+                TimelineMode.Right => RightToLeft ? TimelineMode.Start : TimelineMode.End,
+                _ => timelineMode
+            };
+        }
+        
+        [CascadingParameter] public bool RightToLeft { get; set; }
+        
         /// <summary>
         /// Sets the position of all timelineitems, left and right on every second or all left or right.
         /// </summary>

--- a/src/MudBlazor/Enums/TimelineMode.cs
+++ b/src/MudBlazor/Enums/TimelineMode.cs
@@ -11,6 +11,10 @@ namespace MudBlazor
         [Description("left")]
         Left,
         [Description("right")]
-        Right
+        Right,
+        [Description("start")]
+        Start,
+        [Description("end")]
+        End
     }
 }

--- a/src/MudBlazor/Styles/components/_timeline.scss
+++ b/src/MudBlazor/Styles/components/_timeline.scss
@@ -151,10 +151,16 @@
         }
     }
 
-    &.mud-timeline-mode-left {
+    &.mud-timeline-mode-start {
         &::before {
             right: auto;
             left: 47px;
+        }
+        &.mud-timeline-rtl {
+            &::before {
+                right: 47px;
+                left: auto;
+            }
         }
 
         .mud-timeline-item {
@@ -170,10 +176,16 @@
         }
     }
 
-    &.mud-timeline-mode-right {
+    &.mud-timeline-mode-end {
         &::before {
             right: 47px;
             left: auto;
+        }
+        &.mud-timeline-rtl {
+            &::before {
+                left: 47px;
+                right: auto;
+            }
         }
 
         .mud-timeline-item {


### PR DESCRIPTION
Adds `start/end` options, fixes alignment issue

![timeline](https://user-images.githubusercontent.com/62108893/126041301-577718c1-1669-4dbb-a1c7-cf7d4695a737.gif)
