### PR TITLE
Added XXL  breakpoint

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Hidden/Examples/HiddenExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Hidden/Examples/HiddenExample.razor
@@ -1,6 +1,11 @@
 ﻿@using MudBlazor.Services
 @namespace MudBlazor.Docs.Examples
 
+<MudHidden Breakpoint="Breakpoint.Xxl" Invert="true">
+    <MudCard Class="pa-5">
+        <MudText>XXL</MudText>
+    </MudCard>
+</MudHidden>
 <MudHidden Breakpoint="Breakpoint.Xl" Invert="true">
     <MudCard Class="pa-5">
         <MudText>XL</MudText>

--- a/src/MudBlazor.Docs/Pages/Features/Breakpoints/BreakpointsPage.razor
+++ b/src/MudBlazor.Docs/Pages/Features/Breakpoints/BreakpointsPage.razor
@@ -59,8 +59,17 @@
                                 <MudText Inline="true">Extra Large</MudText>
                             </td>
                             <td>xl</td>
-                            <td>4k and ultra-wide</td>
-                            <td>> 1920px*</td>
+                            <td>HD and 4k</td>
+                            <td>1920px > &lt; 2560px</td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <MudIcon Icon="@Icons.Material.Filled.Tv" Class="mb-n1 mr-1" />
+                                <MudText Inline="true">Extra Extra Large</MudText>
+                            </td>
+                            <td>xx</td>
+                            <td>4k+ and ultra-wide</td>
+                            <td>>= 2560px*</td>
                         </tr>
                     </tbody>
                 </MudSimpleTable>

--- a/src/MudBlazor.Docs/Pages/Features/Display/DisplayPage.razor
+++ b/src/MudBlazor.Docs/Pages/Features/Display/DisplayPage.razor
@@ -6,7 +6,7 @@
         <DocsPageSection>
             <SectionHeader Title="How it works">
                 <Description>
-                    <MudText>Specify the element's <CodeInline>display</CodeInline> property, the classes can be used with all breakpoints from <CodeInline>xs</CodeInline> to <CodeInline>xl</CodeInline>.</MudText>
+                    <MudText>Specify the element's <CodeInline>display</CodeInline> property, the classes can be used with all breakpoints from <CodeInline>xs</CodeInline> to <CodeInline>xxl</CodeInline>.</MudText>
                 </Description>
             </SectionHeader>
             <div class="d-flex">
@@ -15,7 +15,7 @@
             <MudText Class="pt-6 pb-2">The <b>properties</b></MudText>
             <ul class="mud-typography-body1">
                 <li><CodeInline>.d-{value}</CodeInline> - for <CodeInline>xs</CodeInline></li>
-                <li><CodeInline>.d-{breakpoint}-{value}</CodeInline> - for <CodeInline>sm</CodeInline>, <CodeInline>md</CodeInline>, <CodeInline>lg</CodeInline> and <CodeInline>xl</CodeInline></li>
+                <li><CodeInline>.d-{breakpoint}-{value}</CodeInline> - for <CodeInline>sm</CodeInline>, <CodeInline>md</CodeInline>, <CodeInline>lg</CodeInline>, <CodeInline>xl</CodeInline> and <CodeInline>xxl</CodeInline></li>
             </ul>
             <MudText Class="pt-6 pb-2">The <b>value</b> property is one of these</MudText>
             <MudGrid>
@@ -71,13 +71,15 @@
                     <tr><td>Hidden only on sm</td> <td><CodeInline>.d-sm-none .d-md-flex</CodeInline></td></tr>
                     <tr><td>Hidden only on md</td> <td><CodeInline>.d-md-none .d-lg-flex</CodeInline></td></tr>
                     <tr><td>Hidden only on lg</td> <td><CodeInline>.d-lg-none .d-xl-flex</CodeInline></td></tr>
-                    <tr><td>Hidden only on xl</td> <td><CodeInline>.d-xl-none</CodeInline></td></tr>
+                    <tr><td>Hidden only on xl</td> <td><CodeInline>.d-xl-none .d-xxl-flex</CodeInline></td></tr>
+                    <tr><td>Hidden only on xxl</td> <td><CodeInline>.d-xxl-none</CodeInline></td></tr>
                     <tr><td>Visible on all</td> <td><CodeInline>.d-flex</CodeInline></td></tr>
                     <tr><td>Visible only on xs</td> <td><CodeInline>.d-flex .d-sm-none</CodeInline></td></tr>
                     <tr><td>Visible only on sm</td> <td><CodeInline>.d-none .d-sm-flex .d-md-none</CodeInline></td></tr>
                     <tr><td>Visible only on md</td> <td><CodeInline>.d-none .d-md-flex .d-lg-none</CodeInline></td></tr>
                     <tr><td>Visible only on lg</td> <td><CodeInline>.d-none .d-lg-flex .d-xl-none</CodeInline></td></tr>
-                    <tr><td>Visible only on xl</td> <td><CodeInline>.d-none .d-xl-flex</CodeInline></td></tr>
+                    <tr><td>Visible only on xl</td> <td><CodeInline>.d-none .d-xl-flex .d-xxl-none</CodeInline></td></tr>
+                    <tr><td>Visible only on xxl</td> <td><CodeInline>.d-none .d-xxl-flex</CodeInline></td></tr>
                 </tbody>
             </MudSimpleTable>
             <SectionContent DarkenBackground="true" DisplayFlex="true" Class="mt-6">

--- a/src/MudBlazor.Docs/Pages/Features/Flex/FlexPage.razor
+++ b/src/MudBlazor.Docs/Pages/Features/Flex/FlexPage.razor
@@ -29,9 +29,13 @@
                     <MudText>.d-lg-flex</MudText>
                     <MudText>.d-inline-lg-flex</MudText>
                 </MudItem>
-                <MudItem xs="12" sm="12" md="2">
+                <MudItem xs="4" sm="6" md="2">
                     <MudText>.d-xl-flex</MudText>
                     <MudText>.d-inline-xl-flex</MudText>
+                </MudItem>
+                <MudItem xs="4" sm="6" md="2">
+                    <MudText>.d-xxl-flex</MudText>
+                    <MudText>.d-inline-xxl-flex</MudText>
                 </MudItem>
             </MudGrid>
         </DocsPageSection>
@@ -50,26 +54,30 @@
                     <MudText>.flex-row-reverse</MudText>
                     <MudText>.flex-column</MudText>
                     <MudText>.flex-column-reverse</MudText>
-                </MudItem>
-                <MudItem xs="6" sm="6" md="4">
                     <MudText>.flex-sm-row</MudText>
                     <MudText>.flex-sm-row-reverse</MudText>
                     <MudText>.flex-sm-column</MudText>
                     <MudText>.flex-sm-column-reverse</MudText>
+                </MudItem>
+                <MudItem xs="6" sm="6" md="4">
                     <MudText>.flex-md-row</MudText>
                     <MudText>.flex-md-row-reverse</MudText>
                     <MudText>.flex-md-column</MudText>
                     <MudText>.flex-md-column-reverse</MudText>
-                </MudItem>
-                <MudItem xs="12" sm="12" md="4">
                     <MudText>.flex-lg-row</MudText>
                     <MudText>.flex-lg-row-reverse</MudText>
                     <MudText>.flex-lg-column</MudText>
                     <MudText>.flex-lg-column-reverse</MudText>
+                </MudItem>
+                <MudItem xs="12" sm="12" md="4">
                     <MudText>.flex-xl-row</MudText>
                     <MudText>.flex-xl-row-reverse</MudText>
                     <MudText>.flex-xl-column</MudText>
                     <MudText>.flex-xl-column-reverse</MudText>
+                    <MudText>.flex-xxl-row</MudText>
+                    <MudText>.flex-xxl-row-reverse</MudText>
+                    <MudText>.flex-xxl-column</MudText>
+                    <MudText>.flex-xxl-column-reverse</MudText>
                 </MudItem>
             </MudGrid>
         </DocsPageSection>
@@ -89,30 +97,35 @@
                     <MudText>.justify-center</MudText>
                     <MudText>.justify-space-between</MudText>
                     <MudText>.justify-space-around</MudText>
-                </MudItem>
-                <MudItem xs="6" sm="6" md="4">
                     <MudText>.justify-sm-start</MudText>
                     <MudText>.justify-sm-end</MudText>
                     <MudText>.justify-sm-center</MudText>
                     <MudText>.justify-sm-space-between</MudText>
                     <MudText>.justify-sm-space-around</MudText>
+                </MudItem>
+                <MudItem xs="6" sm="6" md="4">
                     <MudText>.justify-md-start</MudText>
                     <MudText>.justify-md-end</MudText>
                     <MudText>.justify-md-center</MudText>
                     <MudText>.justify-md-space-between</MudText>
                     <MudText>.justify-md-space-around</MudText>
-                </MudItem>
-                <MudItem xs="12" sm="12" md="4">
                     <MudText>.justify-lg-start</MudText>
                     <MudText>.justify-lg-end</MudText>
                     <MudText>.justify-lg-center</MudText>
                     <MudText>.justify-lg-space-between</MudText>
                     <MudText>.justify-lg-space-around</MudText>
+                </MudItem>
+                <MudItem xs="12" sm="12" md="4">
                     <MudText>.justify-xl-start</MudText>
                     <MudText>.justify-xl-end</MudText>
                     <MudText>.justify-xl-center</MudText>
                     <MudText>.justify-xl-space-between</MudText>
                     <MudText>.justify-xl-space-around</MudText>
+                    <MudText>.justify-xxl-start</MudText>
+                    <MudText>.justify-xxl-end</MudText>
+                    <MudText>.justify-xxl-center</MudText>
+                    <MudText>.justify-xxl-space-between</MudText>
+                    <MudText>.justify-xxl-space-around</MudText>
                 </MudItem>
             </MudGrid>
         </DocsPageSection>
@@ -132,30 +145,35 @@
                     <MudText>.align-center</MudText>
                     <MudText>.align-baseline</MudText>
                     <MudText>.align-stretch</MudText>
-                </MudItem>
-                <MudItem xs="6" sm="6" md="4">
                     <MudText>.align-sm-start</MudText>
                     <MudText>.align-sm-end</MudText>
                     <MudText>.align-sm-center</MudText>
                     <MudText>.align-sm-baseline</MudText>
                     <MudText>.align-sm-stretch</MudText>
+                </MudItem>
+                <MudItem xs="6" sm="6" md="4">
                     <MudText>.align-md-start</MudText>
                     <MudText>.align-md-end</MudText>
                     <MudText>.align-md-center</MudText>
                     <MudText>.align-md-baseline</MudText>
                     <MudText>.align-md-stretch</MudText>
-                </MudItem>
-                <MudItem xs="12" sm="12" md="4">
                     <MudText>.align-lg-start</MudText>
                     <MudText>.align-lg-end</MudText>
                     <MudText>.align-lg-center</MudText>
                     <MudText>.align-lg-baseline</MudText>
                     <MudText>.align-lg-stretch</MudText>
+                </MudItem>
+                <MudItem xs="12" sm="12" md="4">
                     <MudText>.align-xl-start</MudText>
                     <MudText>.align-xl-end</MudText>
                     <MudText>.align-xl-center</MudText>
                     <MudText>.align-xl-baseline</MudText>
                     <MudText>.align-xl-stretch</MudText>
+                    <MudText>.align-xxl-start</MudText>
+                    <MudText>.align-xxl-end</MudText>
+                    <MudText>.align-xxl-center</MudText>
+                    <MudText>.align-xxl-baseline</MudText>
+                    <MudText>.align-xxl-stretch</MudText>
                 </MudItem>
             </MudGrid>
         </DocsPageSection>
@@ -176,34 +194,40 @@
                     <MudText>.align-self-center</MudText>
                     <MudText>.align-self-baseline</MudText>
                     <MudText>.align-self-stretch</MudText>
-                </MudItem>
-                <MudItem xs="6" sm="6" md="4">
                     <MudText>.align-self-sm-auto</MudText>
                     <MudText>.align-self-sm-start</MudText>
                     <MudText>.align-self-sm-end</MudText>
                     <MudText>.align-self-sm-center</MudText>
                     <MudText>.align-self-sm-baseline</MudText>
                     <MudText>.align-self-sm-stretch</MudText>
+                </MudItem>
+                <MudItem xs="6" sm="6" md="4">
                     <MudText>.align-self-md-auto</MudText>
                     <MudText>.align-self-md-start</MudText>
                     <MudText>.align-self-md-end</MudText>
                     <MudText>.align-self-md-center</MudText>
                     <MudText>.align-self-md-baseline</MudText>
                     <MudText>.align-self-md-stretch</MudText>
-                </MudItem>
-                <MudItem xs="12" sm="12" md="4">
                     <MudText>.align-self-lg-auto</MudText>
                     <MudText>.align-self-lg-start</MudText>
                     <MudText>.align-self-lg-end</MudText>
                     <MudText>.align-self-lg-center</MudText>
                     <MudText>.align-self-lg-baseline</MudText>
                     <MudText>.align-self-lg-stretch</MudText>
+                </MudItem>
+                <MudItem xs="12" sm="12" md="4">
                     <MudText>.align-self-xl-auto</MudText>
                     <MudText>.align-self-xl-start</MudText>
                     <MudText>.align-self-xl-end</MudText>
                     <MudText>.align-self-xl-center</MudText>
                     <MudText>.align-self-xl-baseline</MudText>
                     <MudText>.align-self-xl-stretch</MudText>
+                    <MudText>.align-self-xxl-auto</MudText>
+                    <MudText>.align-self-xxl-start</MudText>
+                    <MudText>.align-self-xxl-end</MudText>
+                    <MudText>.align-self-xxl-center</MudText>
+                    <MudText>.align-self-xxl-baseline</MudText>
+                    <MudText>.align-self-xxl-stretch</MudText>
                 </MudItem>
             </MudGrid>
         </DocsPageSection>
@@ -224,34 +248,40 @@
                     <MudText>.align-content-stretch</MudText>
                     <MudText>.align-content-space-between</MudText>
                     <MudText>.align-content-space-around</MudText>
-                </MudItem>
-                <MudItem xs="6" sm="6" md="4">
                     <MudText>.align-content-sm-start</MudText>
                     <MudText>.align-content-sm-end</MudText>
                     <MudText>.align-content-sm-center</MudText>
                     <MudText>.align-content-sm-stretch</MudText>
                     <MudText>.align-content-sm-space-between</MudText>
                     <MudText>.align-content-sm-space-around</MudText>
+                </MudItem>
+                <MudItem xs="6" sm="6" md="4">
                     <MudText>.align-content-md-start</MudText>
                     <MudText>.align-content-md-end</MudText>
                     <MudText>.align-content-md-center</MudText>
                     <MudText>.align-content-md-stretch</MudText>
                     <MudText>.align-content-md-space-between</MudText>
                     <MudText>.align-content-md-space-around</MudText>
-                </MudItem>
-                <MudItem xs="12" sm="12" md="4">
                     <MudText>.align-content-lg-start</MudText>
                     <MudText>.align-content-lg-end</MudText>
                     <MudText>.align-content-lg-center</MudText>
                     <MudText>.align-content-lg-stretch</MudText>
                     <MudText>.align-content-lg-space-between</MudText>
                     <MudText>.align-content-lg-space-around</MudText>
+                </MudItem>
+                <MudItem xs="12" sm="12" md="4">
                     <MudText>.align-content-xl-start</MudText>
                     <MudText>.align-content-xl-end</MudText>
                     <MudText>.align-content-xl-center</MudText>
                     <MudText>.align-content-xl-stretch</MudText>
                     <MudText>.align-content-xl-space-between</MudText>
                     <MudText>.align-content-xl-space-around</MudText>
+                    <MudText>.align-content-xxl-start</MudText>
+                    <MudText>.align-content-xxl-end</MudText>
+                    <MudText>.align-content-xxl-center</MudText>
+                    <MudText>.align-content-xxl-stretch</MudText>
+                    <MudText>.align-content-xxl-space-between</MudText>
+                    <MudText>.align-content-xxl-space-around</MudText>
                 </MudItem>
             </MudGrid>
         </DocsPageSection>
@@ -278,22 +308,25 @@
                     <MudText>.flex-wrap</MudText>
                     <MudText>.flex-nowrap</MudText>
                     <MudText>.flex-wrap-reverse</MudText>
-                </MudItem>
-                <MudItem xs="6" sm="6" md="4">
                     <MudText>.flex-sm-wrap</MudText>
                     <MudText>.flex-sm-nowrap</MudText>
                     <MudText>.flex-sm-wrap-reverse</MudText>
+                </MudItem>
+                <MudItem xs="6" sm="6" md="4">
                     <MudText>.flex-md-wrap</MudText>
                     <MudText>.flex-md-nowrap</MudText>
                     <MudText>.flex-md-wrap-reverse</MudText>
-                </MudItem>
-                <MudItem xs="12" sm="12" md="4">
                     <MudText>.flex-lg-wrap</MudText>
                     <MudText>.flex-lg-nowrap</MudText>
                     <MudText>.flex-lg-wrap-reverse</MudText>
+                </MudItem>
+                <MudItem xs="12" sm="12" md="4">
                     <MudText>.flex-xl-wrap</MudText>
                     <MudText>.flex-xl-nowrap</MudText>
                     <MudText>.flex-xl-wrap-reverse</MudText>
+                    <MudText>.flex-xxl-wrap</MudText>
+                    <MudText>.flex-xxl-nowrap</MudText>
+                    <MudText>.flex-xxl-wrap-reverse</MudText>
                 </MudItem>
             </MudGrid>
         </DocsPageSection>
@@ -375,7 +408,7 @@
                     <MudText>.order-lg-12</MudText>
                     <MudText>.order-lg-last</MudText>
                 </MudItem>
-                <MudItem xs="12" sm="12" md="2">
+                <MudItem xs="6" sm="6" md="2">
                     <MudText>.order-xl-first</MudText>
                     <MudText>.order-xl-0</MudText>
                     <MudText>.order-xl-1</MudText>
@@ -391,6 +424,23 @@
                     <MudText>.order-xl-11</MudText>
                     <MudText>.order-xl-12</MudText>
                     <MudText>.order-xl-last</MudText>
+                </MudItem>
+                <MudItem xs="6" sm="6" md="2">
+                    <MudText>.order-xxl-first</MudText>
+                    <MudText>.order-xxl-0</MudText>
+                    <MudText>.order-xxl-1</MudText>
+                    <MudText>.order-xxl-2</MudText>
+                    <MudText>.order-xxl-3</MudText>
+                    <MudText>.order-xxl-4</MudText>
+                    <MudText>.order-xxl-5</MudText>
+                    <MudText>.order-xxl-6</MudText>
+                    <MudText>.order-xxl-7</MudText>
+                    <MudText>.order-xxl-8</MudText>
+                    <MudText>.order-xxl-9</MudText>
+                    <MudText>.order-xxl-10</MudText>
+                    <MudText>.order-xxl-11</MudText>
+                    <MudText>.order-xxl-12</MudText>
+                    <MudText>.order-xxl-last</MudText>
                 </MudItem>
             </MudGrid>
         </DocsPageSection>
@@ -409,26 +459,30 @@
                     <MudText>.flex-grow-1</MudText>
                     <MudText>.flex-shrink-0</MudText>
                     <MudText>.flex-shrink-1</MudText>
-                </MudItem>
-                <MudItem xs="6" sm="6" md="4">
                     <MudText>.flex-sm-grow-0</MudText>
                     <MudText>.flex-sm-grow-1</MudText>
                     <MudText>.flex-sm-shrink-0</MudText>
                     <MudText>.flex-sm-shrink-1</MudText>
+                </MudItem>
+                <MudItem xs="6" sm="6" md="4">
                     <MudText>.flex-md-grow-0</MudText>
                     <MudText>.flex-md-grow-1</MudText>
                     <MudText>.flex-md-shrink-0</MudText>
                     <MudText>.flex-md-shrink-1</MudText>
-                </MudItem>
-                <MudItem xs="12" sm="12" md="4">
                     <MudText>.flex-lg-grow-0</MudText>
                     <MudText>.flex-lg-grow-1</MudText>
                     <MudText>.flex-lg-shrink-0</MudText>
                     <MudText>.flex-lg-shrink-1</MudText>
+                </MudItem>
+                <MudItem xs="12" sm="12" md="4">
                     <MudText>.flex-xl-grow-0</MudText>
                     <MudText>.flex-xl-grow-1</MudText>
                     <MudText>.flex-xl-shrink-0</MudText>
                     <MudText>.flex-xl-shrink-1</MudText>
+                    <MudText>.flex-xxl-grow-0</MudText>
+                    <MudText>.flex-xxl-grow-1</MudText>
+                    <MudText>.flex-xxl-shrink-0</MudText>
+                    <MudText>.flex-xxl-shrink-1</MudText>
                 </MudItem>
             </MudGrid>
         </DocsPageSection>

--- a/src/MudBlazor.UnitTests/Components/DrawerTest.cs
+++ b/src/MudBlazor.UnitTests/Components/DrawerTest.cs
@@ -179,9 +179,10 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(Breakpoint.Md)]
         [TestCase(Breakpoint.Lg)]
         [TestCase(Breakpoint.Xl)]
+        [TestCase(Breakpoint.Xxl)]
         public async Task ResponsiveClosed_LargeScreen_SetBreakpoint_Open_CheckState(Breakpoint breakpoint)
         {
-            (Context.Services.GetService<IResizeListenerService>() as MockResizeListenerService)?.ApplyScreenSize(1920, 1080);
+            (Context.Services.GetService<IResizeListenerService>() as MockResizeListenerService)?.ApplyScreenSize(2560, 1080);
 
             var comp = Context.RenderComponent<DrawerResponsiveTest>(Parameter(nameof(DrawerResponsiveTest.Breakpoint), breakpoint));
 
@@ -201,6 +202,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(Breakpoint.Md)]
         [TestCase(Breakpoint.Lg)]
         [TestCase(Breakpoint.Xl)]
+        [TestCase(Breakpoint.Xxl)]
         public async Task ResponsiveClosed_SmallScreen_SetBreakpoint_Open_CheckState(Breakpoint breakpoint)
         {
             (Context.Services.GetService<IResizeListenerService>() as MockResizeListenerService)?.ApplyScreenSize(400, 300);

--- a/src/MudBlazor.UnitTests/Mocks/MockResizeListenerService.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockResizeListenerService.cs
@@ -63,14 +63,17 @@ namespace MudBlazor.UnitTests.Mocks
                 Breakpoint.Md => reference == Breakpoint.Md,
                 Breakpoint.Lg => reference == Breakpoint.Lg,
                 Breakpoint.Xl => reference == Breakpoint.Xl,
+                Breakpoint.Xxl => reference == Breakpoint.Xxl,
                 // * and down
                 Breakpoint.SmAndDown => reference <= Breakpoint.Sm,
                 Breakpoint.MdAndDown => reference <= Breakpoint.Md,
                 Breakpoint.LgAndDown => reference <= Breakpoint.Lg,
+                Breakpoint.XlAndDown => reference <= Breakpoint.Xl,
                 // * and up
                 Breakpoint.SmAndUp => reference >= Breakpoint.Sm,
                 Breakpoint.MdAndUp => reference >= Breakpoint.Md,
                 Breakpoint.LgAndUp => reference >= Breakpoint.Lg,
+                Breakpoint.XlAndUp => reference >= Breakpoint.Xl,
                 _ => false,
             };
         }
@@ -79,7 +82,9 @@ namespace MudBlazor.UnitTests.Mocks
 
         private Breakpoint GetBreakpointInternal()
         {
-            if (_width >= ResizeListenerService.BreakpointDefinitions[Breakpoint.Xl])
+            if (_width >= ResizeListenerService.BreakpointDefinitions[Breakpoint.Xxl])
+                return Breakpoint.Xxl;
+            else if (_width >= ResizeListenerService.BreakpointDefinitions[Breakpoint.Xl])
                 return Breakpoint.Xl;
             else if (_width >= ResizeListenerService.BreakpointDefinitions[Breakpoint.Lg])
                 return Breakpoint.Lg;

--- a/src/MudBlazor.UnitTests/Services/ResizeListenerServiceTests.cs
+++ b/src/MudBlazor.UnitTests/Services/ResizeListenerServiceTests.cs
@@ -42,11 +42,18 @@ namespace MudBlazor.UnitTests.Services
         [TestCase(Breakpoint.Lg, 1919, true)]
         [TestCase(Breakpoint.Lg, 1920, false)]
 
-        // 1920 - *
+        // 1920 - 2559
         [TestCase(Breakpoint.Xl, 1919, false)]
         [TestCase(Breakpoint.Xl, 1920, true)]
-        [TestCase(Breakpoint.Xl, 9999, true)]
+        [TestCase(Breakpoint.Xl, 2559, true)]
+        [TestCase(Breakpoint.Xl, 2560, false)]
 
+        // 2560 - *
+        [TestCase(Breakpoint.Xxl, 2559, false)]
+        [TestCase(Breakpoint.Xxl, 2560, true)]
+        [TestCase(Breakpoint.Xxl, 4000, true)]
+        [TestCase(Breakpoint.Xxl, 9999, true)]
+        
         // >= 600
         [TestCase(Breakpoint.SmAndUp, 599, false)]
         [TestCase(Breakpoint.SmAndUp, 600, true)]
@@ -62,6 +69,12 @@ namespace MudBlazor.UnitTests.Services
         [TestCase(Breakpoint.LgAndUp, 1280, true)]
         [TestCase(Breakpoint.LgAndUp, 9999, true)]
 
+        // >= 1920
+        [TestCase(Breakpoint.XlAndUp, 1919, false)]
+        [TestCase(Breakpoint.XlAndUp, 1920, true)]
+        [TestCase(Breakpoint.XlAndUp, 2560, true)]
+        [TestCase(Breakpoint.XlAndUp, 9999, true)]
+        
         // < 960
         [TestCase(Breakpoint.SmAndDown, 960, false)]
         [TestCase(Breakpoint.SmAndDown, 959, true)]
@@ -76,6 +89,11 @@ namespace MudBlazor.UnitTests.Services
         [TestCase(Breakpoint.LgAndDown, 1920, false)]
         [TestCase(Breakpoint.LgAndDown, 1919, true)]
         [TestCase(Breakpoint.LgAndDown, 0, true)]
+        
+        // < 2560
+        [TestCase(Breakpoint.XlAndDown, 2560, false)]
+        [TestCase(Breakpoint.XlAndDown, 2559, true)]
+        [TestCase(Breakpoint.XlAndDown, 0, true)]
         public async Task IsMediaSizeReturnsCorrectValue(Breakpoint breakpoint, int browserWidth, bool expectedValue)
         {
             // Arrange

--- a/src/MudBlazor/Components/Grid/MudItem.razor
+++ b/src/MudBlazor/Components/Grid/MudItem.razor
@@ -15,6 +15,7 @@
         .AddClass($"mud-grid-item-md-{md.ToString()}", md != 0)
         .AddClass($"mud-grid-item-lg-{lg.ToString()}", lg != 0)
         .AddClass($"mud-grid-item-xl-{xl.ToString()}", xl != 0)
+        .AddClass($"mud-grid-item-xxl-{xxl.ToString()}", xxl != 0)
       .AddClass(Class)
     .Build();
 
@@ -26,6 +27,7 @@
     [Parameter] public int md { get; set; }
     [Parameter] public int lg { get; set; }
     [Parameter] public int xl { get; set; }
+    [Parameter] public int xxl { get; set; }
 
     // ToDo false,auto,true on all sizes.
 

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -24,6 +24,7 @@ namespace MudBlazor
            .AddClass("mud-md-table", Breakpoint == Breakpoint.Md)
            .AddClass("mud-lg-table", Breakpoint is Breakpoint.Lg or Breakpoint.Always)
            .AddClass("mud-xl-table", Breakpoint is Breakpoint.Xl or Breakpoint.Always)
+           .AddClass("mud-xxl-table", Breakpoint is Breakpoint.Xxl or Breakpoint.Always)
            .AddClass("mud-table-dense", Dense)
            .AddClass("mud-table-hover", Hover)
            .AddClass("mud-table-bordered", Bordered)

--- a/src/MudBlazor/Components/ThemeProvider/MudThemeProvider.razor.cs
+++ b/src/MudBlazor/Components/ThemeProvider/MudThemeProvider.razor.cs
@@ -200,6 +200,7 @@ namespace MudBlazor
             //theme.AppendLine($"--{Breakpoint}-md: {Theme.Breakpoints.md};");
             //theme.AppendLine($"--{Breakpoint}-lg: {Theme.Breakpoints.lg};");
             //theme.AppendLine($"--{Breakpoint}-xl: {Theme.Breakpoints.xl};");
+            //theme.AppendLine($"--{Breakpoint}-xxl: {Theme.Breakpoints.xxl};");
 
             //Typography
             theme.AppendLine($"--{Typography}-default-family: '{string.Join("','", Theme.Typography.Default.FontFamily)}';");

--- a/src/MudBlazor/Enums/MaxWidth.cs
+++ b/src/MudBlazor/Enums/MaxWidth.cs
@@ -12,6 +12,8 @@ namespace MudBlazor
         Small,
         [Description("xl")]
         ExtraLarge,
+        [Description("xxl")]
+        ExtraExtraLarge,
         [Description("xs")]
         ExtraSmall,
         [Description("false")]

--- a/src/MudBlazor/Enums/Width.cs
+++ b/src/MudBlazor/Enums/Width.cs
@@ -14,6 +14,8 @@ namespace MudBlazor
         lg,
         [Description("xl")]
         xl,
+        [Description("xxl")]
+        xxl,
         [Description("false")]
         False,
     }

--- a/src/MudBlazor/Services/ResizeListener/Breakpoint.cs
+++ b/src/MudBlazor/Services/ResizeListener/Breakpoint.cs
@@ -5,9 +5,9 @@
     /// </summary>
     public enum Breakpoint
     {
-        Xs, Sm, Md, Lg, Xl,
-        SmAndDown, MdAndDown, LgAndDown,
-        SmAndUp, MdAndUp, LgAndUp,
+        Xs, Sm, Md, Lg, Xl, Xxl,
+        SmAndDown, MdAndDown, LgAndDown, XlAndDown,
+        SmAndUp, MdAndUp, LgAndUp, XlAndUp,
         None,
         Always
     }

--- a/src/MudBlazor/Services/ResizeListener/ResizeListenerService.cs
+++ b/src/MudBlazor/Services/ResizeListener/ResizeListenerService.cs
@@ -131,6 +131,7 @@ _jsRuntime.InvokeAsync<bool>($"mudResizeListener.matchMedia", mediaQuery);
 
         public static Dictionary<Breakpoint, int> BreakpointDefinitions { get; set; } = new Dictionary<Breakpoint, int>()
         {
+            [Breakpoint.Xxl] = 2560,
             [Breakpoint.Xl] = 1920,
             [Breakpoint.Lg] = 1280,
             [Breakpoint.Md] = 960,
@@ -145,7 +146,9 @@ _jsRuntime.InvokeAsync<bool>($"mudResizeListener.matchMedia", mediaQuery);
                 _windowSize = await _browserWindowSizeProvider.GetBrowserWindowSize();
             if (_windowSize == null)
                 return Breakpoint.Xs;
-            if (_windowSize.Width >= BreakpointDefinitions[Breakpoint.Xl])
+            if (_windowSize.Width >= BreakpointDefinitions[Breakpoint.Xxl])
+                return Breakpoint.Xxl;
+            else if (_windowSize.Width >= BreakpointDefinitions[Breakpoint.Xl])
                 return Breakpoint.Xl;
             else if (_windowSize.Width >= BreakpointDefinitions[Breakpoint.Lg])
                 return Breakpoint.Lg;
@@ -177,14 +180,17 @@ _jsRuntime.InvokeAsync<bool>($"mudResizeListener.matchMedia", mediaQuery);
                 Breakpoint.Md => reference == Breakpoint.Md,
                 Breakpoint.Lg => reference == Breakpoint.Lg,
                 Breakpoint.Xl => reference == Breakpoint.Xl,
+                Breakpoint.Xxl => reference == Breakpoint.Xxl,
                 // * and down
                 Breakpoint.SmAndDown => reference <= Breakpoint.Sm,
                 Breakpoint.MdAndDown => reference <= Breakpoint.Md,
                 Breakpoint.LgAndDown => reference <= Breakpoint.Lg,
+                Breakpoint.XlAndDown => reference <= Breakpoint.Xl,
                 // * and up
                 Breakpoint.SmAndUp => reference >= Breakpoint.Sm,
                 Breakpoint.MdAndUp => reference >= Breakpoint.Md,
                 Breakpoint.LgAndUp => reference >= Breakpoint.Lg,
+                Breakpoint.XlAndUp => reference >= Breakpoint.Xl,
                 _ => false,
             };
         }

--- a/src/MudBlazor/Styles/abstracts/_variables.scss
+++ b/src/MudBlazor/Styles/abstracts/_variables.scss
@@ -5,5 +5,6 @@ $breakpoint-sm: 600px;
 $breakpoint-md: 960px;
 $breakpoint-lg: 1280px;
 $breakpoint-xl: 1920px;
+$breakpoint-xxl: 2560px;
 
-$breakpoints: ( xs: $breakpoint-xs, sm: $breakpoint-sm, md: $breakpoint-md, lg: $breakpoint-lg, xl: $breakpoint-xl );
+$breakpoints: ( xs: $breakpoint-xs, sm: $breakpoint-sm, md: $breakpoint-md, lg: $breakpoint-lg, xl: $breakpoint-xl, xxl: $breakpoint-xxl );

--- a/src/MudBlazor/Styles/components/_dialog.scss
+++ b/src/MudBlazor/Styles/components/_dialog.scss
@@ -148,6 +148,10 @@
     max-width: 1920px;
 }
 
+.mud-dialog-width-xxl {
+    max-width: 2560px;
+}
+
 .mud-dialog-width-full {
     width: calc(100% - 64px);
 }

--- a/src/MudBlazor/Styles/components/_grid.scss
+++ b/src/MudBlazor/Styles/components/_grid.scss
@@ -609,3 +609,89 @@
         flex-basis: 100%;
     }
 }
+
+@media (min-width:$breakpoint-xxl) {
+    .mud-grid-item-xxl-auto {
+        flex-grow: 0;
+        max-width: none;
+        flex-basis: auto;
+    }
+
+    .mud-grid-item-xxl-true {
+        flex-grow: 1;
+        max-width: 100%;
+        flex-basis: 0;
+    }
+
+    .mud-grid-item-xxl-1 {
+        flex-grow: 0;
+        max-width: 8.333333%;
+        flex-basis: 8.333333%;
+    }
+
+    .mud-grid-item-xxl-2 {
+        flex-grow: 0;
+        max-width: 16.666667%;
+        flex-basis: 16.666667%;
+    }
+
+    .mud-grid-item-xxl-3 {
+        flex-grow: 0;
+        max-width: 25%;
+        flex-basis: 25%;
+    }
+
+    .mud-grid-item-xxl-4 {
+        flex-grow: 0;
+        max-width: 33.333333%;
+        flex-basis: 33.333333%;
+    }
+
+    .mud-grid-item-xxl-5 {
+        flex-grow: 0;
+        max-width: 41.666667%;
+        flex-basis: 41.666667%;
+    }
+
+    .mud-grid-item-xxl-6 {
+        flex-grow: 0;
+        max-width: 50%;
+        flex-basis: 50%;
+    }
+
+    .mud-grid-item-xxl-7 {
+        flex-grow: 0;
+        max-width: 58.333333%;
+        flex-basis: 58.333333%;
+    }
+
+    .mud-grid-item-xxl-8 {
+        flex-grow: 0;
+        max-width: 66.666667%;
+        flex-basis: 66.666667%;
+    }
+
+    .mud-grid-item-xxl-9 {
+        flex-grow: 0;
+        max-width: 75%;
+        flex-basis: 75%;
+    }
+
+    .mud-grid-item-xxl-10 {
+        flex-grow: 0;
+        max-width: 83.333333%;
+        flex-basis: 83.333333%;
+    }
+
+    .mud-grid-item-xxl-11 {
+        flex-grow: 0;
+        max-width: 91.666667%;
+        flex-basis: 91.666667%;
+    }
+
+    .mud-grid-item-xxl-12 {
+        flex-grow: 0;
+        max-width: 100%;
+        flex-basis: 100%;
+    }
+}

--- a/src/MudBlazor/Styles/components/_table.scss
+++ b/src/MudBlazor/Styles/components/_table.scss
@@ -546,6 +546,10 @@
     @include table-display-smalldevices("lg-");
 }
 
-@media (min-width:$breakpoint-xl) {
-    @include table-display-smalldevices("xl-");
+@media (max-width:$breakpoint-xxl) {
+  @include table-display-smalldevices("xl-");
+}
+
+@media (min-width:$breakpoint-xxl) {
+  @include table-display-smalldevices("xxl-");
 }

--- a/src/MudBlazor/Styles/layout/_container.scss
+++ b/src/MudBlazor/Styles/layout/_container.scss
@@ -46,6 +46,12 @@
     }
 }
 
+@media (min-width:$breakpoint-xxl) {
+    .mud-container-fixed {
+      max-width: $breakpoint-xxl;
+    }
+}
+
 @media (min-width:$breakpoint-xs) {
     .mud-container-maxwidth-xs {
         max-width: 444px;
@@ -73,5 +79,11 @@
 @media (min-width:$breakpoint-xl) {
     .mud-container-maxwidth-xl {
         max-width: $breakpoint-xl;
+    }
+}
+
+@media (min-width:$breakpoint-xxl) {
+    .mud-container-maxwidth-xxl {
+        max-width: $breakpoint-xxl;
     }
 }

--- a/src/MudBlazor/Styles/utilities/_borders.scss
+++ b/src/MudBlazor/Styles/utilities/_borders.scss
@@ -1,4 +1,4 @@
-﻿$border-radiuses: ( "0": 0, "sm": 2px, "lg": 8px, "xl": 24px );
+﻿$border-radiuses: ( "0": 0, "sm": 2px, "lg": 8px, "xl": 24px, "xxl": 24px );
 
 @each $size, $value in $border-radiuses {
     .rounded-#{$size} {

--- a/src/MudBlazor/Styles/utilities/_display.scss
+++ b/src/MudBlazor/Styles/utilities/_display.scss
@@ -59,3 +59,7 @@
 @media (min-width:$breakpoint-xl) {
     @include display-mixin("xl-");
 }
+
+@media (min-width:$breakpoint-xxl) {
+    @include display-mixin("xxl-");
+}

--- a/src/MudBlazor/Styles/utilities/_flex.scss
+++ b/src/MudBlazor/Styles/utilities/_flex.scss
@@ -225,3 +225,7 @@
 @media (min-width:$breakpoint-xl) {
     @include flex-mixin("xl-");
 }
+
+@media (min-width:$breakpoint-xxl) {
+    @include flex-mixin("xxl-");
+}

--- a/src/MudBlazor/Styles/utilities/_spacing.scss
+++ b/src/MudBlazor/Styles/utilities/_spacing.scss
@@ -95,3 +95,7 @@ $spacing-negative-values: ( "n1": -4px, "n2": -8px, "n3": -12px, "n4": -16px, "n
 @media screen and (min-width:$breakpoint-xl) {
     @include spacing-positive-negative("xl-");
 }
+
+@media screen and (min-width:$breakpoint-xxl) {
+    @include spacing-positive-negative("xxl-");
+}

--- a/src/MudBlazor/TScripts/mudResizeListener.js
+++ b/src/MudBlazor/TScripts/mudResizeListener.js
@@ -74,6 +74,8 @@
     }
 
     getBreakpoint (width) {
+        if (width >= this.options.breakpointDefinitions["Xxl"])
+            return 5;
         if (width >= this.options.breakpointDefinitions["Xl"])
             return 4;
         else if (width >= this.options.breakpointDefinitions["Lg"])

--- a/src/MudBlazor/Themes/Models/Breakpoints.cs
+++ b/src/MudBlazor/Themes/Models/Breakpoints.cs
@@ -11,5 +11,6 @@ namespace MudBlazor
         public string md { get; set; } = "960px";
         public string lg { get; set; } = "1280px";
         public string xl { get; set; } = "1920px";
+        public string xxl { get; set; } = "2560px";
     }
 }


### PR DESCRIPTION
Added an XXL breakpoint for larger screen sizes (+2560).

Tested on my local machine as follows:

```xml
<MudGrid>
   <MudItem xs="12" xxl="6">
       <MudPaper>
           Block 1
       </MudPaper>
   </MudItem> 
   <MudItem xs="12" xxl="6">
       <MudPaper>
           Block 2
       </MudPaper>
   </MudItem>     
</MudGrid>
```

On `<2560` screen size this correctly displays 2 separate rows:

![Screenshot from 2021-08-16 14-49-06](https://user-images.githubusercontent.com/281616/129571750-85f21734-b590-42d6-8f7f-4e05c46891a7.png)

And on `+2560` screens, they are displayed on the same row:

![Screenshot from 2021-08-16 14-48-42](https://user-images.githubusercontent.com/281616/129571762-7cc653bd-8f3f-450e-92ab-6cd2e21fbe08.png)

Closes #2270