### PR TITLE
MudTabPager : Customization & Alignment

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TabPagerExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TabPagerExample.razor
@@ -22,9 +22,11 @@
         <MudTd DataLabel="Molar mass">@context.Molar</MudTd>
     </RowTemplate>
     <PagerContent>
-        <MudTablePager HorizontalAlignment="HorizontalAlignment.Left" HidePageNumber="@hidePageNumber" HidePagination="@hidePagination" HideRowsPerPage="@hideRowsPerPage" />
-        <MudTablePager HorizontalAlignment="HorizontalAlignment.Center" HidePageNumber="@hidePageNumber" HidePagination="@hidePagination" HideRowsPerPage="@hideRowsPerPage" />
-        <MudTablePager HorizontalAlignment="HorizontalAlignment.Right" HidePageNumber="@hidePageNumber" HidePagination="@hidePagination" HideRowsPerPage="@hideRowsPerPage" />
+        <MudTablePager InfoFormat="@($"Left {infoFormat}")" HorizontalAlignment="HorizontalAlignment.Left" HidePageNumber="@hidePageNumber" HidePagination="@hidePagination" HideRowsPerPage="@hideRowsPerPage" />
+        <MudTablePager InfoFormat="@($"Start {infoFormat}")" HorizontalAlignment="HorizontalAlignment.Start" HidePageNumber="@hidePageNumber" HidePagination="@hidePagination" HideRowsPerPage="@hideRowsPerPage" />
+        <MudTablePager InfoFormat="@($"Center {infoFormat}")" HorizontalAlignment="HorizontalAlignment.Center" HidePageNumber="@hidePageNumber" HidePagination="@hidePagination" HideRowsPerPage="@hideRowsPerPage" />
+        <MudTablePager InfoFormat="@($"Right {infoFormat}")" HorizontalAlignment="HorizontalAlignment.Right" HidePageNumber="@hidePageNumber" HidePagination="@hidePagination" HideRowsPerPage="@hideRowsPerPage" />
+        <MudTablePager InfoFormat="@($"End {infoFormat}")" HorizontalAlignment="HorizontalAlignment.End" HidePageNumber="@hidePageNumber" HidePagination="@hidePagination" HideRowsPerPage="@hideRowsPerPage" />
     </PagerContent>
 </MudTable>
 
@@ -38,6 +40,7 @@
     private bool hidePageNumber;
     private bool hidePagination;
     private bool hideRowsPerPage;
+    private string infoFormat = "{first_item}-{last_item} of {all_items}";
 
     private IEnumerable<Element> Elements = new List<Element>();
 

--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TabPagerExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TabPagerExample.razor
@@ -22,9 +22,9 @@
         <MudTd DataLabel="Molar mass">@context.Molar</MudTd>
     </RowTemplate>
     <PagerContent>
-        <MudTablePager TextAlignment="TablePagerTextPosition.Left" HidePageNumber="@hidePageNumber" HidePagination="@hidePagination" HideRowsPerPage="@hideRowsPerPage" />
-        <MudTablePager TextAlignment="TablePagerTextPosition.Center" HidePageNumber="@hidePageNumber" HidePagination="@hidePagination" HideRowsPerPage="@hideRowsPerPage" />
-        <MudTablePager TextAlignment="TablePagerTextPosition.Right" HidePageNumber="@hidePageNumber" HidePagination="@hidePagination" HideRowsPerPage="@hideRowsPerPage" />
+        <MudTablePager HorizontalAlignment="HorizontalAlignment.Left" HidePageNumber="@hidePageNumber" HidePagination="@hidePagination" HideRowsPerPage="@hideRowsPerPage" />
+        <MudTablePager HorizontalAlignment="HorizontalAlignment.Center" HidePageNumber="@hidePageNumber" HidePagination="@hidePagination" HideRowsPerPage="@hideRowsPerPage" />
+        <MudTablePager HorizontalAlignment="HorizontalAlignment.Right" HidePageNumber="@hidePageNumber" HidePagination="@hidePagination" HideRowsPerPage="@hideRowsPerPage" />
     </PagerContent>
 </MudTable>
 

--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TabPagerExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TabPagerExample.razor
@@ -22,14 +22,14 @@
         <MudTd DataLabel="Molar mass">@context.Molar</MudTd>
     </RowTemplate>
     <PagerContent>
-        <MudTablePager TextAlignment="TablePagerTextPosition.Left" HidePageNumber="@hidePageNumber" HidePagination="@hidePagination" DisableRowsPerPage="@disableRowsPerPage" />
-        <MudTablePager TextAlignment="TablePagerTextPosition.Center" HidePageNumber="@hidePageNumber" HidePagination="@hidePagination" DisableRowsPerPage="@disableRowsPerPage" />
-        <MudTablePager TextAlignment="TablePagerTextPosition.Right" HidePageNumber="@hidePageNumber" HidePagination="@hidePagination" DisableRowsPerPage="@disableRowsPerPage" />
+        <MudTablePager TextAlignment="TablePagerTextPosition.Left" HidePageNumber="@hidePageNumber" HidePagination="@hidePagination" HideRowsPerPage="@hideRowsPerPage" />
+        <MudTablePager TextAlignment="TablePagerTextPosition.Center" HidePageNumber="@hidePageNumber" HidePagination="@hidePagination" HideRowsPerPage="@hideRowsPerPage" />
+        <MudTablePager TextAlignment="TablePagerTextPosition.Right" HidePageNumber="@hidePageNumber" HidePagination="@hidePagination" HideRowsPerPage="@hideRowsPerPage" />
     </PagerContent>
 </MudTable>
 
 <div class="d-flex flex-wrap mt-4">
-    <MudSwitch @bind-Checked="@disableRowsPerPage" Color="Color.Tertiary">Hide/Show Rows Per Page</MudSwitch>
+    <MudSwitch @bind-Checked="@hideRowsPerPage" Color="Color.Tertiary">Hide/Show Rows per Page</MudSwitch>
     <MudSwitch @bind-Checked="@hidePageNumber" Color="Color.Primary">Hide/Show Page Number</MudSwitch>
     <MudSwitch @bind-Checked="@hidePagination" Color="Color.Secondary">Hide/Show Pagination</MudSwitch>
 </div>
@@ -37,7 +37,7 @@
 @code {
     private bool hidePageNumber;
     private bool hidePagination;
-    private bool disableRowsPerPage;
+    private bool hideRowsPerPage;
 
     private IEnumerable<Element> Elements = new List<Element>();
 

--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TabPagerExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TabPagerExample.razor
@@ -1,0 +1,48 @@
+﻿@using System.Net.Http.Json
+@using MudBlazor.Examples.Data.Models
+@namespace MudBlazor.Docs.Examples
+@inject HttpClient httpClient
+
+<MudTable Items="@Elements">
+    <ToolBarContent>
+        <MudText Typo="Typo.h6">Periodic Elements</MudText>
+    </ToolBarContent>
+    <HeaderContent>
+        <MudTh>Nr</MudTh>
+        <MudTh>Sign</MudTh>
+        <MudTh>Name</MudTh>
+        <MudTh>Position</MudTh>
+        <MudTh>Molar mass</MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd DataLabel="Nr">@context.Number</MudTd>
+        <MudTd DataLabel="Sign">@context.Sign</MudTd>
+        <MudTd DataLabel="Name">@context.Name</MudTd>
+        <MudTd DataLabel="Position">@context.Position</MudTd>
+        <MudTd DataLabel="Molar mass">@context.Molar</MudTd>
+    </RowTemplate>
+    <PagerContent>
+        <MudTablePager TextAlignment="TablePagerTextPosition.Left" DisablePageNumber="@disablePageNumber" DisablePagination="@disablePagination" DisableRowsPerPage="@disableRowsPerPage" />
+        <MudTablePager TextAlignment="TablePagerTextPosition.Center" DisablePageNumber="@disablePageNumber" DisablePagination="@disablePagination" DisableRowsPerPage="@disableRowsPerPage" />
+        <MudTablePager TextAlignment="TablePagerTextPosition.Right" DisablePageNumber="@disablePageNumber" DisablePagination="@disablePagination" DisableRowsPerPage="@disableRowsPerPage" />
+    </PagerContent>
+</MudTable>
+
+<div class="d-flex flex-wrap mt-4">
+    <MudSwitch @bind-Checked="@disableRowsPerPage" Color="Color.Tertiary">Rows Per Page</MudSwitch>
+    <MudSwitch @bind-Checked="@disablePageNumber" Color="Color.Primary">Page Number</MudSwitch>
+    <MudSwitch @bind-Checked="@disablePagination" Color="Color.Secondary">Pagination</MudSwitch>
+</div>
+
+@code {
+    private bool disablePageNumber;
+    private bool disablePagination;
+    private bool disableRowsPerPage;
+
+    private IEnumerable<Element> Elements = new List<Element>();
+
+    protected override async Task OnInitializedAsync()
+    {
+        Elements = await httpClient.GetFromJsonAsync<List<Element>>("webapi/periodictable");
+    }
+}

--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TabPagerExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TabPagerExample.razor
@@ -22,21 +22,21 @@
         <MudTd DataLabel="Molar mass">@context.Molar</MudTd>
     </RowTemplate>
     <PagerContent>
-        <MudTablePager TextAlignment="TablePagerTextPosition.Left" DisablePageNumber="@disablePageNumber" DisablePagination="@disablePagination" DisableRowsPerPage="@disableRowsPerPage" />
-        <MudTablePager TextAlignment="TablePagerTextPosition.Center" DisablePageNumber="@disablePageNumber" DisablePagination="@disablePagination" DisableRowsPerPage="@disableRowsPerPage" />
-        <MudTablePager TextAlignment="TablePagerTextPosition.Right" DisablePageNumber="@disablePageNumber" DisablePagination="@disablePagination" DisableRowsPerPage="@disableRowsPerPage" />
+        <MudTablePager TextAlignment="TablePagerTextPosition.Left" HidePageNumber="@hidePageNumber" HidePagination="@hidePagination" DisableRowsPerPage="@disableRowsPerPage" />
+        <MudTablePager TextAlignment="TablePagerTextPosition.Center" HidePageNumber="@hidePageNumber" HidePagination="@hidePagination" DisableRowsPerPage="@disableRowsPerPage" />
+        <MudTablePager TextAlignment="TablePagerTextPosition.Right" HidePageNumber="@hidePageNumber" HidePagination="@hidePagination" DisableRowsPerPage="@disableRowsPerPage" />
     </PagerContent>
 </MudTable>
 
 <div class="d-flex flex-wrap mt-4">
-    <MudSwitch @bind-Checked="@disableRowsPerPage" Color="Color.Tertiary">Rows Per Page</MudSwitch>
-    <MudSwitch @bind-Checked="@disablePageNumber" Color="Color.Primary">Page Number</MudSwitch>
-    <MudSwitch @bind-Checked="@disablePagination" Color="Color.Secondary">Pagination</MudSwitch>
+    <MudSwitch @bind-Checked="@disableRowsPerPage" Color="Color.Tertiary">Hide/Show Rows Per Page</MudSwitch>
+    <MudSwitch @bind-Checked="@hidePageNumber" Color="Color.Primary">Hide/Show Page Number</MudSwitch>
+    <MudSwitch @bind-Checked="@hidePagination" Color="Color.Secondary">Hide/Show Pagination</MudSwitch>
 </div>
 
 @code {
-    private bool disablePageNumber;
-    private bool disablePagination;
+    private bool hidePageNumber;
+    private bool hidePagination;
     private bool disableRowsPerPage;
 
     private IEnumerable<Element> Elements = new List<Element>();

--- a/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
@@ -36,7 +36,7 @@
         <DocsPageSection>
             <SectionHeader Title="TabPager Customization">
                 <Description>
-                    By setting <CodeInline>DisableRowsPerPage</CodeInline> property or the <CodeInline>DisablePageNumber</CodeInline> property or the <CodeInline>DisablePagination</CodeInline> property to <CodeInline>true</CodeInline>, the corresponding information is hidden in the <CodeInline>MudTabPager</CodeInline>.
+                    By setting <CodeInline>DisableRowsPerPage</CodeInline> property or the <CodeInline>HidePageNumber</CodeInline> property or the <CodeInline>HidePagination</CodeInline> property to <CodeInline>true</CodeInline>, the corresponding information is hidden in the <CodeInline>MudTabPager</CodeInline>.
                     The text position can be defined with the <CodeInline>TextPosition</CodeInline> property.
                 </Description>
             </SectionHeader>

--- a/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
@@ -34,6 +34,19 @@
         </DocsPageSection>
 
         <DocsPageSection>
+            <SectionHeader Title="TabPager Customization">
+                <Description>
+                    By setting <CodeInline>DisableRowsPerPage</CodeInline> property or the <CodeInline>DisablePageNumber</CodeInline> property or the <CodeInline>DisablePagination</CodeInline> property to <CodeInline>true</CodeInline>, the corresponding information is hidden in the <CodeInline>MudTabPager</CodeInline>.
+                    The text position can be defined with <CodeInline>TextPosition</CodeInline> property.
+                </Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" FullWidth="true">
+                <TabPagerExample />
+            </SectionContent>
+            <SectionSource Code="TablePagerExample" ShowCode="false" GitHubFolderName="Table" />
+        </DocsPageSection>
+
+        <DocsPageSection>
             <SectionHeader Title="Sorting">
                 <Description>
                     To enable sorting, add <CodeInline>&lt;MudTableSortLabel></CodeInline> to the header cells and define a function that simply returns the value which should be sorted by when sorting by the specific column.

--- a/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
@@ -37,7 +37,7 @@
             <SectionHeader Title="TabPager Customization">
                 <Description>
                     By setting <CodeInline>DisableRowsPerPage</CodeInline> property or the <CodeInline>DisablePageNumber</CodeInline> property or the <CodeInline>DisablePagination</CodeInline> property to <CodeInline>true</CodeInline>, the corresponding information is hidden in the <CodeInline>MudTabPager</CodeInline>.
-                    The text position can be defined with <CodeInline>TextPosition</CodeInline> property.
+                    The text position can be defined with the <CodeInline>TextPosition</CodeInline> property.
                 </Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" FullWidth="true">

--- a/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
@@ -37,7 +37,7 @@
             <SectionHeader Title="TabPager Customization">
                 <Description>
                     By setting <CodeInline>HideRowsPerPage</CodeInline> property or the <CodeInline>HidePageNumber</CodeInline> property or the <CodeInline>HidePagination</CodeInline> property to <CodeInline>true</CodeInline>, the corresponding information is hidden in the <CodeInline>MudTabPager</CodeInline>.
-                    The text position can be defined with the <CodeInline>HorizontalAlignment</CodeInline> property.
+                    The elements position can be defined with the <CodeInline>HorizontalAlignment</CodeInline> property.
                 </Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" FullWidth="true">

--- a/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
@@ -36,7 +36,7 @@
         <DocsPageSection>
             <SectionHeader Title="TabPager Customization">
                 <Description>
-                    By setting <CodeInline>DisableRowsPerPage</CodeInline> property or the <CodeInline>HidePageNumber</CodeInline> property or the <CodeInline>HidePagination</CodeInline> property to <CodeInline>true</CodeInline>, the corresponding information is hidden in the <CodeInline>MudTabPager</CodeInline>.
+                    By setting <CodeInline>HideRowsPerPage</CodeInline> property or the <CodeInline>HidePageNumber</CodeInline> property or the <CodeInline>HidePagination</CodeInline> property to <CodeInline>true</CodeInline>, the corresponding information is hidden in the <CodeInline>MudTabPager</CodeInline>.
                     The text position can be defined with the <CodeInline>TextPosition</CodeInline> property.
                 </Description>
             </SectionHeader>

--- a/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
@@ -37,13 +37,13 @@
             <SectionHeader Title="TabPager Customization">
                 <Description>
                     By setting <CodeInline>HideRowsPerPage</CodeInline> property or the <CodeInline>HidePageNumber</CodeInline> property or the <CodeInline>HidePagination</CodeInline> property to <CodeInline>true</CodeInline>, the corresponding information is hidden in the <CodeInline>MudTabPager</CodeInline>.
-                    The text position can be defined with the <CodeInline>TextPosition</CodeInline> property.
+                    The text position can be defined with the <CodeInline>HorizontalAlignment</CodeInline> property.
                 </Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" FullWidth="true">
                 <TabPagerExample />
             </SectionContent>
-            <SectionSource Code="TablePagerExample" ShowCode="false" GitHubFolderName="Table" />
+            <SectionSource Code="TabPagerExample" ShowCode="false" GitHubFolderName="Table" />
         </DocsPageSection>
 
         <DocsPageSection>

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -211,7 +211,7 @@ namespace MudBlazor.UnitTests.Components
             Console.WriteLine(comp.Markup);
             // after initial load
             comp.FindAll("tr.mud-table-row").Count.Should().Be(10);
-            comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 59");
+            comp.FindAll("div.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 59");
             comp.FindAll("button")[0].IsDisabled().Should().Be(true);
             comp.FindAll("button")[1].IsDisabled().Should().Be(true);
             comp.FindAll("button")[2].IsDisabled().Should().Be(false);
@@ -220,7 +220,7 @@ namespace MudBlazor.UnitTests.Components
             // click next page
             pagingButtons[2].Click();
             comp.FindAll("tr.mud-table-row").Count.Should().Be(10);
-            comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("11-20 of 59");
+            comp.FindAll("div.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("11-20 of 59");
             comp.FindAll("button")[0].IsDisabled().Should().Be(false);
             comp.FindAll("button")[1].IsDisabled().Should().Be(false);
             comp.FindAll("button")[2].IsDisabled().Should().Be(false);
@@ -228,7 +228,7 @@ namespace MudBlazor.UnitTests.Components
             // last page
             pagingButtons[3].Click();
             comp.FindAll("tr.mud-table-row").Count.Should().Be(9);
-            comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("51-59 of 59");
+            comp.FindAll("div.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("51-59 of 59");
             comp.FindAll("button")[0].IsDisabled().Should().Be(false);
             comp.FindAll("button")[1].IsDisabled().Should().Be(false);
             comp.FindAll("button")[2].IsDisabled().Should().Be(true);
@@ -236,7 +236,7 @@ namespace MudBlazor.UnitTests.Components
             // previous page
             pagingButtons[1].Click();
             comp.FindAll("tr.mud-table-row").Count.Should().Be(10);
-            comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("41-50 of 59");
+            comp.FindAll("div.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("41-50 of 59");
             comp.FindAll("button")[0].IsDisabled().Should().Be(false);
             comp.FindAll("button")[1].IsDisabled().Should().Be(false);
             comp.FindAll("button")[2].IsDisabled().Should().Be(false);
@@ -244,7 +244,7 @@ namespace MudBlazor.UnitTests.Components
             // first page
             pagingButtons[0].Click();
             comp.FindAll("tr.mud-table-row").Count.Should().Be(10);
-            comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 59");
+            comp.FindAll("div.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 59");
             comp.FindAll("button")[0].IsDisabled().Should().Be(true);
             comp.FindAll("button")[1].IsDisabled().Should().Be(true);
             comp.FindAll("button")[2].IsDisabled().Should().Be(false);
@@ -288,7 +288,7 @@ namespace MudBlazor.UnitTests.Components
             await table.InvokeAsync(() => table.Instance.SetRowsPerPage(20));
             pager.Value.Should().Be("20");
             comp.FindAll("tr.mud-table-row").Count.Should().Be(20);
-            comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-20 of 59");
+            comp.FindAll("div.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-20 of 59");
             comp.FindAll("button")[0].IsDisabled().Should().Be(true);
             comp.FindAll("button")[1].IsDisabled().Should().Be(true);
             comp.FindAll("button")[2].IsDisabled().Should().Be(false);
@@ -297,7 +297,7 @@ namespace MudBlazor.UnitTests.Components
             await table.InvokeAsync(() => table.Instance.SetRowsPerPage(60));
             pager.Value.Should().Be("60");
             comp.FindAll("tr.mud-table-row").Count.Should().Be(59);
-            comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-59 of 59");
+            comp.FindAll("div.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-59 of 59");
             comp.FindAll("button")[0].IsDisabled().Should().Be(true);
             comp.FindAll("button")[1].IsDisabled().Should().Be(true);
             comp.FindAll("button")[2].IsDisabled().Should().Be(true);
@@ -306,7 +306,7 @@ namespace MudBlazor.UnitTests.Components
             await table.InvokeAsync(() => table.Instance.SetRowsPerPage(10));
             pager.Value.Should().Be("10");
             comp.FindAll("tr.mud-table-row").Count.Should().Be(10);
-            comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 59");
+            comp.FindAll("div.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 59");
             comp.FindAll("button")[0].IsDisabled().Should().Be(true);
             comp.FindAll("button")[1].IsDisabled().Should().Be(true);
             comp.FindAll("button")[2].IsDisabled().Should().Be(false);
@@ -330,7 +330,7 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("td")[0].TextContent.Trim().Should().Be("1");
             comp.FindAll("td")[1].TextContent.Trim().Should().Be("2");
             comp.FindAll("td")[2].TextContent.Trim().Should().Be("3");
-            comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 99");
+            comp.FindAll("div.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 99");
             comp.FindAll("button")[0].IsDisabled().Should().Be(true);
             comp.FindAll("button")[1].IsDisabled().Should().Be(true);
             comp.FindAll("button")[2].IsDisabled().Should().Be(false);
@@ -340,7 +340,7 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("td")[0].TextContent.Trim().Should().Be("28");
             comp.FindAll("td")[1].TextContent.Trim().Should().Be("29");
             comp.FindAll("td")[2].TextContent.Trim().Should().Be("30");
-            comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("91-99 of 99");
+            comp.FindAll("div.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("91-99 of 99");
             comp.FindAll("button")[0].IsDisabled().Should().Be(false);
             comp.FindAll("button")[1].IsDisabled().Should().Be(false);
             comp.FindAll("button")[2].IsDisabled().Should().Be(true);
@@ -348,7 +348,7 @@ namespace MudBlazor.UnitTests.Components
             // change page size
             await table.InvokeAsync(() => table.Instance.SetRowsPerPage(100));
             pager.Value.Should().Be("100");
-            comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-99 of 99");
+            comp.FindAll("div.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-99 of 99");
             comp.FindAll("button")[0].IsDisabled().Should().Be(true);
             comp.FindAll("button")[1].IsDisabled().Should().Be(true);
             comp.FindAll("button")[2].IsDisabled().Should().Be(true);
@@ -366,11 +366,11 @@ namespace MudBlazor.UnitTests.Components
             // search returns 3 items
             searchString.Change("Ala");
             comp.FindAll("tr").Count.Should().Be(3);
-            comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-3 of 3");
+            comp.FindAll("div.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-3 of 3");
             // clear search
             searchString.Change(string.Empty);
             comp.FindAll("tr").Count.Should().Be(10);
-            comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 59");
+            comp.FindAll("div.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 59");
         }
 
         /// <summary>
@@ -384,24 +384,24 @@ namespace MudBlazor.UnitTests.Components
             Console.WriteLine(comp.Markup);
             // after initial load
             comp.FindAll("tr.mud-table-row").Count.Should().Be(10);
-            comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 59");
+            comp.FindAll("div.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 59");
             var pagingButtons = comp.FindAll("button");
             // goto page 3
             pagingButtons[2].Click();
             pagingButtons[2].Click();
             comp.FindAll("tr.mud-table-row").Count.Should().Be(10);
-            comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("21-30 of 59");
+            comp.FindAll("div.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("21-30 of 59");
             // should return 3 items and 
             var table = comp.FindComponent<MudTable<string>>().Instance;
             var searchString = comp.Find("#searchString");
             searchString.Change("Ala");
             table.GetFilteredItemsCount().Should().Be(3);
             comp.FindAll("tr.mud-table-row").Count.Should().Be(3);
-            comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-3 of 3");
+            comp.FindAll("div.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-3 of 3");
             searchString.Change(string.Empty);
             table.GetFilteredItemsCount().Should().Be(59);
             comp.FindAll("tr.mud-table-row").Count.Should().Be(10);
-            comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 59");
+            comp.FindAll("div.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 59");
         }
 
         /// <summary>
@@ -695,7 +695,7 @@ namespace MudBlazor.UnitTests.Components
             await Task.Delay(200);
             Console.WriteLine(comp.Markup);
             comp.FindAll("tr.mud-table-row").Count.Should().Be(11); // ten rows + header row
-            comp.FindAll("p.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 20");
+            comp.FindAll("div.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 20");
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/Table/MudTablePager.razor
+++ b/src/MudBlazor/Components/Table/MudTablePager.razor
@@ -2,7 +2,10 @@
 @inherits MudComponentBase
 
 <MudToolBar @attributes="UserAttributes" Class="@Classname" Style="@Style">
-    <div class="mud-table-pagination-spacer"></div>
+    @if (TextAlignment == TablePagerTextPosition.Right || TextAlignment == TablePagerTextPosition.Center)
+    {
+        <div class="mud-table-pagination-spacer"></div>
+    }
     @if (!DisableRowsPerPage)
     {
         <MudText Typo="Typo.body2" Class="mud-table-pagination-caption">
@@ -15,14 +18,24 @@
             }
         </MudSelect>
     }
-    <MudText Typo="Typo.body2" Class="mud-table-pagination-caption">
-        @Info
-    </MudText>
-    <div class="mud-table-pagination-actions">
-        <MudIconButton Class="mud-flip-x-rtl" Icon="@Icons.Material.Filled.FirstPage" Disabled="@BackButtonsDisabled" @onclick="@(() => Table.NavigateTo(Page.First))"/>
-        <MudIconButton Class="mud-flip-x-rtl" Icon="@Icons.Material.Filled.NavigateBefore" Disabled="@BackButtonsDisabled" @onclick="@(() => Table.NavigateTo(Page.Previous))"/>
-        <MudIconButton Class="mud-flip-x-rtl" Icon="@Icons.Material.Filled.NavigateNext" Disabled="@ForwardButtonsDisabled" @onclick="@(() => Table.NavigateTo(Page.Next))"/>
-        <MudIconButton Class="mud-flip-x-rtl" Icon="@Icons.Material.Filled.LastPage" Disabled="@ForwardButtonsDisabled" @onclick="@(() => Table.NavigateTo(Page.Last))"/>
-    </div>
+    @if (!DisablePageNumber)
+    {
+        <MudText Typo="Typo.body2" Class="mud-table-pagination-caption">
+            @Info
+        </MudText>
+    }
+    @if (!DisablePagination)
+    {
+        <div class="mud-table-pagination-actions">
+            <MudIconButton Class="mud-flip-x-rtl" Icon="@Icons.Material.Filled.FirstPage" Disabled="@BackButtonsDisabled" @onclick="@(() => Table.NavigateTo(Page.First))"/>
+            <MudIconButton Class="mud-flip-x-rtl" Icon="@Icons.Material.Filled.NavigateBefore" Disabled="@BackButtonsDisabled" @onclick="@(() => Table.NavigateTo(Page.Previous))"/>
+            <MudIconButton Class="mud-flip-x-rtl" Icon="@Icons.Material.Filled.NavigateNext" Disabled="@ForwardButtonsDisabled" @onclick="@(() => Table.NavigateTo(Page.Next))"/>
+            <MudIconButton Class="mud-flip-x-rtl" Icon="@Icons.Material.Filled.LastPage" Disabled="@ForwardButtonsDisabled" @onclick="@(() => Table.NavigateTo(Page.Last))"/>
+        </div>
+    }
+    @if (TextAlignment == TablePagerTextPosition.Left || TextAlignment == TablePagerTextPosition.Center)
+    {
+        <div class="mud-table-pagination-spacer"></div>
+    }
 </MudToolBar>
 

--- a/src/MudBlazor/Components/Table/MudTablePager.razor
+++ b/src/MudBlazor/Components/Table/MudTablePager.razor
@@ -2,38 +2,46 @@
 @inherits MudComponentBase
 
 <MudToolBar @attributes="UserAttributes" Class="@Classname" Style="@Style">
-    @if (HorizontalAlignment == HorizontalAlignment.Right || HorizontalAlignment == HorizontalAlignment.Center)
+    @if (HorizontalAlignment == HorizontalAlignment.End || 
+        (HorizontalAlignment == HorizontalAlignment.Right && !RightToLeft) || 
+        (HorizontalAlignment == HorizontalAlignment.Left && RightToLeft) || 
+         HorizontalAlignment == HorizontalAlignment.Center)
     {
         <div class="mud-table-pagination-spacer"></div>
     }
     @if (!!HideRowsPerPage)
     {
-        <MudText Typo="Typo.body2" Class="mud-table-pagination-caption">
-            @RowsPerPageString
-        </MudText>
-        <MudSelect T="string" ValueChanged="SetRowsPerPage" Value="@Table?.RowsPerPage.ToString()" Class="mud-table-pagination-select" DisableUnderLine="true" Dense="true">
+        <div class="@PaginationClassname">
+            <div class="mud-table-pagination-caption">
+                <div class="mud-table-pagination-information">@RowsPerPageString</div>
+            </div>
+            <MudSelect T="string" ValueChanged="SetRowsPerPage" Value="@Table?.RowsPerPage.ToString()" Class="mud-table-pagination-select" DisableUnderLine="true" Dense="true">
             @foreach (int pageSize in PageSizeOptions)
             {
-                <MudSelectItem T="string" Value="@pageSize.ToString()">@pageSize.ToString().ToUpper()</MudSelectItem>
+            <MudSelectItem T="string" Value="@pageSize.ToString()">@pageSize.ToString().ToUpper()</MudSelectItem>
             }
-        </MudSelect>
+            </MudSelect>
+        </div>
     }
     @if (!HidePageNumber)
     {
-        <MudText Typo="Typo.body2" Class="mud-table-pagination-caption">
-            @Info
-        </MudText>
+        <div class="mud-table-pagination-caption">
+            <div class="mud-table-page-number-information">@Info</div>
+        </div>
     }
     @if (!HidePagination)
     {
         <div class="mud-table-pagination-actions">
-            <MudIconButton Class="mud-flip-x-rtl" Icon="@Icons.Material.Filled.FirstPage" Disabled="@BackButtonsDisabled" @onclick="@(() => Table.NavigateTo(Page.First))"/>
-            <MudIconButton Class="mud-flip-x-rtl" Icon="@Icons.Material.Filled.NavigateBefore" Disabled="@BackButtonsDisabled" @onclick="@(() => Table.NavigateTo(Page.Previous))"/>
-            <MudIconButton Class="mud-flip-x-rtl" Icon="@Icons.Material.Filled.NavigateNext" Disabled="@ForwardButtonsDisabled" @onclick="@(() => Table.NavigateTo(Page.Next))"/>
-            <MudIconButton Class="mud-flip-x-rtl" Icon="@Icons.Material.Filled.LastPage" Disabled="@ForwardButtonsDisabled" @onclick="@(() => Table.NavigateTo(Page.Last))"/>
+            <MudIconButton Class="mud-flip-x-rtl" Icon="@Icons.Material.Filled.FirstPage" Disabled="@BackButtonsDisabled" @onclick="@(() => Table.NavigateTo(Page.First))" />
+            <MudIconButton Class="mud-flip-x-rtl" Icon="@Icons.Material.Filled.NavigateBefore" Disabled="@BackButtonsDisabled" @onclick="@(() => Table.NavigateTo(Page.Previous))" />
+            <MudIconButton Class="mud-flip-x-rtl" Icon="@Icons.Material.Filled.NavigateNext" Disabled="@ForwardButtonsDisabled" @onclick="@(() => Table.NavigateTo(Page.Next))" />
+            <MudIconButton Class="mud-flip-x-rtl" Icon="@Icons.Material.Filled.LastPage" Disabled="@ForwardButtonsDisabled" @onclick="@(() => Table.NavigateTo(Page.Last))" />
         </div>
     }
-    @if (HorizontalAlignment == HorizontalAlignment.Left || HorizontalAlignment == HorizontalAlignment.Center)
+    @if (HorizontalAlignment == HorizontalAlignment.Start ||
+      (HorizontalAlignment == HorizontalAlignment.Left && !RightToLeft) ||
+      (HorizontalAlignment == HorizontalAlignment.Right && RightToLeft) ||
+       HorizontalAlignment == HorizontalAlignment.Center)
     {
         <div class="mud-table-pagination-spacer"></div>
     }

--- a/src/MudBlazor/Components/Table/MudTablePager.razor
+++ b/src/MudBlazor/Components/Table/MudTablePager.razor
@@ -2,7 +2,7 @@
 @inherits MudComponentBase
 
 <MudToolBar @attributes="UserAttributes" Class="@Classname" Style="@Style">
-    @if (TextAlignment == TablePagerTextPosition.Right || TextAlignment == TablePagerTextPosition.Center)
+    @if (HorizontalAlignment == HorizontalAlignment.Right || HorizontalAlignment == HorizontalAlignment.Center)
     {
         <div class="mud-table-pagination-spacer"></div>
     }
@@ -33,7 +33,7 @@
             <MudIconButton Class="mud-flip-x-rtl" Icon="@Icons.Material.Filled.LastPage" Disabled="@ForwardButtonsDisabled" @onclick="@(() => Table.NavigateTo(Page.Last))"/>
         </div>
     }
-    @if (TextAlignment == TablePagerTextPosition.Left || TextAlignment == TablePagerTextPosition.Center)
+    @if (HorizontalAlignment == HorizontalAlignment.Left || HorizontalAlignment == HorizontalAlignment.Center)
     {
         <div class="mud-table-pagination-spacer"></div>
     }

--- a/src/MudBlazor/Components/Table/MudTablePager.razor
+++ b/src/MudBlazor/Components/Table/MudTablePager.razor
@@ -9,7 +9,7 @@
     {
         <div class="mud-table-pagination-spacer"></div>
     }
-    @if (!!HideRowsPerPage)
+    @if (!HideRowsPerPage)
     {
         <div class="@PaginationClassname">
             <div class="mud-table-pagination-caption">

--- a/src/MudBlazor/Components/Table/MudTablePager.razor
+++ b/src/MudBlazor/Components/Table/MudTablePager.razor
@@ -18,13 +18,13 @@
             }
         </MudSelect>
     }
-    @if (!DisablePageNumber)
+    @if (!HidePageNumber)
     {
         <MudText Typo="Typo.body2" Class="mud-table-pagination-caption">
             @Info
         </MudText>
     }
-    @if (!DisablePagination)
+    @if (!HidePagination)
     {
         <div class="mud-table-pagination-actions">
             <MudIconButton Class="mud-flip-x-rtl" Icon="@Icons.Material.Filled.FirstPage" Disabled="@BackButtonsDisabled" @onclick="@(() => Table.NavigateTo(Page.First))"/>

--- a/src/MudBlazor/Components/Table/MudTablePager.razor
+++ b/src/MudBlazor/Components/Table/MudTablePager.razor
@@ -6,7 +6,7 @@
     {
         <div class="mud-table-pagination-spacer"></div>
     }
-    @if (!DisableRowsPerPage)
+    @if (!!HideRowsPerPage)
     {
         <MudText Typo="Typo.body2" Class="mud-table-pagination-caption">
             @RowsPerPageString

--- a/src/MudBlazor/Components/Table/MudTablePager.razor
+++ b/src/MudBlazor/Components/Table/MudTablePager.razor
@@ -18,7 +18,7 @@
             <MudSelect T="string" ValueChanged="SetRowsPerPage" Value="@Table?.RowsPerPage.ToString()" Class="mud-table-pagination-select" DisableUnderLine="true" Dense="true">
             @foreach (int pageSize in PageSizeOptions)
             {
-            <MudSelectItem T="string" Value="@pageSize.ToString()">@pageSize.ToString().ToUpper()</MudSelectItem>
+                <MudSelectItem T="string" Value="@pageSize.ToString()">@pageSize.ToString().ToUpper()</MudSelectItem>
             }
             </MudSelect>
         </div>

--- a/src/MudBlazor/Components/Table/MudTablePager.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTablePager.razor.cs
@@ -21,12 +21,12 @@ namespace MudBlazor
         /// <summary>
         /// Set true to hide the number of pages.
         /// </summary>
-        [Parameter] public bool DisablePageNumber { get; set; }
+        [Parameter] public bool HidePageNumber { get; set; }
 
         /// <summary>
         /// Set true to hide the pagination.
         /// </summary>
-        [Parameter] public bool DisablePagination { get; set; }
+        [Parameter] public bool HidePagination { get; set; }
 
         /// <summary>
         /// Set the text position.

--- a/src/MudBlazor/Components/Table/MudTablePager.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTablePager.razor.cs
@@ -33,7 +33,7 @@ namespace MudBlazor
         /// Set true to hide the part of the pager which allows to change the page size.
         /// </summary>
         [Obsolete("DisableRowsPerPage is obsolete. Use HideRowsPerPage instead!", false)]
-        [Parameter] public bool DisableRowsPerPage { get; set; }
+        [Parameter] public bool DisableRowsPerPage { get => HideRowsPerPage; set => HideRowsPerPage = value; }
 
         /// <summary>
         /// Set true to hide the number of pages.

--- a/src/MudBlazor/Components/Table/MudTablePager.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTablePager.razor.cs
@@ -35,9 +35,9 @@ namespace MudBlazor
         [Parameter] public bool HidePagination { get; set; }
 
         /// <summary>
-        /// Set the text position.
+        /// Set the horizontal alignment position.
         /// </summary>
-        [Parameter] public TablePagerTextPosition TextAlignment { get; set; } = TablePagerTextPosition.Right;
+        [Parameter] public HorizontalAlignment HorizontalAlignment { get; set; } = HorizontalAlignment.Right;
 
         /// <summary>
         /// Define a list of available page size options for the user to choose from

--- a/src/MudBlazor/Components/Table/MudTablePager.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTablePager.razor.cs
@@ -7,9 +7,20 @@ namespace MudBlazor
     public partial class MudTablePager : MudComponentBase
     {
         protected string Classname =>
-            new CssBuilder("mud-table-pagination-toolbar")
+                    new CssBuilder("mud-table-pagination-toolbar")
+                    .AddClass("mud-tablepager-left", !RightToLeft)
+                    .AddClass("mud-tablepager-right", RightToLeft)
+                    .AddClass(Class)
+                    .Build();
+
+        protected string PaginationClassname =>
+            new CssBuilder("mud-table-pagination-display")
+            .AddClass("mud-tablepager-left", !RightToLeft)
+            .AddClass("mud-tablepager-right", RightToLeft)
             .AddClass(Class)
             .Build();
+
+        [CascadingParameter] public bool RightToLeft { get; set; }
 
         [CascadingParameter] public TableContext Context { get; set; }
 

--- a/src/MudBlazor/Components/Table/MudTablePager.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTablePager.razor.cs
@@ -19,6 +19,21 @@ namespace MudBlazor
         [Parameter] public bool DisableRowsPerPage { get; set; }
 
         /// <summary>
+        /// Set true to hide the number of pages.
+        /// </summary>
+        [Parameter] public bool DisablePageNumber { get; set; }
+
+        /// <summary>
+        /// Set true to hide the pagination.
+        /// </summary>
+        [Parameter] public bool DisablePagination { get; set; }
+
+        /// <summary>
+        /// Set the text position.
+        /// </summary>
+        [Parameter] public TablePagerTextPosition TextAlignment { get; set; } = TablePagerTextPosition.Right;
+
+        /// <summary>
         /// Define a list of available page size options for the user to choose from
         /// </summary>
         [Parameter] public int[] PageSizeOptions { get; set; } = new int[] { 10, 25, 50, 100 };

--- a/src/MudBlazor/Components/Table/MudTablePager.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTablePager.razor.cs
@@ -16,6 +16,12 @@ namespace MudBlazor
         /// <summary>
         /// Set true to hide the part of the pager which allows to change the page size.
         /// </summary>
+        [Parameter] public bool HideRowsPerPage { get; set; }
+
+        /// <summary>
+        /// Set true to hide the part of the pager which allows to change the page size.
+        /// </summary>
+        [Obsolete("DisableRowsPerPage is obsolete. Use HideRowsPerPage instead!", false)]
         [Parameter] public bool DisableRowsPerPage { get; set; }
 
         /// <summary>

--- a/src/MudBlazor/Components/Table/TablePagerTextPosition.cs
+++ b/src/MudBlazor/Components/Table/TablePagerTextPosition.cs
@@ -1,0 +1,15 @@
+﻿using System.ComponentModel;
+
+
+namespace MudBlazor
+{
+    public enum TablePagerTextPosition
+    {
+        [Description("center")]
+        Center,
+        [Description("left")]
+        Left,
+        [Description("right")]
+        Right
+    }
+}

--- a/src/MudBlazor/Enums/HorizontalAlignment.cs
+++ b/src/MudBlazor/Enums/HorizontalAlignment.cs
@@ -1,15 +1,18 @@
 ﻿using System.ComponentModel;
 
-
 namespace MudBlazor
 {
-    public enum TablePagerTextPosition
+    public enum HorizontalAlignment
     {
         [Description("center")]
         Center,
         [Description("left")]
         Left,
         [Description("right")]
-        Right
+        Right,
+        [Description("start")]
+        Start,
+        [Description("end")]
+        End
     }
 }

--- a/src/MudBlazor/Styles/components/_table.scss
+++ b/src/MudBlazor/Styles/components/_table.scss
@@ -302,14 +302,17 @@
 
 .mud-table-pagination-caption {
     flex-shrink: 0;
+    align-items: center;
+    padding-left: 10px;
+    padding-right: 10px;
 }
 
 .mud-table-pagination-select {
     cursor: pointer;
     margin-left: 10px !important;
     margin-right: 10px !important;
+    margin-top: 3px !important;
     min-width: 52px;
-    margin-top: 0px !important;
 
     & .mud-select-input {
         margin-top: 0px !important;
@@ -330,9 +333,11 @@
 
 .mud-table-pagination-actions {
     flex-shrink: 0;
-    margin-left: 20px;
-    margin-inline-start: 20px;
+    align-items: center;
+    margin-left: 10px;
+    margin-inline-start: 10px;
     margin-inline-end: unset;
+    margin-bottom: 2px !important;
 }
 
 .mud-table-smalldevices-sortselect {

--- a/src/MudBlazor/Styles/components/_table.scss
+++ b/src/MudBlazor/Styles/components/_table.scss
@@ -337,7 +337,7 @@
     margin-left: 10px;
     margin-inline-start: 10px;
     margin-inline-end: unset;
-    margin-bottom: 2px !important;
+    margin-bottom: 3px !important;
 }
 
 .mud-table-smalldevices-sortselect {

--- a/src/MudBlazor/Styles/components/_table.scss
+++ b/src/MudBlazor/Styles/components/_table.scss
@@ -277,6 +277,30 @@
     }
 }
 
+.mud-table-pagination-display {
+    display: flex;
+    flex-shrink: 0;
+
+    & .mud-tablepager-left {
+        flex-direction: row !important;
+    }
+
+    & .mud-tablepager-right {
+        flex-direction: row-reverse !important;
+    }
+}
+
+.mud-table-pagination-information {
+    white-space: nowrap;
+    direction: initial;
+    margin-top: 6px;
+}
+
+.mud-table-page-number-information {
+    white-space: nowrap;
+    direction: initial;
+}
+
 .mud-table-pagination {
     color: var(--mud-theme-on-surface);
     overflow: auto;
@@ -294,6 +318,14 @@
     padding-right: 2px;
     padding-inline-end: 2px;
     padding-inline-start: unset;
+
+    & .mud-tablepager-left {
+        flex-direction: row !important;
+    }
+
+    & .mud-tablepager-right {
+        flex-direction: row-reverse !important;
+    }
 }
 
 .mud-table-pagination-spacer {


### PR DESCRIPTION
Here are the list of modifications. This gives you the ability to customize what information will be displayed and where it will be displayed.

* Property to hide the Page Number  with ```HidePageNumber```
* Property to hide the Pagination with ```HidePagination```
* Property to define the elements position with ```HorizontalAligment```
* Better vertical alignment of all information in the ```MudTabPager``` (blue line on the attached screenshot)
* There is now a space separation on the left edge for better display (orange square on the attached screenshot)
* ```DisableRowsPerPage``` parameter is now _obsolete_. It has been replaced by the ```HideRowsPerPage``` parameter
* An example has been added in the documentation

![image](https://user-images.githubusercontent.com/16502423/127772201-fb148658-f00d-46e3-96b9-85ecf444a382.png)

![image](https://user-images.githubusercontent.com/16502423/128644935-55b64a76-63e7-4466-9542-0bcd229add23.png)