### PR TITLE
MudAutoComplete: Fix CoerceText not working on empty search results (#2617)

### DIFF
--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -129,6 +129,8 @@ namespace MudBlazor.UnitTests.Components
             // set a value the search won't find
             autocompletecomp.SetParam(a => a.Text, "Austria"); // not part of the U.S.
             await comp.InvokeAsync(() => autocomplete.ToggleMenu());
+            // IsOpen must be true to properly simulate a user clicking outside of the component, which is what the next ToggleMenu call below does.
+            autocomplete.IsOpen.Should().BeTrue();
             // now trigger the coercion by closing the menu
             await comp.InvokeAsync(() => autocomplete.ToggleMenu());
             autocomplete.Value.Should().Be("Alabama");

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -298,7 +298,6 @@ namespace MudBlazor
             if (_items?.Length == 0)
             {
                 await CoerceValueToText();
-                IsOpen = false;
                 StateHasChanged();
                 return;
             }

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -227,7 +227,7 @@ namespace MudBlazor
             if (IsOpen)
             {
                 await _elementReference.SelectAsync();
-                OnSearch();
+                await OnSearchAsync();
             }
             else
             {
@@ -266,14 +266,18 @@ namespace MudBlazor
             if (ResetValueOnEmptyText && string.IsNullOrWhiteSpace(Text))
                 await SetValueAsync(default(T), updateText);
             if (DebounceInterval <= 0)
-                OnSearch();
+                await OnSearchAsync();
             else
                 _timer = new Timer(OnTimerComplete, null, DebounceInterval, Timeout.Infinite);
         }
 
-        private void OnTimerComplete(object stateInfo) => InvokeAsync(OnSearch);
+        private void OnTimerComplete(object stateInfo) => InvokeAsync(OnSearchAsync);
 
-        private async void OnSearch()
+        /// <remarks>
+        /// This async method needs to return a task and be awaited in order for
+        /// unit tests that trigger this method to work correctly.
+        /// </remarks>
+        private async Task OnSearchAsync()
         {
             if (MinCharacters > 0 && (string.IsNullOrWhiteSpace(Text) || Text.Length < MinCharacters))
             {


### PR DESCRIPTION
Fixes #2617 

A call to `ToggleMenu` is not being triggered when clicking away from the `MudAutocomplete` component. `ToggleMenu` is where the call to `CoerceTextToValue` happens. I found that `IsOpen` was being set to false whenever the search function returned an empty list, but this didn't actually do anything, from what I could tell. So, removing this one line fixes this issue.

I looked into adding it to `OnInputBlurred`, but that doesn't work because when a selection is made it also triggers `OnInputBlurred`, as the comment by @henon pointed out.)