### PR TITLE
Menu: Prevent item click when drop-down is closed

### DIFF
--- a/src/MudBlazor/Components/Menu/MudMenu.razor
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor
@@ -35,7 +35,7 @@
     @* The portal has to include  the cascading values inside, because it's not able to teletransport the cascade *@
     <MudPopover Open="@_isOpen" Class="@MenuClassname" MaxHeight="@MaxHeight" Style="@PopoverStyle" Direction="@Direction" OffsetX="@OffsetX" OffsetY="@OffsetY">
         <CascadingValue Value="@this">
-            <MudList Clickable="true" Dense="@Dense" 
+            <MudList Clickable="@(_isOpen==false?false:true)" Dense="@Dense" 
             @onmouseleave="@(ActivationEvent== MouseEvent.MouseOver ? CloseMenu : null)">
                 @ChildContent
             </MudList>


### PR DESCRIPTION
This is the same approach in #2647, this time implement on MudMenu.

I create a temporary example described on #2509 and it seemed to solve this. @henon 

But we should notice that, this approach doesn't solve all issues. Ex. having two menus when clicking a menu on AppBar still remains (Maybe these related to Portal).

fixes #2509