### PR TITLE
Select: Prevent item click when drop-down is closed in multi-selection mode

### DIFF
--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -24,9 +24,12 @@
         </MudInputControl>
         <MudPopover Open=@(_isOpen) MaxHeight="@MaxHeight" Direction="@Direction" OffsetX="@OffsetX" OffsetY="@OffsetY" Class="@PopoverClass">
             <CascadingValue Value="@((IMudSelect)this)" IsFixed="true">
-                <MudList Clickable="true" Dense="@Dense">
-                    @ChildContent
-                </MudList>
+                @if (_isOpen)
+                {
+                    <MudList Clickable="true" Dense="@Dense">
+                        @ChildContent
+                    </MudList>
+                }
             </CascadingValue>
         </MudPopover>
     </div>

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -24,11 +24,8 @@
         </MudInputControl>
         <MudPopover Open=@(_isOpen) MaxHeight="@MaxHeight" Direction="@Direction" OffsetX="@OffsetX" OffsetY="@OffsetY" Class="@PopoverClass">
             <CascadingValue Value="@((IMudSelect)this)" IsFixed="true">
-                <MudList Clickable="true" Dense="@Dense">
-                    @if (_isOpen)
-                    {
-                        @ChildContent
-                    }
+                <MudList Clickable="true" Dense="@Dense" Disabled="!_isOpen">
+                    @ChildContent
                 </MudList>
             </CascadingValue>
         </MudPopover>

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -29,7 +29,7 @@
                     <MudListItem Icon="@SelectAllCheckBoxIcon" Text="@SelectAllText" OnClick="SelectAllClickAsync"  
                      Dense="@Dense" Class="mud-list-item-clickable mud-select-all mud-typography-body1"/>
                 }
-                <MudList Clickable="true" Dense="@Dense">
+                <MudList Clickable="@(_isOpen==false?false:true)" Dense="@Dense">
                     @ChildContent
                 </MudList>
             </CascadingValue>

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -24,7 +24,7 @@
         </MudInputControl>
         <MudPopover Open=@(_isOpen) MaxHeight="@MaxHeight" Direction="@Direction" OffsetX="@OffsetX" OffsetY="@OffsetY" Class="@PopoverClass">
             <CascadingValue Value="@((IMudSelect)this)" IsFixed="true">
-                <MudList Clickable="true" Dense="@Dense" Disabled="!_isOpen">
+                <MudList Clickable="@(_isOpen==false?false:true)" Dense="@Dense">
                     @ChildContent
                 </MudList>
             </CascadingValue>

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -24,12 +24,12 @@
         </MudInputControl>
         <MudPopover Open=@(_isOpen) MaxHeight="@MaxHeight" Direction="@Direction" OffsetX="@OffsetX" OffsetY="@OffsetY" Class="@PopoverClass">
             <CascadingValue Value="@((IMudSelect)this)" IsFixed="true">
-                @if (_isOpen)
-                {
-                    <MudList Clickable="true" Dense="@Dense">
+                <MudList Clickable="true" Dense="@Dense">
+                    @if (_isOpen)
+                    {
                         @ChildContent
-                    </MudList>
-                }
+                    }
+                </MudList>
             </CascadingValue>
         </MudPopover>
     </div>

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -157,8 +157,6 @@ namespace MudBlazor
         {
             get
             {
-                if (ChildContent == null)
-                    return false;
                 if (Value == null)
                     return false;
                 if (!_value_lookup.TryGetValue(Value, out var item))
@@ -179,8 +177,6 @@ namespace MudBlazor
 
         protected RenderFragment GetSelectedValuePresenter()
         {
-            if (ChildContent == null)
-                return null;
             if (Value == null)
                 return null;
             if (!_value_lookup.TryGetValue(Value, out var selected_item))

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -179,6 +179,8 @@ namespace MudBlazor
 
         protected RenderFragment GetSelectedValuePresenter()
         {
+            if (ChildContent == null)
+                return null;
             if (Value == null)
                 return null;
             if (!_value_lookup.TryGetValue(Value, out var selected_item))

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -157,6 +157,8 @@ namespace MudBlazor
         {
             get
             {
+                if (ChildContent == null)
+                    return false;
                 if (Value == null)
                     return false;
                 if (!_value_lookup.TryGetValue(Value, out var item))


### PR DESCRIPTION
Solves duplicate issues: #2452, #2593.

Detail: Added if block visible check for selectable items to make sure they show/hide correctly. (Closing popover may not be sufficient against inputs)

Before:

https://user-images.githubusercontent.com/78308169/132133795-7cf56751-f23f-4099-ab59-7112fd94da17.mp4

After:

https://user-images.githubusercontent.com/78308169/132133811-e2174c99-644b-4f22-bea2-17e46f826282.mp4

fixes #2452
fixes #2593.