### PR TITLE
MudAlert : AlertTextPosition parameter replacement by ContentAlignment parameter

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Alert/AlertPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Alert/AlertPage.razor
@@ -6,7 +6,7 @@
         <DocsPageSection>
             <SectionHeader Title="Simple alerts">
                 <Description>
-                    There are five severity levels that each set a different icon and a color. Set the <CodeInline>TextPosition</CodeInline> property to define the text position.
+                    There are five severity levels that each set a different icon and a color.
                 </Description>
             </SectionHeader>
             <SectionContent Outlined="true" FullWidth="true">
@@ -70,15 +70,15 @@
             <SectionSource Code="AlertElevationExample" ShowCode="true" GitHubFolderName="Alert" />
         </DocsPageSection>
         <DocsPageSection>
-            <SectionHeader Title="Text Position">
+            <SectionHeader Title="Content Alignment">
                 <Description>
-                    Set the <CodeInline>AlertTextPosition</CodeInline> property to define the text position.
+                    Set the <CodeInline>ContentAlignment</CodeInline> property to define the content alignment.
                 </Description>
             </SectionHeader>
             <SectionContent Outlined="true" FullWidth="true">
-                <AlertPositionExample />
+                <AlertAlignmentExample />
             </SectionContent>
-            <SectionSource Code="AlertPositionExample" GitHubFolderName="Alert" />
+            <SectionSource Code="AlertAlignmentExample" GitHubFolderName="Alert" />
         </DocsPageSection>
         <DocsPageSection>
             <SectionHeader Title="Close Icon and Event">

--- a/src/MudBlazor.Docs/Pages/Components/Alert/Examples/AlertAlignmentExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Alert/Examples/AlertAlignmentExample.razor
@@ -1,0 +1,7 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudAlert Severity="Severity.Normal" ContentAlignment="HorizontalAlignment.Left">Left</MudAlert>
+<MudAlert Severity="Severity.Info" ContentAlignment="HorizontalAlignment.Center">Center</MudAlert>
+<MudAlert Severity="Severity.Success" ContentAlignment="HorizontalAlignment.Right">Right</MudAlert>
+<MudAlert Severity="Severity.Warning" ContentAlignment="HorizontalAlignment.Start">Start</MudAlert>
+<MudAlert Severity="Severity.Error" ContentAlignment="HorizontalAlignment.End">End</MudAlert>

--- a/src/MudBlazor.Docs/Pages/Components/Alert/Examples/AlertCloseExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Alert/Examples/AlertCloseExample.razor
@@ -2,11 +2,11 @@
 
 @if (showLeaveAlert)
 {
-    <MudAlert Severity="Severity.Info" AlertTextPosition="AlertTextPosition.Center" ShowCloseIcon="true" CloseIconClicked="(() => CloseMe(true))">Time to leave. Please close me!</MudAlert>
+    <MudAlert Severity="Severity.Info" ContentAlignment="HorizontalAlignment.Center" ShowCloseIcon="true" CloseIconClicked="(() => CloseMe(true))">Time to leave. Please close me!</MudAlert>
 }
 @if (showCallAlert)
 {
-    <MudAlert Severity="Severity.Success" AlertTextPosition="AlertTextPosition.Center" ShowCloseIcon="true" CloseIconClicked="(() => CloseMe(false))">Time to call. Please close me!</MudAlert>
+    <MudAlert Severity="Severity.Success" ContentAlignment="HorizontalAlignment.Center" ShowCloseIcon="true" CloseIconClicked="(() => CloseMe(false))">Time to call. Please close me!</MudAlert>
 }
 @if (!showLeaveAlert && !showCallAlert)
 {

--- a/src/MudBlazor.Docs/Pages/Components/Alert/Examples/AlertPositionExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Alert/Examples/AlertPositionExample.razor
@@ -1,7 +1,0 @@
-﻿@namespace MudBlazor.Docs.Examples
-
-<MudAlert Severity="Severity.Normal" AlertTextPosition="AlertTextPosition.Left">Left</MudAlert>
-<MudAlert Severity="Severity.Info" AlertTextPosition="AlertTextPosition.Center">Center</MudAlert>
-<MudAlert Severity="Severity.Success" AlertTextPosition="AlertTextPosition.Right">Right</MudAlert>
-<MudAlert Severity="Severity.Warning" AlertTextPosition="AlertTextPosition.Start">Start</MudAlert>
-<MudAlert Severity="Severity.Error" AlertTextPosition="AlertTextPosition.End">End</MudAlert>

--- a/src/MudBlazor/Components/Alert/MudAlert.razor.cs
+++ b/src/MudBlazor/Components/Alert/MudAlert.razor.cs
@@ -34,28 +34,6 @@ namespace MudBlazor
             };
         }
 
-        private void SetContentAlignment(AlertTextPosition alertTextPosition)
-        {
-            switch (alertTextPosition)
-            {
-                case AlertTextPosition.Right:
-                    ContentAlignment = HorizontalAlignment.Right;
-                    break;
-                case AlertTextPosition.Left:
-                    ContentAlignment = HorizontalAlignment.Left;
-                    break;
-                case AlertTextPosition.Start:
-                    ContentAlignment = HorizontalAlignment.Start;
-                    break;
-                case AlertTextPosition.End:
-                    ContentAlignment = HorizontalAlignment.End;
-                    break;
-                case AlertTextPosition.Center:
-                    ContentAlignment = HorizontalAlignment.Center;
-                    break;
-            };
-        }
-
         [CascadingParameter] public bool RightToLeft { get; set; }
 
         /// <summary>
@@ -66,9 +44,13 @@ namespace MudBlazor
         /// <summary>
         /// Sets the position of the text to the start (Left in LTR and right in RTL).
         /// </summary>
-        private AlertTextPosition alertTextPosition = AlertTextPosition.Left;
         [Obsolete("AlertTextPosition is obsolete. Use ContentAlignment instead!", false)]
-        [Parameter] public AlertTextPosition AlertTextPosition { get { return alertTextPosition; } set { SetContentAlignment(value); alertTextPosition = value; }}
+        [Parameter]
+        public AlertTextPosition AlertTextPosition
+        {
+            get => (AlertTextPosition)ContentAlignment;
+            set => ContentAlignment = (HorizontalAlignment)value;
+        }
 
         /// <summary>
         /// The callback, when the close button has been clicked.

--- a/src/MudBlazor/Components/Alert/MudAlert.razor.cs
+++ b/src/MudBlazor/Components/Alert/MudAlert.razor.cs
@@ -21,16 +21,38 @@ namespace MudBlazor
 
         protected string ClassPosition =>
         new CssBuilder("mud-alert-position")
-            .AddClass($"justify-sm-{ConvertAlertTextPosition(AlertTextPosition).ToDescriptionString()}")
+            .AddClass($"justify-sm-{ConvertHorizontalAlignment(ContentAlignment).ToDescriptionString()}")
         .Build();
 
-        private AlertTextPosition ConvertAlertTextPosition(AlertTextPosition alertTextPosition)
+        private HorizontalAlignment ConvertHorizontalAlignment(HorizontalAlignment contentAlignment)
         {
-            return alertTextPosition switch
+            return contentAlignment switch
             {
-                AlertTextPosition.Right => RightToLeft ? AlertTextPosition.Start : AlertTextPosition.End,
-                AlertTextPosition.Left => RightToLeft ? AlertTextPosition.End : AlertTextPosition.Start,
-                _ => alertTextPosition
+                HorizontalAlignment.Right => RightToLeft ? HorizontalAlignment.Start : HorizontalAlignment.End,
+                HorizontalAlignment.Left => RightToLeft ? HorizontalAlignment.End : HorizontalAlignment.Start,
+                _ => contentAlignment
+            };
+        }
+
+        private void SetContentAlignment(AlertTextPosition alertTextPosition)
+        {
+            switch (alertTextPosition)
+            {
+                case AlertTextPosition.Right:
+                    ContentAlignment = HorizontalAlignment.Right;
+                    break;
+                case AlertTextPosition.Left:
+                    ContentAlignment = HorizontalAlignment.Left;
+                    break;
+                case AlertTextPosition.Start:
+                    ContentAlignment = HorizontalAlignment.Start;
+                    break;
+                case AlertTextPosition.End:
+                    ContentAlignment = HorizontalAlignment.End;
+                    break;
+                case AlertTextPosition.Center:
+                    ContentAlignment = HorizontalAlignment.Center;
+                    break;
             };
         }
 
@@ -39,7 +61,14 @@ namespace MudBlazor
         /// <summary>
         /// Sets the position of the text to the start (Left in LTR and right in RTL).
         /// </summary>
-        [Parameter] public AlertTextPosition AlertTextPosition { get; set; } = AlertTextPosition.Left;
+        [Parameter] public HorizontalAlignment ContentAlignment { get; set; } = HorizontalAlignment.Left;
+
+        /// <summary>
+        /// Sets the position of the text to the start (Left in LTR and right in RTL).
+        /// </summary>
+        private AlertTextPosition alertTextPosition = AlertTextPosition.Left;
+        [Obsolete("AlertTextPosition is obsolete. Use ContentAlignment instead!", false)]
+        [Parameter] public AlertTextPosition AlertTextPosition { get { return alertTextPosition; } set { SetContentAlignment(value); alertTextPosition = value; }}
 
         /// <summary>
         /// The callback, when the close button has been clicked.


### PR DESCRIPTION
* The ```AlertTextPosition``` parameter is replaced by the ```ContentAlignment``` parameter.
* The ```AlertTextPosition``` parameter still works but is marked as _Obsolete_.
* The example in the official documentation has been updated as well.

![image](https://user-images.githubusercontent.com/16502423/128743630-a3f74281-1d69-4407-b6f3-26b31ccb8c31.png)