### PR TITLE
Enable CS1591 Missing XML Docs (exclude Colors and Icons)

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -285,7 +285,7 @@ dotnet_diagnostic.CA1822.severity = suggestion
 # CS1591 Missing XML comment for publicly visible type or member
 # We should try and finish the documentation and remove this
 # For now its too noisy
-dotnet_diagnostic.CS1591.severity = none
+dotnet_diagnostic.CS1591.severity = suggestion
 # IDE0071 Require file header 
 dotnet_diagnostic.IDE0073.severity = none
 # IDE0055: Fix formatting

--- a/src/MudBlazor/Colors/Colors.cs
+++ b/src/MudBlazor/Colors/Colors.cs
@@ -1,4 +1,6 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System.Diagnostics.CodeAnalysis;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Icons/Custom/Brands.cs
+++ b/src/MudBlazor/Icons/Custom/Brands.cs
@@ -1,4 +1,6 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System.Diagnostics.CodeAnalysis;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Icons/Custom/FileFormats.cs
+++ b/src/MudBlazor/Icons/Custom/FileFormats.cs
@@ -1,4 +1,6 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System.Diagnostics.CodeAnalysis;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Icons/Custom/Uncategorized.cs
+++ b/src/MudBlazor/Icons/Custom/Uncategorized.cs
@@ -1,4 +1,6 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System.Diagnostics.CodeAnalysis;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Icons/Icons.cs
+++ b/src/MudBlazor/Icons/Icons.cs
@@ -1,4 +1,6 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System.Diagnostics.CodeAnalysis;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Icons/Material/Filled.cs
+++ b/src/MudBlazor/Icons/Material/Filled.cs
@@ -1,4 +1,6 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System.Diagnostics.CodeAnalysis;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Icons/Material/Outlined.cs
+++ b/src/MudBlazor/Icons/Material/Outlined.cs
@@ -1,4 +1,6 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System.Diagnostics.CodeAnalysis;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Icons/Material/Rounded.cs
+++ b/src/MudBlazor/Icons/Material/Rounded.cs
@@ -1,4 +1,6 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System.Diagnostics.CodeAnalysis;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Icons/Material/Sharp.cs
+++ b/src/MudBlazor/Icons/Material/Sharp.cs
@@ -1,4 +1,6 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System.Diagnostics.CodeAnalysis;
 
 namespace MudBlazor
 {


### PR DESCRIPTION
This only enables informational messages to help fill in the missing docs.
Some of these are protected members as they are publicly visible to inheritors.

@henon There are 1749 missing xml comments.