### PR TITLE
Increased max contributors

### DIFF
--- a/src/MudBlazor.Docs/Services/GitHubApiClient.cs
+++ b/src/MudBlazor.Docs/Services/GitHubApiClient.cs
@@ -24,7 +24,7 @@ namespace MudBlazor.Docs.Services
         {
             try
             {
-                var result = await _http.GetFromJsonAsync<GithubContributors[]>("https://api.github.com:443/repos/Garderoben/MudBlazor/contributors");
+                var result = await _http.GetFromJsonAsync<GithubContributors[]>("https://api.github.com:443/repos/Garderoben/MudBlazor/contributors?per_page=100");
                 return result;
             }
             catch (Exception e)


### PR DESCRIPTION
Increased to max contributors gotten from to API (per page) from the default 30 to the maximum of 100 to show all contributors on the 'Meet the team' docs page