### PR TITLE
MudColorPicker fixing unstable hue value in spectrum mode and enable click inside the selection circle

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
@@ -453,7 +453,8 @@ namespace MudBlazor.UnitTests.Components
 
             overlay.Click(new MouseEventArgs { OffsetX = x, OffsetY = y });
 
-            MudColor expectedColor = "#232232ff";
+            MudColor color = "#232232ff";
+            MudColor expectedColor = new MudColor(color.R, color.G, color.B, _defaultColor);
 
             CheckColorRelatedValues(comp, x, y, expectedColor, ColorPickerMode.RGB);
         }

--- a/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
@@ -1241,5 +1241,37 @@ namespace MudBlazor.UnitTests.Components
                 }
             }
         }
+
+        [Test]
+        public void Click_Selector_ColorPanel()
+        {
+            var comp = Context.RenderComponent<SimpleColorPickerTest>();
+            Console.WriteLine(comp.Markup);
+
+            var overlay = comp.Find(CssSelector);
+
+            var x = 99.2;
+            var y = 200.98;
+
+            overlay.Click(new MouseEventArgs { OffsetX = x, OffsetY = y });
+
+            MudColor color = "#232232ff";
+            MudColor expectedColor = new MudColor(color.R, color.G, color.B, _defaultColor);
+
+            CheckColorRelatedValues(comp, x, y, expectedColor, ColorPickerMode.RGB);
+
+            var selector = comp.Find(".mud-picker-color-selector");
+
+            //a click in the center of the selector shouldn't change something
+            selector.Click(new MouseEventArgs { OffsetX = 13, OffsetY = 13 });
+
+            CheckColorRelatedValues(comp, x, y, expectedColor, ColorPickerMode.RGB);
+
+            selector.Click(new MouseEventArgs { OffsetX = 5, OffsetY = 20 });
+
+            MudColor secondExpectedColor = new MudColor(31, 30, 42, _defaultColor);
+            CheckColorRelatedValues(comp, x - 8, y + 7, secondExpectedColor, ColorPickerMode.RGB);
+
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
@@ -1214,5 +1214,31 @@ namespace MudBlazor.UnitTests.Components
                 _eventListener.ElementIdMapper.Keys.Should().BeEmpty();
             }
         }
+
+        [Test]
+        public void StableHue_WhenColorSpectrumClicked()
+        {
+            var comp = Context.RenderComponent<MudColorPicker>(p =>
+            {
+                p.Add(x => x.PickerVariant, PickerVariant.Static);
+                p.Add(x => x.ColorPickerView, ColorPickerView.Spectrum);
+            });
+
+            Console.WriteLine(comp.Markup);
+
+            var overlay = comp.Find(CssSelector);
+
+            double expectedHue = _defaultColor.H;
+
+            for (int x = 0; x < 312; x += 5)
+            {
+                for (int y = 0; y < 250; y += 5)
+                {
+                    overlay.Click(new MouseEventArgs { OffsetX = x, OffsetY = y });
+
+                    comp.Instance.Value.H.Should().Be(expectedHue);
+                }
+            }
+        }
     }
 }

--- a/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor
+++ b/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor
@@ -28,8 +28,8 @@
                         <div class="mud-picker-color-overlay" style="@($"background-color: {_baseColor.ToString(MudColorOutputFormats.RGB)}")">
                             <div class="mud-picker-color-overlay mud-picker-color-overlay-white">
                                 <div class="mud-picker-color-overlay mud-picker-color-overlay-black">
-                                    <div class="mud-picker-color-overlay" id="@_id" @onclick="OnMouseClick">
-                                        <svg class="mud-picker-color-selector" height="26" width="26" style="transform: @GetSelectorLocation()" @onclick:stopPropagation="true">
+                                    <div class="mud-picker-color-overlay" id="@_id" @onclick="OnColorOverlayClick">
+                                        <svg class="mud-picker-color-selector" height="26" width="26" style="transform: @GetSelectorLocation()" @onclick="OnSelectorClicked" @onclick:stopPropagation="true">
                                             <defs>
                                                 <filter id="mud-picker-color-selector-shadow" x="-50%" y="-50%" width="200%" height="200%">
                                                     <feGaussianBlur in="SourceAlpha" stdDeviation="1" />

--- a/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
+++ b/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
@@ -290,7 +290,8 @@ namespace MudBlazor
             var b = b_x * y;
 
             _skipFeedback = true;
-            Value = new MudColor((byte)r, (byte)g, (byte)b, _color.A);
+            //in this mode, H is expected to be stable, so copy H value
+            Value = new MudColor((byte)r, (byte)g, (byte)b, _color);
             _skipFeedback = false;
         }
 

--- a/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
+++ b/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
@@ -37,6 +37,7 @@ namespace MudBlazor
 
         private const double _maxY = 250;
         private const double _maxX = 312;
+        private const double _selctorSize = 26.0;
 
         private double _selectorX;
         private double _selectorY;
@@ -330,9 +331,8 @@ namespace MudBlazor
 
         #region mouse interactions
 
-        private void OnMouseClick(MouseEventArgs e)
+        private void HandleColorOverlayClicked()
         {
-            SetSelectorBasedOnMouseEvents(e);
             UpdateColorBaseOnSelection();
 
             if (IsAnyControlVisible() == false)
@@ -341,19 +341,31 @@ namespace MudBlazor
             }
         }
 
+        private void OnSelectorClicked(MouseEventArgs e)
+        {
+            SetSelectorBasedOnMouseEvents(e, false);
+            HandleColorOverlayClicked();
+        }
+
+        private void OnColorOverlayClick(MouseEventArgs e)
+        {
+            SetSelectorBasedOnMouseEvents(e, true);
+            HandleColorOverlayClicked();
+        }
+
         private void OnMouseOver(MouseEventArgs e)
         {
             if (e.Buttons == 1)
             {
-                SetSelectorBasedOnMouseEvents(e);
+                SetSelectorBasedOnMouseEvents(e, true);
                 UpdateColorBaseOnSelection();
             }
         }
 
-        private void SetSelectorBasedOnMouseEvents(MouseEventArgs e)
+        private void SetSelectorBasedOnMouseEvents(MouseEventArgs e, bool offsetIsAbsolute)
         {
-            _selectorX = e.OffsetX.EnsureRange(_maxX);
-            _selectorY = e.OffsetY.EnsureRange(_maxY);
+            _selectorX = (offsetIsAbsolute == true ? e.OffsetX : (e.OffsetX - _selctorSize / 2.0) + _selectorX).EnsureRange(_maxX);
+            _selectorY = (offsetIsAbsolute == true ? e.OffsetY : (e.OffsetY - _selctorSize / 2.0) + _selectorY).EnsureRange(_maxY);
         }
 
         #endregion

--- a/src/MudBlazor/Utilities/MudColor.cs
+++ b/src/MudBlazor/Utilities/MudColor.cs
@@ -133,6 +133,18 @@ namespace MudBlazor.Utilities
             CalculateHSL();
         }
 
+        /// <summary>
+        /// initilize a new MudColor with new RGB values but keeps the hue value from the color
+        /// </summary>
+        /// <param name="r">R</param>
+        /// <param name="g">G</param>
+        /// <param name="b">B</param>
+        /// <param name="color">Existing color to copy hue value from </param>
+        public MudColor(byte r, byte g, byte b, MudColor color) : this(r,g,b,color.A)
+        {
+            H = color.H;
+        }
+
         public MudColor(int r, int g, int b, double alpha) :
          this(r, g, b, (byte)((alpha * 255.0).EnsureRange(255)))
         {


### PR DESCRIPTION
This PR contains two fixes

### 1. Stabilizing hue during selection in the spectrum mode

Currently, the hue value is not stable when a color is selected in the spectrum mode.

![79e8e182f3](https://user-images.githubusercontent.com/51370361/127970821-c2a45a37-abd1-4f99-9405-4545aaa12a14.gif)

This is the result of the different color spaces between HSL and RGB. For the same RGB colors multiple HSL exists and vice versa. I have introduced a new constructor of ``MudColor`` to accept a color where the H value is copied. This constructor is used, in the ``MouseClick`` event handler. 

![color-picker-stable-hue](https://user-images.githubusercontent.com/51370361/127971006-70cbe8eb-d502-454f-9b77-e72fb8c62e79.gif)

Besides, there is a new unit test to cover this behavior. 

### 2. Enable click inside the selector

The selector only changes if a click outside of the selector circle itself is registered.

![2491e146ff](https://user-images.githubusercontent.com/51370361/128121531-c0e5d47d-758b-4fb7-b93e-67a21417c6b4.gif)

The selector has now a click event handler and the handling involves that the offset values are relative values. 

```
private void SetSelectorBasedOnMouseEvents(MouseEventArgs e, bool offsetIsAbsolute)
{
    _selectorX = (offsetIsAbsolute == true ? e.OffsetX : (e.OffsetX - _selctorSize / 2.0) + _selectorX).EnsureRange(_maxX);
   _selectorY = (offsetIsAbsolute == true ? e.OffsetY : (e.OffsetY - _selctorSize / 2.0) + _selectorY).EnsureRange(_maxY);
}
```

![color-picker-click-inside-selector](https://user-images.githubusercontent.com/51370361/128121759-a2aabb14-da89-4273-9211-72db99b8cece.gif)

A unit test for that is included too.