### PR TITLE
MudDialog: Fix close button dialog button alignment in RTL (#2201)

### DIFF
--- a/src/MudBlazor/Components/Dialog/MudDialogInstance.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialogInstance.razor.cs
@@ -12,6 +12,8 @@ namespace MudBlazor
     public partial class MudDialogInstance : MudComponentBase
     {
         private DialogOptions _options = new DialogOptions();
+        
+        [CascadingParameter] public bool RightToLeft { get; set; }
         [CascadingParameter] private MudDialogProvider Parent { get; set; }
         [CascadingParameter] private DialogOptions GlobalDialogOptions { get; set; } = new DialogOptions();
 
@@ -151,6 +153,7 @@ namespace MudBlazor
             .AddClass(DialogMaxWidth, !FullScreen)
             .AddClass("mud-dialog-width-full", FullWidth && !FullScreen)
             .AddClass("mud-dialog-fullscreen", FullScreen)
+            .AddClass("mud-dialog-rtl", RightToLeft)
             .AddClass(Class)
         .Build();
 

--- a/src/MudBlazor/Styles/components/_dialog.scss
+++ b/src/MudBlazor/Styles/components/_dialog.scss
@@ -70,7 +70,12 @@
     -webkit-animation: mud-open-dialog-center 0.1s cubic-bezier(0.390, 0.575, 0.565, 1.000) both;
     animation: mud-open-dialog-center 0.1s cubic-bezier(0.390, 0.575, 0.565, 1.000) both;
     box-shadow: 0px 11px 15px -7px rgba(0,0,0,0.2), 0px 24px 38px 3px rgba(0,0,0,0.14), 0px 9px 46px 8px rgba(0,0,0,0.12);
-
+    
+    &.mud-dialog-rtl .mud-dialog-title .mud-button-root {
+        right: unset;
+        left: 8px;
+    }
+    
     & .mud-dialog-title {
         flex: 0 0 auto;
         margin: 0;
@@ -81,7 +86,6 @@
         + * > .mud-dialog-content {
             border-radius: 0
         }
-
         & .mud-button-root {
             top: 8px;
             right: 8px;


### PR DESCRIPTION
Fixes #2201

Before fix:
![grafik](https://user-images.githubusercontent.com/62108893/126791682-5303f53f-4e22-454a-8572-242bc68333ab.png)

After fix:
![grafik](https://user-images.githubusercontent.com/62108893/126791734-618507ff-c395-4202-96c1-11417d3c8662.png)