### PR TITLE
Docs: optimize table pagination example for mobile

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Pagination/Examples/PaginationTableExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Pagination/Examples/PaginationTableExample.razor
@@ -4,7 +4,7 @@
 @inject HttpClient httpClient
 @using System.Net.Http.Json
 
-<MudTable @ref="@_table" Items="@_elements" RowsPerPage="4" Hover="true" Breakpoint="Breakpoint.Sm" LoadingProgressColor="Color.Info">
+<MudTable Class="mud-width-full" @ref="@_table" Items="@_elements" RowsPerPage="4" Hover="true" Breakpoint="Breakpoint.Sm" LoadingProgressColor="Color.Info">
     <HeaderContent>
         <MudTh>Nr</MudTh>
         <MudTh>Sign</MudTh>
@@ -20,7 +20,7 @@
         <MudTd DataLabel="Molar mass">@context.Molar</MudTd>
     </RowTemplate>
     <PagerContent>
-        <MudPagination SelectedChanged="PageChanged" Count="@(_table.GetFilteredItemsCount() / _table.RowsPerPage)" Class="pa-4"/>
+        <MudPagination SelectedChanged="PageChanged" BoundaryCount="1" MiddleCount="2" Count="@(_table.GetFilteredItemsCount() / _table.RowsPerPage)" Class="pa-4"/>
     </PagerContent>
 </MudTable>
 


### PR DESCRIPTION
I think it's about MudPagination can't wrap and it causes the MudTable not fit in small screens.

Pagination example will revised that it can seem on mobile properly. And it also have full width to see the table full on bigger screens.

Before (Mobile)
![Ekran Görüntüsü (228)](https://user-images.githubusercontent.com/78308169/132095423-68092af2-a2ed-468c-a48b-b8ab24566020.png)

After (Mobile)
![Ekran Görüntüsü (227)](https://user-images.githubusercontent.com/78308169/132095448-c49b096a-efdf-4c4f-b34e-3e6668a24abd.png)

Before (Desktop)
![Ekran Görüntüsü (225)](https://user-images.githubusercontent.com/78308169/132095518-70cb55ef-bc0f-47e9-bae2-84780f2c92cc.png)

After (Desktop)
![Ekran Görüntüsü (226)](https://user-images.githubusercontent.com/78308169/132095544-9c914ee4-eb03-44f1-93f9-1af20dc27d2b.png)



