### PR TITLE
MudNavLink: re-use OnClickHandler from MudBaseSelectItem 

### DIFF
--- a/src/MudBlazor/Components/NavMenu/MudNavLink.razor
+++ b/src/MudBlazor/Components/NavMenu/MudNavLink.razor
@@ -3,14 +3,14 @@
 @using Microsoft.AspNetCore.Components.Routing
 
 <div @attributes="UserAttributes" class="@Classname" disabled="@Disabled" style="@Style">
-    @if (!OnClick.HasDelegate) 
+    @if (!OnClick.HasDelegate && Command == null)
     { 
         <NavLink @onclick="@HandleNavigation" 
                  class="@LinkClassname" 
                  @attributes="@Attributes"
                  Match="@Match" 
                  ActiveClass="active">
-            @if (!String.IsNullOrEmpty(Icon))
+            @if (!string.IsNullOrEmpty(Icon))
             {
                 <MudIcon Icon="@Icon" Color="@IconColor" Class="@IconClassname"/>
             }
@@ -21,10 +21,10 @@
     }
     else
     {
-        <div @onclick="HandleClick"
+        <div @onclick="OnClickHandler"
              class="@LinkClassname"
              ActiveClass="active">
-            @if (!String.IsNullOrEmpty(Icon))
+            @if (!string.IsNullOrEmpty(Icon))
             {
                 <MudIcon Icon="@Icon" Color="@IconColor" Class="@IconClassname" />
             }

--- a/src/MudBlazor/Components/NavMenu/MudNavLink.razor.cs
+++ b/src/MudBlazor/Components/NavMenu/MudNavLink.razor.cs
@@ -58,17 +58,6 @@ namespace MudBlazor
             {
                 return NavigationEventReceiver.OnNavigation();
             }
-
-            return Task.CompletedTask;
-        }
-
-        private Task HandleClick(MouseEventArgs args)
-        {
-            if (!Disabled)
-            {
-                return OnClick.InvokeAsync(args);
-            }
-
             return Task.CompletedTask;
         }
     }


### PR DESCRIPTION
Issue: #2052.
in `<MudNavLink>` reuse OnClickHandler from `MudBaseSelectItem` which handles Command