### PR TITLE
fix some incorrect as usages

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
@@ -123,15 +123,15 @@ namespace MudBlazor.UnitTests.Components.Components
             hueSlideValue.Should().ContainSingle();
             hueSlideValue[0].Should().BeAssignableTo<IHtmlInputElement>();
 
-            (hueSlideValue[0] as IHtmlInputElement).Value.Should().Be(((int)expectedColor.H).ToString());
+            ((IHtmlInputElement)hueSlideValue[0]).Value.Should().Be(((int)expectedColor.H).ToString());
 
             var alphaSlider = comp.FindAll(_alphaSliderCssSelector);
             alphaSlider.Should().ContainSingle();
             alphaSlider[0].Should().BeAssignableTo<IHtmlInputElement>();
 
-            (alphaSlider[0] as IHtmlInputElement).Value.Should().Be(((int)expectedColor.A).ToString());
+            ((IHtmlInputElement)alphaSlider[0]).Value.Should().Be(((int)expectedColor.A).ToString());
 
-            var alphaSliderStyleAttritbute = (alphaSlider[0].Parent as IHtmlElement).GetAttribute("style");
+            var alphaSliderStyleAttritbute = ((IHtmlElement)alphaSlider[0].Parent).GetAttribute("style");
 
             if (isRtl == false)
             {
@@ -736,7 +736,7 @@ namespace MudBlazor.UnitTests.Components.Components
             var inputs = comp.FindAll(".mud-picker-color-inputfield input");
             inputs.Should().ContainSingle();
             inputs.Should().AllBeAssignableTo<IHtmlInputElement>();
-            (inputs[0] as IHtmlInputElement).Value.Should().Be("#0cdc7c");
+            ((IHtmlInputElement)inputs[0]).Value.Should().Be("#0cdc7c");
 
             comp.Instance.TextValue.Should().Be("#0cdc7c");
 
@@ -745,7 +745,7 @@ namespace MudBlazor.UnitTests.Components.Components
             inputs = comp.FindAll(".mud-picker-color-inputfield input");
             inputs.Should().ContainSingle();
             inputs.Should().AllBeAssignableTo<IHtmlInputElement>();
-            (inputs[0] as IHtmlInputElement).Value.Should().Be("#0cdc7c78");
+            ((IHtmlInputElement)inputs[0]).Value.Should().Be("#0cdc7c78");
 
             comp.Instance.TextValue.Should().Be("#0cdc7c78");
         }

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -374,7 +374,7 @@ namespace MudBlazor.UnitTests.Components
             var text = date.ToShortDateString();
 
             picker.Text.Should().Be(text);
-            (comp.FindAll("input")[0] as IHtmlInputElement).Value.Should().Be(text);
+            ((IHtmlInputElement)comp.FindAll("input")[0]).Value.Should().Be(text);
         }
 
         [Test]
@@ -384,7 +384,7 @@ namespace MudBlazor.UnitTests.Components
             var comp = OpenPicker(Parameter(nameof(MudDatePicker.IsDateDisabledFunc), isDisabledFunc));
 
             comp.Instance.IsDateDisabledFunc.Should().Be(isDisabledFunc);
-            comp.FindAll("button.mud-picker-calendar-day").Select(button => (button as IHtmlButtonElement).IsDisabled)
+            comp.FindAll("button.mud-picker-calendar-day").Select(button => ((IHtmlButtonElement)button).IsDisabled)
                 .Should().OnlyContain(disabled => disabled == true);
         }
 
@@ -425,7 +425,7 @@ namespace MudBlazor.UnitTests.Components
         public void IsDateDisabledFunc_NoDisabledDatesByDefault()
         {
             var comp = OpenPicker();
-            comp.FindAll("button.mud-picker-calendar-day").Select(button => (button as IHtmlButtonElement).IsDisabled)
+            comp.FindAll("button.mud-picker-calendar-day").Select(button => ((IHtmlButtonElement)button).IsDisabled)
                 .Should().OnlyContain(disabled => disabled == false);
         }
 

--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
@@ -343,8 +343,8 @@ namespace MudBlazor.UnitTests.Components
 
             picker.Text.Should().Be(RangeConverter<DateTime>.Join(textStart, textEnd));
             var inputs = comp.FindAll("input");
-            (inputs[0] as IHtmlInputElement).Value.Should().Be(textStart);
-            (inputs[1] as IHtmlInputElement).Value.Should().Be(textEnd);
+            ((IHtmlInputElement)inputs[0]).Value.Should().Be(textStart);
+            ((IHtmlInputElement)inputs[1]).Value.Should().Be(textEnd);
         }
 
         [Test]
@@ -362,7 +362,7 @@ namespace MudBlazor.UnitTests.Components
             var comp = OpenPicker(Parameter(nameof(MudDateRangePicker.IsDateDisabledFunc), isDisabledFunc));
 
             comp.Instance.IsDateDisabledFunc.Should().Be(isDisabledFunc);
-            comp.FindAll("button.mud-picker-calendar-day").Select(button => (button as IHtmlButtonElement).IsDisabled)
+            comp.FindAll("button.mud-picker-calendar-day").Select(button => ((IHtmlButtonElement)button).IsDisabled)
                 .Should().OnlyContain(disabled => disabled == true);
         }
 
@@ -411,7 +411,7 @@ namespace MudBlazor.UnitTests.Components
         public void IsDateDisabledFunc_NoDisabledDatesByDefault()
         {
             var comp = OpenPicker();
-            comp.FindAll("button.mud-picker-calendar-day").Select(button => (button as IHtmlButtonElement).IsDisabled)
+            comp.FindAll("button.mud-picker-calendar-day").Select(button => ((IHtmlButtonElement)button).IsDisabled)
                 .Should().OnlyContain(disabled => disabled == false);
         }
 

--- a/src/MudBlazor.UnitTests/Components/DialogTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DialogTests.cs
@@ -182,7 +182,7 @@ namespace MudBlazor.UnitTests.Components
             Console.WriteLine("----------------------------------------");
             Console.WriteLine(comp.Markup);
 
-            (dialogReference.Dialog as DialogWithParameters).TestValue.Should().Be("new_test");
+            ((DialogWithParameters)dialogReference.Dialog).TestValue.Should().Be("new_test");
             textField.Text.Should().Be("new_test");
         }
 

--- a/src/MudBlazor.UnitTests/Components/DynamicTabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DynamicTabsTests.cs
@@ -59,7 +59,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Nodes.Should().ContainSingle();
             comp.Nodes[0].Should().BeAssignableTo<IHtmlDivElement>();
 
-            (comp.Nodes[0] as IHtmlDivElement).ClassList.Should().BeEquivalentTo("mud-tabs", "mud-dynamic-tabs");
+            ((IHtmlDivElement)comp.Nodes[0]).ClassList.Should().BeEquivalentTo("mud-tabs", "mud-dynamic-tabs");
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Extensions/IRenderedComponentExtensions.cs
+++ b/src/MudBlazor.UnitTests/Extensions/IRenderedComponentExtensions.cs
@@ -17,13 +17,13 @@ namespace MudBlazor.UnitTests
 
         public static void SetParam<T>(this IRenderedComponentBase<T> self, Expression<Func<T, object>> exp, object? value) where T : IComponent
         {
-            var name = (exp.Body as MemberExpression ?? ((UnaryExpression)exp.Body).Operand as MemberExpression).Member.Name;
+            var name = (exp.Body as MemberExpression ?? (MemberExpression)((UnaryExpression)exp.Body).Operand).Member.Name;
             self.SetParametersAndRender(ComponentParameter.CreateParameter(name, value));
         }
 
         public static void SetCascadingValue<T>(this IRenderedComponentBase<T> self, Expression<Func<T, object>> exp, object value) where T : IComponent
         {
-            var name = (exp.Body as MemberExpression ?? ((UnaryExpression)exp.Body).Operand as MemberExpression).Member.Name;
+            var name = (exp.Body as MemberExpression ?? (MemberExpression)((UnaryExpression)exp.Body).Operand).Member.Name;
             self.SetParametersAndRender(ComponentParameter.CreateCascadingValue(name, value));
         }
 
@@ -39,7 +39,7 @@ namespace MudBlazor.UnitTests
 
         public static void SetCallback<T, U>(this IRenderedComponentBase<T> self, Expression<Func<T, EventCallback<U>>> exp, Action<U> callback) where T : IComponent
         {
-            var name = (exp.Body as MemberExpression ?? ((UnaryExpression)exp.Body).Operand as MemberExpression).Member.Name;
+            var name = (exp.Body as MemberExpression ?? (MemberExpression)((UnaryExpression)exp.Body).Operand).Member.Name;
             self.SetParametersAndRender(ComponentParameter.CreateParameter(name, new EventCallback<U>(null, callback)));
         }
     }

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -18,7 +18,7 @@ namespace MudBlazor
         {
             Converter.GetFunc = OnGet;
             Converter.SetFunc = OnSet;
-            (Converter as DefaultConverter<TimeSpan?>).Format = format24Hours;
+            ((DefaultConverter<TimeSpan?>)Converter).Format = format24Hours;
             AdornmentIcon = Icons.Material.Filled.AccessTime;
         }
 
@@ -29,12 +29,12 @@ namespace MudBlazor
 
             var time = DateTime.Today.Add(timespan.Value);
 
-            return time.ToString((Converter as DefaultConverter<TimeSpan?>).Format, Culture);
+            return time.ToString(((DefaultConverter<TimeSpan?>)Converter).Format, Culture);
         }
 
         private TimeSpan? OnGet(string value)
         {
-            if (DateTime.TryParseExact(value, (Converter as DefaultConverter<TimeSpan?>).Format, Culture, DateTimeStyles.None, out DateTime time))
+            if (DateTime.TryParseExact(value, ((DefaultConverter<TimeSpan?>)Converter).Format, Culture, DateTimeStyles.None, out DateTime time))
             {
                 return time.TimeOfDay;
             }


### PR DESCRIPTION
in these cases the `as` should be a cast, since if it isnt of that type it would be a null ref