### PR TITLE
Fix MudProgressCircular looking not full value

### DIFF
--- a/src/MudBlazor/Components/Progress/MudProgressCircular.razor
+++ b/src/MudBlazor/Components/Progress/MudProgressCircular.razor
@@ -5,11 +5,11 @@
     <svg class="mud-progress-circular-svg" viewBox="22 22 44 44">
         @if (Indeterminate)
         {
-            <circle class="@SvgClassname" cx="44" cy="44" r="20.2" fill="none" stroke-width="@StrokeWidth"></circle>
+            <circle class="@SvgClassname" cx="44" cy="44" r="20" fill="none" stroke-width="@StrokeWidth"></circle>
         }
         else
         {
-            <circle class="@SvgClassname" cx="44" cy="44" r="20.2" fill="none" stroke-width="@StrokeWidth" style="stroke-dasharray: @MagicNumber; stroke-dashoffset: @_svg_value;"></circle>
+            <circle class="@SvgClassname" cx="44" cy="44" r="20" fill="none" stroke-width="@StrokeWidth" style="stroke-dasharray: @MagicNumber; stroke-dashoffset: @_svg_value;"></circle>
         }
     </svg>
 </div>


### PR DESCRIPTION
We're fixing MudProgressCircular to look unfinished even it has max value

Before:
![Screenshot 2021-08-20 at 01-18-24 TryMudBlazor - Write, compile, execute and share Blazor components in the browser](https://user-images.githubusercontent.com/78308169/130151680-d97b047a-1b49-4c08-bf10-54d1472b6b96.png)

After:
![Screenshot 2021-08-20 at 01-30-25 TryMudBlazor - Write, compile, execute and share Blazor components in the browser](https://user-images.githubusercontent.com/78308169/130152719-8e75c762-dc92-4c75-b8da-41a8bb33e34d.png)

