### PR TITLE
Fixed invisible MudText with Typo.inherit

### DIFF
--- a/src/MudBlazor/Components/Typography/MudText.razor
+++ b/src/MudBlazor/Components/Typography/MudText.razor
@@ -43,4 +43,7 @@
     case Typo.overline:
         <span @attributes="UserAttributes" class="@Classname" style="@Style">@ChildContent</span>
         break;
+    case Typo.inherit:
+        <span @attributes="UserAttributes" class="@Classname" style="@Style">@ChildContent</span>
+        break;
 }


### PR DESCRIPTION
MudText with Typo.inherit was not created due to missing case in switch statement.