### PR TITLE
Fix for SelectedIndex text on Docs for MudCarousel and MudTimeline

### DIFF
--- a/src/MudBlazor/Base/MudBaseItemsControl.cs
+++ b/src/MudBlazor/Base/MudBaseItemsControl.cs
@@ -23,7 +23,7 @@ namespace MudBlazor
         private TChildComponent _lastContainer = null;
         private int _selectedIndexField = -1;
         /// <summary>
-        /// Selected MudCarouselItem's index
+        /// Selected Item's index
         /// </summary>
         [Parameter]
         public int SelectedIndex


### PR DESCRIPTION
It's written in MudBaseItemsControl's class, and shoudn't reffer to any component.