### PR TITLE
Update MudTableBase.cs - Make MudTable parameter RowsPerPage parameter two-way bind-able.

### DIFF
--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -361,7 +361,7 @@ namespace MudBlazor
             _rowsPerPage = size;
             CurrentPage = 0;
             StateHasChanged();
-            RowsPerPageChanged.InvokeAsync(_rowsPerPage);
+            RowsPerPageChanged.InvokeAsync(_rowsPerPage.Value);
             if (_isFirstRendered)
                 InvokeServerLoadFunc();
         }

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -123,6 +123,11 @@ namespace MudBlazor
                     SetRowsPerPage(value);
             }
         }
+        
+        /// <summary>
+        /// Rows Per Page two-waybindable parameter
+        /// </summary>
+        [Parameter] public EventCallback<int> RowsPerPageChanged {get;set;}
 
         /// <summary>
         /// The page index of the currently displayed page (Zero based). Usually called by MudTablePager.
@@ -356,6 +361,7 @@ namespace MudBlazor
             _rowsPerPage = size;
             CurrentPage = 0;
             StateHasChanged();
+            RowsPerPageChanged.InvokeAsync(_rowsPerPage);
             if (_isFirstRendered)
                 InvokeServerLoadFunc();
         }


### PR DESCRIPTION
MudTable: Make MudTable parameter RowsPerPage parameter two-way bind-able. (#2603)
