### PR TITLE
DatePicker: Fix exceptions when binding against Date.MinValue #2319

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DateTimeMinValueDatePickerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DateTimeMinValueDatePickerTest.razor
@@ -1,0 +1,7 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudDatePicker @bind-Date="Date" />
+
+@code {
+    public DateTime? Date { get; set; } = DateTime.MinValue;
+}

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -559,5 +559,26 @@ namespace MudBlazor.UnitTests.Components
             // Check that the date should remain the same because readonly is true
             picker.Date.Should().Be(now);
         }
+
+        [Test]
+        public async Task CheckDateTimeMinValueTest()
+        {
+            // Define the datetime minvalue for the date
+            var date = DateTime.MinValue;
+
+            // Get access to the datepicker of the instance
+            var comp = ctx.RenderComponent<DateTimeMinValueDatePickerTest>();
+            var datePicker = comp.FindComponent<MudDatePicker>();
+            
+            // Get the instance of the datepicker
+            var picker = comp.Instance;
+
+            // Open the datepicker
+            await comp.InvokeAsync(() => datePicker.Instance.Open());
+
+            // An error should be raised if the datepicker could not be not opened and the days could not generated
+            // It means that there would be an exception!
+            comp.FindAll("button.mud-picker-calendar-day").Where(x => x.TrimmedText().Equals("1")).First().Click();
+        }
     }
 }

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor
@@ -17,6 +17,10 @@
         <div class="mud-picker-calendar-content @($"mud-picker-calendar-content-{MaxMonthColumns ?? DisplayMonths}")">
             @{
                 int dayId = 0;
+                @if (_picker_month.HasValue && _picker_month.Value.Year == 1 && _picker_month.Value.Month == 1)
+                {
+                    dayId = -1;
+                }
             }
             @for (int displayMonth = 0; displayMonth < DisplayMonths; ++displayMonth)
             {
@@ -100,15 +104,42 @@
                                     @foreach (var day in GetWeek(tempMonth, tempWeek))
                                     {
                                         var tempId = ++dayId;
-                                        <button @key="day" type="button" style="--day-id: @tempId;"
-                                                class="mud-button-root mud-icon-button mud-ripple mud-ripple-icon mud-picker-calendar-day @GetDayClasses(tempMonth, day)"
-                                                @onclick="(() => { var d = day; OnDayClicked(d); })"
-                                                @onclick:stopPropagation="true"
-                                                aria-label='@day.ToString("dddd, dd MMMM yyyy")'
-                                                onmouseover="this.closest('.mud-picker-calendar-content').style.setProperty('--selected-day', @tempId);"
-                                                disabled="@((day < MinDate) || (day > MaxDate) || IsDateDisabledFunc(day))">
-                                            <p class="mud-typography mud-typography-body2 mud-inherit-text">@GetCalendarDayOfMonth(day)</p>
-                                        </button>
+                                        @if (_picker_month.HasValue && _picker_month.Value.Year == 1 && _picker_month.Value.Month == 1)
+                                        {
+                                            @if (tempId != 0)
+                                            { 
+                                                var yesterday = day.AddDays(-1);
+                                                <button @key="tempId" type="button" style="--day-id: @(tempId + 1);"
+                                                        class="mud-button-root mud-icon-button mud-ripple mud-ripple-icon mud-picker-calendar-day @(day.Day == _picker_month.Value.Day? GetDayClasses(tempMonth, day) : GetDayClasses(tempMonth, yesterday))"
+                                                        @onclick="(() => { var d = yesterday; OnDayClicked(d); })"
+                                                        @onclick:stopPropagation="true"
+                                                        aria-label='@yesterday.ToString("dddd, dd MMMM yyyy")'
+                                                        onmouseover="this.closest('.mud-picker-calendar-content').style.setProperty('--selected-day', @(tempId + 1));"
+                                                        disabled="@((yesterday < MinDate) || (yesterday > MaxDate) || IsDateDisabledFunc(yesterday))">
+                                                    <p class="mud-typography mud-typography-body2 mud-inherit-text">@GetCalendarDayOfMonth(yesterday)</p>
+                                                </button>
+                                            }
+                                            else
+                                            {
+                                                <button @key="tempId" type="button" style="--day-id: 1;"
+                                                        class="mud-button-root mud-icon-button mud-ripple mud-ripple-icon mud-picker-calendar-day mud-day"
+                                                        aria-label='' disabled>
+                                                    <p class="mud-typography mud-typography-body2 mud-inherit-text"></p>
+                                                </button>
+                                            }
+                                        }
+                                        else
+                                        {
+                                            <button @key="day" type="button" style="--day-id: @tempId;"
+                                                    class="mud-button-root mud-icon-button mud-ripple mud-ripple-icon mud-picker-calendar-day @GetDayClasses(tempMonth, day)"
+                                                    @onclick="(() => { var d = day; OnDayClicked(d); })"
+                                                    @onclick:stopPropagation="true"
+                                                    aria-label='@day.ToString("dddd, dd MMMM yyyy")'
+                                                    onmouseover="this.closest('.mud-picker-calendar-content').style.setProperty('--selected-day', @tempId);"
+                                                    disabled="@((day < MinDate) || (day > MaxDate) || IsDateDisabledFunc(day))">
+                                                <p class="mud-typography mud-typography-body2 mud-inherit-text">@GetCalendarDayOfMonth(day)</p>
+                                            </button>
+                                        }
                                     }
                                 }
                             </div>

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor
@@ -94,6 +94,7 @@
                                 @for (int week = 0; week < 6; week++)
                                 {
                                     int tempWeek = week;
+                                    var firstMonthFirstYear = _picker_month.HasValue && _picker_month.Value.Year == 1 && _picker_month.Value.Month == 1;
 
                                     @if (ShowWeekNumbers)
                                     {
@@ -104,40 +105,26 @@
                                     @foreach (var day in GetWeek(tempMonth, tempWeek))
                                     {
                                         var tempId = ++dayId;
-                                        @if (_picker_month.HasValue && _picker_month.Value.Year == 1 && _picker_month.Value.Month == 1)
+                                        
+                                        @if (tempId != 0 || !firstMonthFirstYear)
                                         {
-                                            @if (tempId != 0)
-                                            { 
-                                                var yesterday = day.AddDays(-1);
-                                                <button @key="tempId" type="button" style="--day-id: @(tempId + 1);"
-                                                        class="mud-button-root mud-icon-button mud-ripple mud-ripple-icon mud-picker-calendar-day @(day.Day == _picker_month.Value.Day? GetDayClasses(tempMonth, day) : GetDayClasses(tempMonth, yesterday))"
-                                                        @onclick="(() => { var d = yesterday; OnDayClicked(d); })"
-                                                        @onclick:stopPropagation="true"
-                                                        aria-label='@yesterday.ToString("dddd, dd MMMM yyyy")'
-                                                        onmouseover="this.closest('.mud-picker-calendar-content').style.setProperty('--selected-day', @(tempId + 1));"
-                                                        disabled="@((yesterday < MinDate) || (yesterday > MaxDate) || IsDateDisabledFunc(yesterday))">
-                                                    <p class="mud-typography mud-typography-body2 mud-inherit-text">@GetCalendarDayOfMonth(yesterday)</p>
-                                                </button>
-                                            }
-                                            else
-                                            {
-                                                <button @key="tempId" type="button" style="--day-id: 1;"
-                                                        class="mud-button-root mud-icon-button mud-ripple mud-ripple-icon mud-picker-calendar-day mud-day"
-                                                        aria-label='' disabled>
-                                                    <p class="mud-typography mud-typography-body2 mud-inherit-text"></p>
-                                                </button>
-                                            }
+                                            var selectedDay = !firstMonthFirstYear ? day : day.AddDays(-1);
+                                            <button @key="selectedDay" type="button" style="--day-id: @(!firstMonthFirstYear ? tempId: tempId + 1);"
+                                                    class="mud-button-root mud-icon-button mud-ripple mud-ripple-icon mud-picker-calendar-day @(!firstMonthFirstYear || day.Day == _picker_month.Value.Day? GetDayClasses(tempMonth, day) : GetDayClasses(tempMonth, selectedDay))"
+                                                    @onclick="(() => { var d = selectedDay; OnDayClicked(d); })"
+                                                    @onclick:stopPropagation="true"
+                                                    aria-label='@selectedDay.ToString("dddd, dd MMMM yyyy")'
+                                                    onmouseover="this.closest('.mud-picker-calendar-content').style.setProperty('--selected-day', @(!firstMonthFirstYear ? tempId: tempId + 1));"
+                                                    disabled="@((selectedDay < MinDate) || (selectedDay > MaxDate) || IsDateDisabledFunc(selectedDay))">
+                                                <p class="mud-typography mud-typography-body2 mud-inherit-text">@GetCalendarDayOfMonth(selectedDay)</p>
+                                            </button>
                                         }
                                         else
                                         {
-                                            <button @key="day" type="button" style="--day-id: @tempId;"
-                                                    class="mud-button-root mud-icon-button mud-ripple mud-ripple-icon mud-picker-calendar-day @GetDayClasses(tempMonth, day)"
-                                                    @onclick="(() => { var d = day; OnDayClicked(d); })"
-                                                    @onclick:stopPropagation="true"
-                                                    aria-label='@day.ToString("dddd, dd MMMM yyyy")'
-                                                    onmouseover="this.closest('.mud-picker-calendar-content').style.setProperty('--selected-day', @tempId);"
-                                                    disabled="@((day < MinDate) || (day > MaxDate) || IsDateDisabledFunc(day))">
-                                                <p class="mud-typography mud-typography-body2 mud-inherit-text">@GetCalendarDayOfMonth(day)</p>
+                                            <button @key="0" type="button" style="--day-id: 1;"
+                                                    class="mud-button-root mud-icon-button mud-ripple mud-ripple-icon mud-picker-calendar-day mud-day"
+                                                    aria-label='' disabled>
+                                                <p class="mud-typography mud-typography-body2 mud-inherit-text"></p>
                                             </button>
                                         }
                                     }

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor
@@ -109,7 +109,7 @@
                                         @if (tempId != 0 || !firstMonthFirstYear)
                                         {
                                             var selectedDay = !firstMonthFirstYear ? day : day.AddDays(-1);
-                                            <button @key="selectedDay" type="button" style="--day-id: @(!firstMonthFirstYear ? tempId: tempId + 1);"
+                                            <button @key="@(!firstMonthFirstYear ? selectedDay : tempId)" type="button" style="--day-id: @(!firstMonthFirstYear ? tempId: tempId + 1);"
                                                     class="mud-button-root mud-icon-button mud-ripple mud-ripple-icon mud-picker-calendar-day @(!firstMonthFirstYear || day.Day == _picker_month.Value.Day? GetDayClasses(tempMonth, day) : GetDayClasses(tempMonth, selectedDay))"
                                                     @onclick="(() => { var d = selectedDay; OnDayClicked(d); })"
                                                     @onclick:stopPropagation="true"

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -154,6 +154,11 @@ namespace MudBlazor
         protected DateTime GetMonthStart(int month)
         {
             var monthStartDate = _picker_month ?? DateTime.Today.StartOfMonth(Culture);
+            // Return the min supported datetime of the calendar when this is year 1 and first month!
+            if (_picker_month.HasValue && _picker_month.Value.Year == 1 && _picker_month.Value.Month == 1)
+            {
+                return Culture.Calendar.MinSupportedDateTime;
+            }
             return Culture.Calendar.AddMonths(monthStartDate, month);
         }
 
@@ -257,6 +262,11 @@ namespace MudBlazor
 
         private void OnPreviousMonthClick()
         {
+            // It is impossible to go further into the past after the first year and the first month!
+            if (PickerMonth.HasValue && PickerMonth.Value.Year == 1 && PickerMonth.Value.Month == 1)
+            {
+                return;
+            }
             PickerMonth = GetMonthStart(0).AddDays(-1).StartOfMonth(Culture);
         }
 

--- a/src/MudBlazor/Extensions/DateTimeExtensions.cs
+++ b/src/MudBlazor/Extensions/DateTimeExtensions.cs
@@ -38,6 +38,10 @@ namespace MudBlazor.Extensions
         public static DateTime StartOfWeek(this DateTime self, DayOfWeek firstDayOfWeek)
         {
             var diff = (7 + (self.DayOfWeek - firstDayOfWeek)) % 7;
+            if (self.Year == 1 && self.Month == 1 && (self.Day - diff) < 1)
+            {
+                return self.Date;
+            }
             return self.AddDays(-1 * diff).Date;
         }
     }


### PR DESCRIPTION
Fixes #2319
This is a fix for [#2319](https://github.com/Garderoben/MudBlazor/issues/2319).

Here are the modifications / remarks : 

* Fixed exception with ```DateTime.MinValue```
* Fixed ```StartOfWeek``` method in DateTime extension for another exception when using ```DateTime.MinValue```
* Fixed when trying to go to the past when the year is 0001 and it is January
* An empty disabled button has been added for Sunday because the first day in January for the year 0001 is Monday
* A test has been added to validate the case of the exception
* The implementation has been done in a way that inherited code and logic should not be affected

![image](https://user-images.githubusercontent.com/16502423/127018640-98c1de2a-49ba-4aec-9b5a-13ba1375284c.png)