### PR TITLE
Introduction of the subscription-based resize services

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/BreakpointProvider/BreakpointProviderPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/BreakpointProvider/BreakpointProviderPage.razor
@@ -1,0 +1,36 @@
+﻿@page "/components/breakpointProvider"
+
+<DocsPage>
+    <DocsPageHeader Title="Breakpoint Provider" SubTitle="Exposing the current breakpoint to multiple components" />
+    <DocsPageContent>
+        <DocsPageSection>
+            <SectionHeader Title="How it works">
+                <Description>
+					<MudText>
+						The breakpoint provider offers a cascading parameter that exposes the window's current breakpoint (xs,sm,md,lg,xl). 
+						These features improve the performance if your layout heavily relies on such features or if you don't want to use the BreakpointListenerService directly in your own components.
+					</MudText>
+					<MudText>
+						If a <strong>MudHidden</strong> is used within a <strong>MudBreakpointProvider</strong>, it will use the provided value instead of relying on the IBreakpointListenerService. 
+						That would reduce the number of render cycles if a change of the browser size occurred. 
+					</MudText>
+				</Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" DisplayFlex="true">
+                <BreakpointProviderPageHiddenExample />
+            </SectionContent>
+            <SectionSource Code="BreakpointProviderPageHiddenExample" />
+        </DocsPageSection>
+        <DocsPageSection>
+            <SectionHeader Title="Listening to browser window breakpoint changes">
+                <Description>
+                    <MudText>The <strong> IBreakpointListenerService</strong> is the service that powers the MudBreakpoint Provider. It can be used in own components </MudText>
+                </Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true">
+                <BreakpointListenerExample />
+            </SectionContent>
+            <SectionSource Code="BreakpointListenerExample" />
+        </DocsPageSection>
+    </DocsPageContent>
+</DocsPage>

--- a/src/MudBlazor.Docs/Pages/Components/BreakpointProvider/Examples/BreakpointListenerExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/BreakpointProvider/Examples/BreakpointListenerExample.razor
@@ -1,0 +1,52 @@
+﻿@using MudBlazor.Services
+@namespace MudBlazor.Docs.Examples
+@implements IAsyncDisposable
+
+
+<MudCard Class="pa-5">
+	<MudText>Size started with @_start</MudText>
+	@if (_breakpointHistory.Count > 0)
+	{
+		<MudText>And continued with: </MudText>
+		<MudList Dense="_breakpointHistory.Count > 10">
+			@foreach (var item in _breakpointHistory)
+			{
+				<MudListItem Text="@item.ToString()"></MudListItem>
+			}
+		</MudList>
+	}
+</MudCard>
+
+@code
+{
+	[Inject] IBreakpointListenerService BreakpointListener { get; set; }
+
+	private List<Breakpoint> _breakpointHistory = new();
+
+	private Guid _subscriptionId;
+	private Breakpoint _start;
+
+	protected override async Task OnAfterRenderAsync(bool firstRender)
+	{
+		if (firstRender)
+		{
+			var subscriptionResult = await BreakpointListener.Subscribe((breakpoint) =>
+			{
+				_breakpointHistory.Add(breakpoint);
+				InvokeAsync(StateHasChanged);
+			}, new ResizeOptions
+			{
+				ReportRate = 250,
+				NotifyOnBreakpointOnly = true,
+			});
+
+			_start = subscriptionResult.Breakpoint;
+			_subscriptionId = subscriptionResult.SubscriptionId;
+			StateHasChanged();
+		}
+
+		await base.OnAfterRenderAsync(firstRender);
+	}
+
+	public async ValueTask DisposeAsync() => await BreakpointListener.Unsubscribe(_subscriptionId);
+}

--- a/src/MudBlazor.Docs/Pages/Components/BreakpointProvider/Examples/BreakpointProviderPageHiddenExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/BreakpointProvider/Examples/BreakpointProviderPageHiddenExample.razor
@@ -1,0 +1,71 @@
+﻿@using MudBlazor.Services
+@namespace MudBlazor.Docs.Examples
+
+<MudBreakpointProvider>
+	@for (int i = 0; i < _amountOfRows; i++)
+	{
+		<MudHidden Breakpoint="Breakpoint.Xl" Invert="true">
+			<MudCard Class="pa-5">
+				<MudText>XL</MudText>
+			</MudCard>
+		</MudHidden>
+		<MudHidden Breakpoint="Breakpoint.Lg" Invert="true">
+			<MudCard Class="pa-5">
+				<MudText>LG</MudText>
+			</MudCard>
+		</MudHidden>
+		<MudHidden Breakpoint="Breakpoint.Md" Invert="true">
+			<MudCard Class="pa-5">
+				<MudText>MD</MudText>
+			</MudCard>
+		</MudHidden>
+		<MudHidden Breakpoint="Breakpoint.Sm" Invert="true">
+			<MudCard Class="pa-5">
+				<MudText>SM</MudText>
+			</MudCard>
+		</MudHidden>
+		<MudHidden Breakpoint="Breakpoint.Xs" Invert="true">
+			<MudCard Class="pa-5">
+				<MudText>XS</MudText>
+			</MudCard>
+		</MudHidden>
+		<MudHidden Breakpoint="Breakpoint.LgAndUp" Invert="true">
+			<MudCard Class="pa-5">
+				<MudText>LG and Up</MudText>
+			</MudCard>
+		</MudHidden>
+		<MudHidden Breakpoint="Breakpoint.MdAndUp" Invert="true">
+			<MudCard Class="pa-5">
+				<MudText>MD and Up</MudText>
+			</MudCard>
+		</MudHidden>
+		<MudHidden Breakpoint="Breakpoint.SmAndUp" Invert="true">
+			<MudCard Class="pa-5">
+				<MudText>SM and Up</MudText>
+			</MudCard>
+		</MudHidden>
+		<MudHidden Breakpoint="Breakpoint.LgAndDown" Invert="true">
+			<MudCard Class="pa-5">
+				<MudText>LG and Down</MudText>
+			</MudCard>
+		</MudHidden>
+		<MudHidden Breakpoint="Breakpoint.MdAndDown" Invert="true">
+			<MudCard Class="pa-5">
+				<MudText>MD and Down</MudText>
+			</MudCard>
+		</MudHidden>
+		<MudHidden Breakpoint="Breakpoint.SmAndDown" Invert="true">
+			<MudCard Class="pa-5">
+				<MudText>SM and Down</MudText>
+			</MudCard>
+		</MudHidden>
+	}
+</MudBreakpointProvider>
+
+<MudSlider @bind-Value="_amountOfRows" Min="1" Max="100"></MudSlider>
+<MudText>Rows: @_amountOfRows</MudText>
+
+@code {
+	private int _amountOfRows = 10;
+
+} 

--- a/src/MudBlazor.Docs/Pages/Components/Hidden/Examples/BrowserResizeEventExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Hidden/Examples/BrowserResizeEventExample.razor
@@ -1,6 +1,12 @@
 ﻿@using MudBlazor.Services
 @namespace MudBlazor.Docs.Examples
-@implements IDisposable
+@implements IAsyncDisposable
+
+<MudAlert Severity=Severity.Warning>
+	MudBlazor 5.1.2 introduced new implementations for handling browser resize events.
+	The <strong>IResizeListenerService</strong> can still be used but we strongly encourage you to move to the 
+	<strong>ISubscriptionBasedResizeListenerService </strong>
+</MudAlert>
 
 <MudCard Class="pa-5">
     <MudText>
@@ -11,21 +17,27 @@
 
 @code
 {
-    [Inject] IResizeListenerService ResizeListener { get; set; }
+	[Inject] ISubscriptionBasedResizeListenerService ResizeListener { get; set; }
 
     int width = 0;
     int height = 0;
 
-    protected override async Task OnInitializedAsync()
-    {
-        await base.OnInitializedAsync();
-    }
+	private Guid _subscriptionId;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender)
         {
-            ResizeListener.OnResized += OnResized;
+			_subscriptionId = await ResizeListener.Subscribe((size) =>
+			{
+				width = size.Width;
+				height = size.Height;
+				InvokeAsync(StateHasChanged);
+			}, new ResizeOptions
+			{
+				ReportRate = 250,
+				NotifyOnBreakpointOnly = false,
+			});
 
             var size = await ResizeListener.GetBrowserWindowSize();
             height = size.Height;
@@ -36,15 +48,5 @@
         await base.OnAfterRenderAsync(firstRender);
     }
 
-    private void OnResized(object sender, BrowserWindowSize size)
-    {
-        width = size.Width;
-        height = size.Height;
-        InvokeAsync(StateHasChanged);
-    }
-
-    public void Dispose()
-    {
-        ResizeListener.OnResized -= OnResized;
-    }
+    public async ValueTask DisposeAsync() => await ResizeListener.Unsubscribe(_subscriptionId);
 }

--- a/src/MudBlazor.Docs/Pages/Components/Hidden/Examples/HiddenExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Hidden/Examples/HiddenExample.razor
@@ -1,64 +1,62 @@
 ﻿@using MudBlazor.Services
 @namespace MudBlazor.Docs.Examples
 
-<MudHidden Breakpoint="Breakpoint.Xxl" Invert="true">
-    <MudCard Class="pa-5">
-        <MudText>XXL</MudText>
-    </MudCard>
-</MudHidden>
 <MudHidden Breakpoint="Breakpoint.Xl" Invert="true">
-    <MudCard Class="pa-5">
-        <MudText>XL</MudText>
-    </MudCard>
+	<MudCard Class="pa-5">
+		<MudText>XL</MudText>
+	</MudCard>
 </MudHidden>
 <MudHidden Breakpoint="Breakpoint.Lg" Invert="true">
-    <MudCard Class="pa-5">
-        <MudText>LG</MudText>
-    </MudCard>
+	<MudCard Class="pa-5">
+		<MudText>LG</MudText>
+	</MudCard>
 </MudHidden>
 <MudHidden Breakpoint="Breakpoint.Md" Invert="true">
-    <MudCard Class="pa-5">
-        <MudText>MD</MudText>
-    </MudCard>
+	<MudCard Class="pa-5">
+		<MudText>MD</MudText>
+	</MudCard>
 </MudHidden>
 <MudHidden Breakpoint="Breakpoint.Sm" Invert="true">
-    <MudCard Class="pa-5">
-        <MudText>SM</MudText>
-    </MudCard>
+	<MudCard Class="pa-5">
+		<MudText>SM</MudText>
+	</MudCard>
 </MudHidden>
 <MudHidden Breakpoint="Breakpoint.Xs" Invert="true">
-    <MudCard Class="pa-5">
-        <MudText>XS</MudText>
-    </MudCard>
+	<MudCard Class="pa-5">
+		<MudText>XS</MudText>
+	</MudCard>
 </MudHidden>
 <MudHidden Breakpoint="Breakpoint.LgAndUp" Invert="true">
-    <MudCard Class="pa-5">
-        <MudText>LG and Up</MudText>
-    </MudCard>
+	<MudCard Class="pa-5">
+		<MudText>LG and Up</MudText>
+	</MudCard>
 </MudHidden>
 <MudHidden Breakpoint="Breakpoint.MdAndUp" Invert="true">
-    <MudCard Class="pa-5">
-        <MudText>MD and Up</MudText>
-    </MudCard>
+	<MudCard Class="pa-5">
+		<MudText>MD and Up</MudText>
+	</MudCard>
 </MudHidden>
 <MudHidden Breakpoint="Breakpoint.SmAndUp" Invert="true">
-    <MudCard Class="pa-5">
-        <MudText>SM and Up</MudText>
-    </MudCard>
+	<MudCard Class="pa-5">
+		<MudText>SM and Up</MudText>
+	</MudCard>
 </MudHidden>
 <MudHidden Breakpoint="Breakpoint.LgAndDown" Invert="true">
-    <MudCard Class="pa-5">
-        <MudText>LG and Down</MudText>
-    </MudCard>
+	<MudCard Class="pa-5">
+		<MudText>LG and Down</MudText>
+	</MudCard>
 </MudHidden>
 <MudHidden Breakpoint="Breakpoint.MdAndDown" Invert="true">
-    <MudCard Class="pa-5">
-        <MudText>MD and Down</MudText>
-    </MudCard>
+	<MudCard Class="pa-5">
+		<MudText>MD and Down</MudText>
+	</MudCard>
 </MudHidden>
 <MudHidden Breakpoint="Breakpoint.SmAndDown" Invert="true">
-    <MudCard Class="pa-5">
-        <MudText>SM and Down</MudText>
-    </MudCard>
+	<MudCard Class="pa-5">
+		<MudText>SM and Down</MudText>
+	</MudCard>
 </MudHidden>
 
+
+@code {
+} 

--- a/src/MudBlazor.Docs/Services/MenuService.cs
+++ b/src/MudBlazor.Docs/Services/MenuService.cs
@@ -33,6 +33,7 @@ namespace MudBlazor.Docs.Services
             .AddItem("Container", typeof(MudContainer))
             .AddItem("Grid", typeof(MudGrid), typeof(MudItem))
             .AddItem("Hidden", typeof(MudHidden))
+            .AddItem("Breakpoint Provider", typeof(MudBreakpointProvider))
             .AddItem("Chips", typeof(MudChip))
             .AddItem("ChipSet", typeof(MudChipSet))
             .AddItem("Badge", typeof(MudBadge))

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Hidden/BreakpointProviderWithMudHiddenTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Hidden/BreakpointProviderWithMudHiddenTest.razor
@@ -1,0 +1,24 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudBreakpointProvider OnBreakpointChanged="@( (x) => BreakpointChangedHistory.Add(x))">
+	<MudHidden Breakpoint="@Breakpoint">
+		<MudText>MudHidden content 1</MudText>
+	</MudHidden>
+		<MudHidden Breakpoint="@Breakpoint">
+		<MudText>MudHidden content 2</MudText>
+	</MudHidden>
+		<MudHidden Breakpoint="@Breakpoint">
+		<MudText>MudHidden content 3</MudText>
+	</MudHidden>
+		<MudHidden Breakpoint="@Breakpoint">
+		<MudText>MudHidden content 4</MudText>
+	</MudHidden>
+</MudBreakpointProvider>
+
+@code {
+
+	[Parameter] public Breakpoint Breakpoint { get; set; }
+
+	public List<Breakpoint> BreakpointChangedHistory { get; set; } = new();
+
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Hidden/SimpleMudHiddenTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Hidden/SimpleMudHiddenTest.razor
@@ -1,0 +1,15 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents
+
+<MudHidden Invert="@Invert" Breakpoint="@Breakpoint" IsHiddenChanged="@( (x) => HiddenChangedHistory.Add(x) )" >
+	<MudText>MudHidden content</MudText>
+</MudHidden>
+
+@code {
+	[Parameter] public bool Invert { get; set; }
+	[Parameter] public Breakpoint Breakpoint { get; set; }
+
+	public List<Boolean> HiddenChangedHistory { get; set; } = new();
+
+	
+
+}

--- a/src/MudBlazor.UnitTests/Components/DrawerTest.cs
+++ b/src/MudBlazor.UnitTests/Components/DrawerTest.cs
@@ -1,12 +1,11 @@
-﻿
-
-#pragma warning disable CS1998 // async without await
+﻿#pragma warning disable CS1998 // async without await
 
 using System;
 using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
+using Moq;
 using MudBlazor.Services;
 using MudBlazor.UnitTests.Mocks;
 using MudBlazor.UnitTests.TestComponents;
@@ -18,10 +17,21 @@ namespace MudBlazor.UnitTests.Components
     [TestFixture]
     public class DrawerTest : BunitTest
     {
+        private Mock<IBreakpointListenerService> _breakpointListenerServiceMock;
+        private Action<Breakpoint> _breakpointUpdateCallback;
+
         public override void Setup()
         {
             base.Setup();
-            Context.Services.AddScoped<IResizeListenerService, MockResizeListenerService>();
+            _breakpointListenerServiceMock = new Mock<IBreakpointListenerService>();
+
+            _breakpointListenerServiceMock
+                .Setup(x => x.Subscribe(It.IsAny<Action<Breakpoint>>()))
+                .ReturnsAsync(new BreakpointListenerSubscribeResult(Guid.NewGuid(), Breakpoint.Md))
+                .Callback<Action<Breakpoint>>(x => _breakpointUpdateCallback = x)
+                .Verifiable();
+
+            Context.Services.AddScoped(sp => _breakpointListenerServiceMock.Object);
         }
 
         [Test]
@@ -157,11 +167,12 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task ResponsiveSmallClosed_Open_CheckOpenedAndOverlay()
+        [TestCase(Breakpoint.Xs)]
+        [TestCase(Breakpoint.Sm)]
+        public async Task ResponsiveSmallClosed_Open_CheckOpenedAndOverlay(Breakpoint point)
         {
-            (Context.Services.GetService<IResizeListenerService>() as MockResizeListenerService)?.ApplyScreenSize(500, 768);
-
             var comp = Context.RenderComponent<DrawerResponsiveTest>();
+            await comp.InvokeAsync(() => _breakpointUpdateCallback(point));
 
             Console.WriteLine(comp.Markup);
 
@@ -179,12 +190,10 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(Breakpoint.Md)]
         [TestCase(Breakpoint.Lg)]
         [TestCase(Breakpoint.Xl)]
-        [TestCase(Breakpoint.Xxl)]
         public async Task ResponsiveClosed_LargeScreen_SetBreakpoint_Open_CheckState(Breakpoint breakpoint)
         {
-            (Context.Services.GetService<IResizeListenerService>() as MockResizeListenerService)?.ApplyScreenSize(2560, 1080);
-
             var comp = Context.RenderComponent<DrawerResponsiveTest>(Parameter(nameof(DrawerResponsiveTest.Breakpoint), breakpoint));
+            await comp.InvokeAsync(() => _breakpointUpdateCallback(Breakpoint.Xl));
 
             Console.WriteLine(comp.Markup);
 
@@ -202,12 +211,10 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(Breakpoint.Md)]
         [TestCase(Breakpoint.Lg)]
         [TestCase(Breakpoint.Xl)]
-        [TestCase(Breakpoint.Xxl)]
         public async Task ResponsiveClosed_SmallScreen_SetBreakpoint_Open_CheckState(Breakpoint breakpoint)
         {
-            (Context.Services.GetService<IResizeListenerService>() as MockResizeListenerService)?.ApplyScreenSize(400, 300);
-
             var comp = Context.RenderComponent<DrawerResponsiveTest>(Parameter(nameof(DrawerResponsiveTest.Breakpoint), breakpoint));
+            await comp.InvokeAsync(() => _breakpointUpdateCallback(Breakpoint.Xs));
 
             Console.WriteLine(comp.Markup);
 
@@ -224,11 +231,11 @@ namespace MudBlazor.UnitTests.Components
         public async Task ResponsiveClosed_ResizeMultiple_CheckStates()
         {
             var srv = Context.Services.GetService<IResizeListenerService>() as MockResizeListenerService;
-            srv?.ApplyScreenSize(1280, 768);
 
             var comp = Context.RenderComponent<DrawerResponsiveTest>(Parameter(nameof(DrawerResponsiveTest.PreserveOpenState), true));
-
             Console.WriteLine(comp.Markup);
+
+            await comp.InvokeAsync(() => _breakpointUpdateCallback(Breakpoint.Lg));
 
             //open drawer
             comp.Find("button").Click();
@@ -237,13 +244,13 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.Drawer.Open.Should().BeTrue();
 
             //resize to small, drawer should close
-            srv?.ApplyScreenSize(600, 768);
+            await comp.InvokeAsync(() => _breakpointUpdateCallback(Breakpoint.Xs));
 
             comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeFalse();
 
             //resize to large, drawer should open automatically
-            srv?.ApplyScreenSize(1024, 768);
+            await comp.InvokeAsync(() => _breakpointUpdateCallback(Breakpoint.Lg));
 
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeTrue();
@@ -254,14 +261,15 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
 
             //resize to small, then open drawer
-            srv?.ApplyScreenSize(600, 768);
+            await comp.InvokeAsync(() => _breakpointUpdateCallback(Breakpoint.Sm));
+
             comp.Find("button").Click();
 
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
             comp.FindAll("aside+.mud-drawer-overlay").Count.Should().Be(1);
 
             //resize to large, drawer should stays open
-            srv?.ApplyScreenSize(1024, 768);
+            await comp.InvokeAsync(() => _breakpointUpdateCallback(Breakpoint.Lg));
 
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
             comp.FindAll("aside+.mud-drawer-overlay").Count.Should().Be(0);
@@ -274,10 +282,8 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Responsive_ResizeToSmall_RestoreToLarge_CheckStates()
         {
-            var srv = Context.Services.GetService<IResizeListenerService>() as MockResizeListenerService;
-            srv?.ApplyScreenSize(1280, 768);
-
             var comp = Context.RenderComponent<DrawerResponsiveTest>(Parameter(nameof(DrawerResponsiveTest.PreserveOpenState), true));
+            await comp.InvokeAsync(() => _breakpointUpdateCallback(Breakpoint.Lg));
 
             Console.WriteLine(comp.Markup);
 
@@ -288,19 +294,20 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.Drawer.Open.Should().BeTrue();
 
             //resize to small, drawer should close
-            srv?.ApplyScreenSize(800, 768);
+            await comp.InvokeAsync(() => _breakpointUpdateCallback(Breakpoint.Sm));
+
 
             comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeFalse();
 
             //resize to extra small, drawer should close
-            srv?.ApplyScreenSize(400, 768);
+            await comp.InvokeAsync(() => _breakpointUpdateCallback(Breakpoint.Xs));
 
             comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeFalse();
 
             //resize to large, drawer should open automatically
-            srv?.ApplyScreenSize(1024, 768);
+            await comp.InvokeAsync(() => _breakpointUpdateCallback(Breakpoint.Lg));
 
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeTrue();

--- a/src/MudBlazor.UnitTests/Components/HiddenTests.cs
+++ b/src/MudBlazor.UnitTests/Components/HiddenTests.cs
@@ -1,0 +1,261 @@
+﻿
+#pragma warning disable CS1998 // async without await
+
+using System;
+using System.Threading.Tasks;
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using MudBlazor.Services;
+using MudBlazor.UnitTests.TestComponents;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Components
+{
+    [TestFixture]
+    public class HiddenTests : BunitTest
+    {
+        [Test]
+        [TestCase(false, false, false)]
+        [TestCase(false, true, true)]
+        [TestCase(true, false, true)]
+        [TestCase(true, true, false)]
+        public void Content_Visible(bool mediaResult, bool invert, bool isHidden)
+        {
+            var listenerMock = new Mock<IBreakpointListenerService>();
+            listenerMock.Setup(x => x.Subscribe(It.IsAny<Action<Breakpoint>>())).ReturnsAsync(new BreakpointListenerSubscribeResult(Guid.NewGuid(), Breakpoint.Md)).Verifiable();
+            listenerMock.Setup(x => x.IsMediaSize(Breakpoint.Lg, Breakpoint.Md)).Returns(mediaResult).Verifiable();
+
+            Context.Services.AddSingleton(sp => listenerMock.Object);
+
+            var comp = Context.RenderComponent<SimpleMudHiddenTest>(p =>
+            {
+                p.Add(x => x.Breakpoint, Breakpoint.Lg);
+                p.Add(x => x.Invert, invert);
+            });
+            Console.WriteLine(comp.Markup);
+
+            if (isHidden == true)
+            {
+                Assert.Throws<ElementNotFoundException>(() => comp.Find("p"));
+            }
+            else
+            {
+                comp.Find("p").TextContent.Should().Be("MudHidden content");
+            }
+
+            listenerMock.Verify();
+        }
+
+        [Test]
+        public void SizeChanged()
+        {
+            Action<Breakpoint> callback = null;
+
+            var listenerMock = new Mock<IBreakpointListenerService>();
+            listenerMock.Setup(x => x.Subscribe(It.IsAny<Action<Breakpoint>>()))
+                .ReturnsAsync(new BreakpointListenerSubscribeResult(Guid.NewGuid(), Breakpoint.Md))
+                .Callback<Action<Breakpoint>>(x => callback = x)
+                .Verifiable();
+
+            listenerMock.Setup(x => x.IsMediaSize(Breakpoint.Lg, Breakpoint.Md)).Returns(false).Verifiable();
+            listenerMock.Setup(x => x.IsMediaSize(Breakpoint.Lg, Breakpoint.Xs)).Returns(true).Verifiable();
+            listenerMock.Setup(x => x.IsMediaSize(Breakpoint.Lg, Breakpoint.Xl)).Returns(false).Verifiable();
+
+            Context.Services.AddSingleton(sp => listenerMock.Object);
+
+            var comp = Context.RenderComponent<SimpleMudHiddenTest>(p =>
+            {
+                p.Add(x => x.Breakpoint, Breakpoint.Lg);
+                p.Add(x => x.Invert, false);
+            });
+
+            comp.Find("p").TextContent.Should().Be("MudHidden content");
+
+            comp.InvokeAsync(() => callback.Invoke(Breakpoint.Xs));
+
+            Assert.Throws<ElementNotFoundException>(() => comp.Find("p"));
+
+            comp.InvokeAsync(() => callback.Invoke(Breakpoint.Xl));
+            comp.Find("p").TextContent.Should().Be("MudHidden content");
+
+            comp.Instance.HiddenChangedHistory.Should().HaveCount(3).And.BeEquivalentTo(new[] { false, true, false });
+
+            listenerMock.Verify();
+        }
+
+        [Test]
+        public void InvertChangedAfterInitilizing()
+        {
+            var listenerMock = new Mock<IBreakpointListenerService>();
+            listenerMock.Setup(x => x.Subscribe(It.IsAny<Action<Breakpoint>>())).ReturnsAsync(new BreakpointListenerSubscribeResult(Guid.NewGuid(), Breakpoint.Md)).Verifiable();
+            listenerMock.Setup(x => x.IsMediaSize(Breakpoint.Lg, Breakpoint.Md)).Returns(false).Verifiable();
+
+            Context.Services.AddSingleton(sp => listenerMock.Object);
+
+            var comp = Context.RenderComponent<SimpleMudHiddenTest>(p =>
+            {
+                p.Add(x => x.Breakpoint, Breakpoint.Lg);
+                p.Add(x => x.Invert, false);
+            });
+            Console.WriteLine(comp.Markup);
+
+            comp.Find("p").TextContent.Should().Be("MudHidden content");
+
+            comp.SetParametersAndRender(p => p.Add(x => x.Invert, true));
+
+            Assert.Throws<ElementNotFoundException>(() => comp.Find("p"));
+
+            listenerMock.Verify(x => x.IsMediaSize(Breakpoint.Lg, Breakpoint.Md), Times.Exactly(4));
+            listenerMock.Verify();
+        }
+
+        [Test]
+        public void ReferenceBreakpointChangedAfterInitilizing()
+        {
+            var listenerMock = new Mock<IBreakpointListenerService>();
+            listenerMock.Setup(x => x.Subscribe(It.IsAny<Action<Breakpoint>>())).ReturnsAsync(new BreakpointListenerSubscribeResult(Guid.NewGuid(), Breakpoint.Md)).Verifiable();
+            listenerMock.Setup(x => x.IsMediaSize(Breakpoint.Lg, Breakpoint.Md)).Returns(false).Verifiable();
+            listenerMock.Setup(x => x.IsMediaSize(Breakpoint.Xs, Breakpoint.Md)).Returns(true).Verifiable();
+
+            Context.Services.AddSingleton(sp => listenerMock.Object);
+
+            var comp = Context.RenderComponent<SimpleMudHiddenTest>(p =>
+            {
+                p.Add(x => x.Breakpoint, Breakpoint.Lg);
+                p.Add(x => x.Invert, false);
+            });
+            Console.WriteLine(comp.Markup);
+
+            comp.Find("p").TextContent.Should().Be("MudHidden content");
+
+            comp.SetParametersAndRender(p => p.Add(x => x.Breakpoint, Breakpoint.Xs));
+
+            Assert.Throws<ElementNotFoundException>(() => comp.Find("p"));
+
+            listenerMock.Verify(x => x.IsMediaSize(Breakpoint.Lg, Breakpoint.Md), Times.Exactly(2));
+            listenerMock.Verify(x => x.IsMediaSize(Breakpoint.Xs, Breakpoint.Md), Times.Exactly(2));
+            listenerMock.Verify();
+        }
+
+        [Test]
+        public void SizeChangedToNone()
+        {
+            Action<Breakpoint> callback = null;
+
+            var listenerMock = new Mock<IBreakpointListenerService>();
+            listenerMock.Setup(x => x.Subscribe(It.IsAny<Action<Breakpoint>>()))
+                .ReturnsAsync(new BreakpointListenerSubscribeResult(Guid.NewGuid(), Breakpoint.Md))
+                .Callback<Action<Breakpoint>>(x => callback = x)
+                .Verifiable();
+
+            listenerMock.Setup(x => x.IsMediaSize(Breakpoint.Lg, Breakpoint.Md)).Returns(false).Verifiable();
+
+            Context.Services.AddSingleton(sp => listenerMock.Object);
+
+            var comp = Context.RenderComponent<SimpleMudHiddenTest>(p =>
+            {
+                p.Add(x => x.Breakpoint, Breakpoint.Lg);
+                p.Add(x => x.Invert, false);
+            });
+
+            comp.Find("p").TextContent.Should().Be("MudHidden content");
+
+            comp.InvokeAsync(() => callback.Invoke(Breakpoint.None));
+            comp.Find("p").TextContent.Should().Be("MudHidden content");
+
+            comp.Instance.HiddenChangedHistory.Should().ContainSingle().And.BeEquivalentTo(new[] { false });
+
+            listenerMock.Verify();
+        }
+
+        [Test]
+        public void WithinMudBreakpointProvider()
+        {
+            var listenerMock = new Mock<IBreakpointListenerService>();
+            listenerMock.Setup(x => x.Subscribe(It.IsAny<Action<Breakpoint>>()))
+                .ReturnsAsync(new BreakpointListenerSubscribeResult(Guid.NewGuid(), Breakpoint.Md))
+                .Verifiable();
+
+            listenerMock.Setup(x => x.IsMediaSize(Breakpoint.Lg, Breakpoint.Md)).Returns(false).Verifiable();
+
+            Context.Services.AddSingleton(sp => listenerMock.Object);
+
+            var comp = Context.RenderComponent<BreakpointProviderWithMudHiddenTest>(p =>
+            {
+                p.Add(x => x.Breakpoint, Breakpoint.Lg);
+            });
+
+            var items = comp.FindAll("p");
+
+            items.Should().HaveCount(4);
+
+            for (int i = 0; i < 4; i++)
+            {
+                var item = items[i];
+                item.TextContent.Should().Be($"MudHidden content {i + 1}");
+            }
+
+            listenerMock.Verify(x => x.Subscribe(It.IsAny<Action<Breakpoint>>()), Times.Once());
+            listenerMock.Verify(x => x.IsMediaSize(Breakpoint.Lg, Breakpoint.Md), Times.Exactly(8));
+            listenerMock.Verify();
+        }
+
+        [Test]
+        public void WithinMudBreakpointProvider_UpdateBreakpointValue()
+        {
+            Action<Breakpoint> callback = null;
+
+            var listenerMock = new Mock<IBreakpointListenerService>();
+            listenerMock.Setup(x => x.Subscribe(It.IsAny<Action<Breakpoint>>()))
+                .ReturnsAsync(new BreakpointListenerSubscribeResult(Guid.NewGuid(), Breakpoint.Md))
+                .Callback<Action<Breakpoint>>(x => callback = x)
+                .Verifiable();
+
+            listenerMock.Setup(x => x.IsMediaSize(Breakpoint.Lg, Breakpoint.Md)).Returns(false).Verifiable();
+            listenerMock.Setup(x => x.IsMediaSize(Breakpoint.Lg, Breakpoint.Xs)).Returns(true).Verifiable();
+            listenerMock.Setup(x => x.IsMediaSize(Breakpoint.Lg, Breakpoint.Sm)).Returns(false).Verifiable();
+            Context.Services.AddSingleton(sp => listenerMock.Object);
+
+            var comp = Context.RenderComponent<BreakpointProviderWithMudHiddenTest>(p =>
+            {
+                p.Add(x => x.Breakpoint, Breakpoint.Lg);
+            });
+
+            var items = comp.FindAll("p");
+
+            items.Should().HaveCount(4);
+
+            for (int i = 0; i < 4; i++)
+            {
+                var item = items[i];
+                item.TextContent.Should().Be($"MudHidden content {i + 1}");
+            }
+
+            comp.InvokeAsync(() => callback(Breakpoint.Xs));
+            items = comp.FindAll("p");
+            items.Should().BeEmpty();
+
+            comp.InvokeAsync(() => callback(Breakpoint.Sm));
+            items = comp.FindAll("p");
+
+            items.Should().HaveCount(4);
+
+            for (int i = 0; i < 4; i++)
+            {
+                var item = items[i];
+                item.TextContent.Should().Be($"MudHidden content {i + 1}");
+            }
+
+            comp.Instance.BreakpointChangedHistory.Should().HaveCount(3).And.BeEquivalentTo(new[] { Breakpoint.Md, Breakpoint.Xs, Breakpoint.Sm });
+
+            listenerMock.Verify(x => x.Subscribe(It.IsAny<Action<Breakpoint>>()), Times.Once());
+            listenerMock.Verify(x => x.IsMediaSize(Breakpoint.Lg, Breakpoint.Md), Times.Exactly(8));
+            listenerMock.Verify(x => x.IsMediaSize(Breakpoint.Lg, Breakpoint.Xs), Times.Exactly(16));
+            listenerMock.Verify(x => x.IsMediaSize(Breakpoint.Lg, Breakpoint.Sm), Times.Exactly(16));
+
+            listenerMock.Verify();
+        }
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/UserAttributes/UserAttributesTests.cs
+++ b/src/MudBlazor.UnitTests/Components/UserAttributes/UserAttributesTests.cs
@@ -23,6 +23,7 @@ namespace MudBlazor.UnitTests.UserAttributes
         {
             Exclude(typeof(MudBooleanInput<>)); // This is the base class of Switch and CheckBox and should be skipped
             Exclude(typeof(MudHidden));         // No need to test
+            Exclude(typeof(MudBreakpointProvider)); // just exposing a cascading value, no layout implications
             Exclude(typeof(MudPicker<>));       // Internal component, skip
             Exclude(typeof(MudRadioGroup<>));   // Wrapping component, skip
         }

--- a/src/MudBlazor.UnitTests/Generated/ApiDocsTests.cs
+++ b/src/MudBlazor.UnitTests/Generated/ApiDocsTests.cs
@@ -24,6 +24,8 @@ namespace MudBlazor.UnitTests.Components
             ctx.Services.AddSingleton<IDialogService>(new DialogService());
             ctx.Services.AddSingleton<ISnackbar, SnackbarService>();
             ctx.Services.AddSingleton<IResizeListenerService>(new MockResizeListenerService());
+            ctx.Services.AddSingleton<ISubscriptionBasedResizeListenerService>(new MockSubscriptionBasedResizeListenerService());
+            ctx.Services.AddSingleton<IBreakpointListenerService>(new MockBreakpointListenerService());
             ctx.Services.AddTransient<IScrollManager, MockScrollManager>();
             ctx.Services.AddTransient<IScrollListener, MockScrollListener>();
             ctx.Services.AddTransient<IJsApiService, MockJsApiServices>();

--- a/src/MudBlazor.UnitTests/Generated/ExampleDocsTests.cs
+++ b/src/MudBlazor.UnitTests/Generated/ExampleDocsTests.cs
@@ -24,6 +24,8 @@ namespace MudBlazor.UnitTests.Components
             ctx.Services.AddSingleton<IDialogService>(new DialogService());
             ctx.Services.AddSingleton<ISnackbar, SnackbarService>();
             ctx.Services.AddSingleton<IResizeListenerService>(new MockResizeListenerService());
+            ctx.Services.AddSingleton<ISubscriptionBasedResizeListenerService>(new MockSubscriptionBasedResizeListenerService());
+            ctx.Services.AddSingleton<IBreakpointListenerService>(new MockBreakpointListenerService());
             ctx.Services.AddTransient<IScrollManager, MockScrollManager>();
             ctx.Services.AddTransient<IScrollListener, MockScrollListener>();
             ctx.Services.AddTransient<IJsApiService, MockJsApiServices>();

--- a/src/MudBlazor.UnitTests/Mocks/MockBreakpointListenerService.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockBreakpointListenerService.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Threading.Tasks;
+using MudBlazor.Services;
+
+namespace MudBlazor.UnitTests.Mocks
+{
+#pragma warning disable CS1998 // Justification - Implementing IResizeListenerService
+    public class MockBreakpointListenerService : IBreakpointListenerService
+    {
+        private int _width, _height;
+
+        internal void ApplyScreenSize(int width, int height)
+        {
+            _width = width;
+            _height = height;
+
+            OnResized?.Invoke(this, new BrowserWindowSize()
+            {
+                Width = _width,
+                Height = _height
+            });
+            OnBreakpointChanged?.Invoke(this, GetBreakpointInternal());
+        }
+
+#nullable enable
+#pragma warning disable CS0414 // justification implementing interface  
+        public event EventHandler<BrowserWindowSize>? OnResized;
+        public event EventHandler<Breakpoint>? OnBreakpointChanged;
+#pragma warning restore CS0414 
+#nullable disable
+        public async ValueTask<BrowserWindowSize> GetBrowserWindowSize()
+        {
+            return new BrowserWindowSize()
+            {
+                Width = _width,
+                Height = _height
+            };
+        }
+
+        public async Task<bool> IsMediaSize(Breakpoint breakpoint)
+        {
+            if (breakpoint == Breakpoint.None)
+                return false;
+
+            return IsMediaSize(breakpoint, await GetBreakpoint());
+        }
+
+        public bool IsMediaSize(Breakpoint breakpoint, Breakpoint reference)
+        {
+            if (breakpoint == Breakpoint.None)
+                return false;
+
+            return breakpoint switch
+            {
+                Breakpoint.Xs => reference == Breakpoint.Xs,
+                Breakpoint.Sm => reference == Breakpoint.Sm,
+                Breakpoint.Md => reference == Breakpoint.Md,
+                Breakpoint.Lg => reference == Breakpoint.Lg,
+                Breakpoint.Xl => reference == Breakpoint.Xl,
+                // * and down
+                Breakpoint.SmAndDown => reference <= Breakpoint.Sm,
+                Breakpoint.MdAndDown => reference <= Breakpoint.Md,
+                Breakpoint.LgAndDown => reference <= Breakpoint.Lg,
+                // * and up
+                Breakpoint.SmAndUp => reference >= Breakpoint.Sm,
+                Breakpoint.MdAndUp => reference >= Breakpoint.Md,
+                Breakpoint.LgAndUp => reference >= Breakpoint.Lg,
+                _ => false,
+            };
+        }
+
+        public async Task<Breakpoint> GetBreakpoint() => GetBreakpointInternal();
+
+        public Task<BreakpointListenerSubscribeResult> Subscribe(Action<Breakpoint> callback) => Task.FromResult(new BreakpointListenerSubscribeResult(Guid.NewGuid(),Breakpoint.Sm));
+        public Task<BreakpointListenerSubscribeResult> Subscribe(Action<Breakpoint> callback, ResizeOptions options) => Task.FromResult(new BreakpointListenerSubscribeResult(Guid.NewGuid(), Breakpoint.Sm));
+        public Task<bool> Unsubscribe(Guid subscriptionId) => Task.FromResult(true);
+
+        private Breakpoint GetBreakpointInternal()
+        {
+            if (_width >= ResizeListenerService.BreakpointDefinitions[Breakpoint.Xl])
+                return Breakpoint.Xl;
+            else if (_width >= ResizeListenerService.BreakpointDefinitions[Breakpoint.Lg])
+                return Breakpoint.Lg;
+            else if (_width >= ResizeListenerService.BreakpointDefinitions[Breakpoint.Md])
+                return Breakpoint.Md;
+            else if (_width >= ResizeListenerService.BreakpointDefinitions[Breakpoint.Sm])
+                return Breakpoint.Sm;
+            else
+                return Breakpoint.Xs;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            OnResized = null;
+            OnBreakpointChanged = null;
+            return ValueTask.CompletedTask;
+        }
+    }
+#pragma warning restore CS1998
+}

--- a/src/MudBlazor.UnitTests/Mocks/MockSubscriptionBasedResizeListenerService.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockSubscriptionBasedResizeListenerService.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Threading.Tasks;
+using MudBlazor.Services;
+
+namespace MudBlazor.UnitTests.Mocks
+{
+#pragma warning disable CS1998 // Justification - Implementing IResizeListenerService
+    public class MockSubscriptionBasedResizeListenerService : ISubscriptionBasedResizeListenerService
+    {
+        private int _width, _height;
+
+        internal void ApplyScreenSize(int width, int height)
+        {
+            _width = width;
+            _height = height;
+
+            OnResized?.Invoke(this, new BrowserWindowSize()
+            {
+                Width = _width,
+                Height = _height
+            });
+            OnBreakpointChanged?.Invoke(this, GetBreakpointInternal());
+        }
+
+#nullable enable
+#pragma warning disable CS0414 // justification implementing interface  
+        public event EventHandler<BrowserWindowSize>? OnResized;
+        public event EventHandler<Breakpoint>? OnBreakpointChanged;
+#pragma warning restore CS0414 
+#nullable disable
+        public async ValueTask<BrowserWindowSize> GetBrowserWindowSize()
+        {
+            return new BrowserWindowSize()
+            {
+                Width = _width,
+                Height = _height
+            };
+        }
+
+        public async Task<bool> IsMediaSize(Breakpoint breakpoint)
+        {
+            if (breakpoint == Breakpoint.None)
+                return false;
+
+            return IsMediaSize(breakpoint, await GetBreakpoint());
+        }
+
+        public bool IsMediaSize(Breakpoint breakpoint, Breakpoint reference)
+        {
+            if (breakpoint == Breakpoint.None)
+                return false;
+
+            return breakpoint switch
+            {
+                Breakpoint.Xs => reference == Breakpoint.Xs,
+                Breakpoint.Sm => reference == Breakpoint.Sm,
+                Breakpoint.Md => reference == Breakpoint.Md,
+                Breakpoint.Lg => reference == Breakpoint.Lg,
+                Breakpoint.Xl => reference == Breakpoint.Xl,
+                // * and down
+                Breakpoint.SmAndDown => reference <= Breakpoint.Sm,
+                Breakpoint.MdAndDown => reference <= Breakpoint.Md,
+                Breakpoint.LgAndDown => reference <= Breakpoint.Lg,
+                // * and up
+                Breakpoint.SmAndUp => reference >= Breakpoint.Sm,
+                Breakpoint.MdAndUp => reference >= Breakpoint.Md,
+                Breakpoint.LgAndUp => reference >= Breakpoint.Lg,
+                _ => false,
+            };
+        }
+
+        public async Task<Breakpoint> GetBreakpoint() => GetBreakpointInternal();
+
+        public Task<Guid> Subscribe(Action<BrowserWindowSize> callback) => Task.FromResult(new Guid());
+        public Task<Guid> Subscribe(Action<BrowserWindowSize> callback, ResizeOptions options) => Task.FromResult(new Guid());
+        public Task<bool> Unsubscribe(Guid subscriptionId) => Task.FromResult(true);
+
+        private Breakpoint GetBreakpointInternal()
+        {
+            if (_width >= ResizeListenerService.BreakpointDefinitions[Breakpoint.Xl])
+                return Breakpoint.Xl;
+            else if (_width >= ResizeListenerService.BreakpointDefinitions[Breakpoint.Lg])
+                return Breakpoint.Lg;
+            else if (_width >= ResizeListenerService.BreakpointDefinitions[Breakpoint.Md])
+                return Breakpoint.Md;
+            else if (_width >= ResizeListenerService.BreakpointDefinitions[Breakpoint.Sm])
+                return Breakpoint.Sm;
+            else
+                return Breakpoint.Xs;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            OnResized = null;
+            OnBreakpointChanged = null;
+            return ValueTask.CompletedTask;
+        }
+    }
+#pragma warning restore CS1998
+}

--- a/src/MudBlazor.UnitTests/Services/BreakpointListenerServiceTests.cs
+++ b/src/MudBlazor.UnitTests/Services/BreakpointListenerServiceTests.cs
@@ -1,0 +1,623 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using Microsoft.JSInterop;
+using Moq;
+using MudBlazor.Services;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Services
+{
+    [TestFixture]
+    public class BreakpointListenerServiceTests
+    {
+        private Mock<IBrowserWindowSizeProvider> _browserWindowSizeProvider;
+        private Mock<IJSRuntime> _jsruntimeMock;
+        private BreakpointListenerService _service;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _browserWindowSizeProvider = new Mock<IBrowserWindowSizeProvider>();
+            _browserWindowSizeProvider.Setup(x => x.GetBrowserWindowSize()).ReturnsAsync(new BrowserWindowSize { Width = 970, Height = 30 }).Verifiable();
+            _jsruntimeMock = new Mock<IJSRuntime>();
+            _service = new BreakpointListenerService(_jsruntimeMock.Object, _browserWindowSizeProvider.Object);
+        }
+
+
+        private record ListenForResizeCallbackInfo(
+            DotNetObjectReference<BreakpointListenerService> DotnetRef, ResizeOptions options, Guid ListenerId);
+
+
+        private void SetupJsMockForSubscription(ResizeOptions expectedOptions, bool setBreakpoints, Action<ListenForResizeCallbackInfo> callbackInfo = null)
+        {
+            if (setBreakpoints == true)
+            {
+                expectedOptions.BreakpointDefinitions = BreakpointListenerService.DefaultBreakpointDefinitions.ToDictionary(x => x.Key.ToString(), x => x.Value);
+            }
+
+            _jsruntimeMock.Setup(x => x.InvokeAsync<object>("mudResizeListenerFactory.listenForResize",
+               It.Is<object[]>(z =>
+                   z[0] is DotNetObjectReference<BreakpointListenerService> == true &&
+                   (ResizeOptions)z[1] == expectedOptions &&
+                   (Guid)z[2] != default
+               ))).ReturnsAsync(new object()).Callback<string, object[]>((x, z) => callbackInfo?.Invoke(new ListenForResizeCallbackInfo(
+                    (DotNetObjectReference<BreakpointListenerService>)z[0],
+                    (ResizeOptions)z[1], (Guid)z[2]
+                   ))).Verifiable();
+
+        }
+
+        private void SetupJsMockForUnsubscription(Guid listenerId)
+        {
+            _jsruntimeMock.Setup(x => x.InvokeAsync<object>("mudResizeListenerFactory.cancelListener",
+               It.Is<object[]>(z =>
+                   (Guid)z[0] == listenerId
+               ))).ReturnsAsync(new object()).Verifiable();
+        }
+
+        private async Task CheckSubscriptionOptions(ResizeOptions expectedOptions, bool setBreakpoint)
+        {
+            SetupJsMockForSubscription(expectedOptions, setBreakpoint);
+
+            var subscriptionResult = await _service.Subscribe((Breakpoint size) => { }, expectedOptions);
+
+            subscriptionResult.Should().NotBeNull();
+            subscriptionResult.SubscriptionId.Should().NotBe(Guid.Empty);
+            subscriptionResult.Breakpoint.Should().Be(Breakpoint.Md);
+
+            _jsruntimeMock.Verify();
+        }
+
+        [Test]
+        public async Task Subscribe_WithDefaultOptions()
+        {
+            await CheckSubscriptionOptions(new ResizeOptions(), true);
+        }
+
+
+        [Test]
+        public async Task Subscribe_WithDefaultOptions_SetBreakpoint()
+        {
+            var option = new ResizeOptions();
+            await CheckSubscriptionOptions(option, true);
+
+            option.BreakpointDefinitions.Should().NotBeNull();
+
+            option.BreakpointDefinitions.Should().NotBeNull();
+            option.BreakpointDefinitions.Keys.Should().BeEquivalentTo(BreakpointListenerService.DefaultBreakpointDefinitions.Keys.Select(x => x.ToString()).ToList());
+            option.BreakpointDefinitions.Values.Should().BeEquivalentTo(BreakpointListenerService.DefaultBreakpointDefinitions.Values);
+        }
+
+        [Test]
+        public async Task Subscribe_WithDefaultOptions_DontSetBreakpoint()
+        {
+            var breakpointDict = new Dictionary<string, int>
+                {
+                    { "something", 12 },
+                };
+
+            var option = new ResizeOptions
+            {
+                BreakpointDefinitions = breakpointDict
+            };
+
+            await CheckSubscriptionOptions(option, false);
+
+            option.BreakpointDefinitions.Should().BeEquivalentTo(breakpointDict);
+        }
+
+        [Test]
+        public async Task Subscribe_WithOptionsSetInConstructor()
+        {
+            var customResizeOptioons = new ResizeOptions
+            {
+                ReportRate = 120,
+            };
+
+            var optionGetter = new Mock<IOptions<ResizeOptions>>();
+            optionGetter.SetupGet(x => x.Value).Returns(customResizeOptioons);
+
+            _service = new BreakpointListenerService(_jsruntimeMock.Object, _browserWindowSizeProvider.Object, optionGetter.Object);
+            await CheckSubscriptionOptions(customResizeOptioons, true);
+        }
+
+        [Test]
+        public async Task Subscribe_WithPerCallOption()
+        {
+            var customResizeOptioons = new ResizeOptions
+            {
+                ReportRate = 130,
+            };
+
+            SetupJsMockForSubscription(customResizeOptioons, true);
+
+            var subscriptionResult = await _service.Subscribe((Breakpoint size) => { }, customResizeOptioons);
+
+            subscriptionResult.Should().NotBeNull();
+            subscriptionResult.SubscriptionId.Should().NotBe(Guid.Empty);
+            subscriptionResult.Breakpoint.Should().Be(Breakpoint.Md);
+
+            _jsruntimeMock.Verify();
+        }
+
+        [Test]
+        public async Task Subscribe_WithPerCallOptionSetAsNull()
+        {
+            var customResizeOptioons = new ResizeOptions();
+
+            SetupJsMockForSubscription(customResizeOptioons, true);
+            var subscriptionResult = await _service.Subscribe((Breakpoint size) => { }, null);
+
+            subscriptionResult.Should().NotBeNull();
+            subscriptionResult.SubscriptionId.Should().NotBe(Guid.Empty);
+            subscriptionResult.Breakpoint.Should().Be(Breakpoint.Md);
+
+            _jsruntimeMock.Verify();
+        }
+
+        [Test]
+        public void Subscribe_Failed_NullCallback()
+        {
+            Assert.ThrowsAsync<ArgumentNullException>(() => _service.Subscribe(null));
+            Assert.ThrowsAsync<ArgumentNullException>(() => _service.Subscribe(null, new ResizeOptions()));
+        }
+
+        [Test]
+        public async Task SubscribeAndUnsubcribe_SingleSubscription()
+        {
+            var customResizeOptioons = new ResizeOptions();
+
+            Action<ListenForResizeCallbackInfo> feedbackCaller = (x) =>
+            {
+                if (x.ListenerId == default)
+                {
+                    throw new ArgumentException();
+                }
+
+                SetupJsMockForUnsubscription(x.ListenerId);
+
+            };
+
+            SetupJsMockForSubscription(customResizeOptioons, true, feedbackCaller);
+            var subscriptionId = await _service.Subscribe((Breakpoint size) => { }, null);
+
+            var result = await _service.Unsubscribe(subscriptionId.SubscriptionId);
+
+            result.Should().BeTrue();
+
+            _browserWindowSizeProvider.Verify(x => x.GetBrowserWindowSize(), Times.Once());
+            _jsruntimeMock.Verify();
+
+        }
+
+        [Test]
+        public async Task SubscribeAndUnsubcribe_DisposeOfDotNet()
+        {
+            var customResizeOptioons = new ResizeOptions();
+
+            for (int i = 0; i < 4; i++)
+            {
+                var lastDotnetRefHashCode = 0;
+
+                Action<ListenForResizeCallbackInfo> feedbackCaller = (x) =>
+                {
+                    if (x.ListenerId == default)
+                    {
+                        throw new ArgumentException();
+                    }
+
+                    if (x.DotnetRef.GetHashCode() == lastDotnetRefHashCode)
+                    {
+                        throw new ArgumentException();
+                    }
+
+                    lastDotnetRefHashCode = x.DotnetRef.GetHashCode();
+
+                    SetupJsMockForUnsubscription(x.ListenerId);
+
+                };
+
+                SetupJsMockForSubscription(customResizeOptioons, true, feedbackCaller);
+                var subscritionResult = await _service.Subscribe((Breakpoint size) => { }, null);
+
+                var result = await _service.Unsubscribe(subscritionResult.SubscriptionId);
+
+                result.Should().BeTrue();
+
+                _jsruntimeMock.Verify();
+            }
+        }
+
+        [Test]
+        public async Task SubscribeAndUnsubcribe_MultipleSubscription()
+        {
+            var customResizeOptioons = new ResizeOptions();
+
+            var feedbackCallerCount = 0;
+
+            Action<ListenForResizeCallbackInfo> feedbackCaller = (x) =>
+            {
+                if (x.ListenerId == default)
+                {
+                    throw new ArgumentException();
+                }
+
+                feedbackCallerCount++;
+            };
+
+            SetupJsMockForSubscription(customResizeOptioons, true, feedbackCaller);
+
+            HashSet<Guid> subscriptionIds = new HashSet<Guid>();
+
+            for (int i = 0; i < 10; i++)
+            {
+                var subscritionResult = await _service.Subscribe((Breakpoint size) => { });
+                subscriptionIds.Add(subscritionResult.SubscriptionId);
+            }
+
+            feedbackCallerCount.Should().Be(1);
+            subscriptionIds.Should().HaveCount(10);
+
+            _jsruntimeMock.Verify();
+            _browserWindowSizeProvider.Verify(x => x.GetBrowserWindowSize(), Times.Once());
+        }
+
+        [Test]
+        public async Task SubscribeAndUnsubcribe_MultipleSubscription_WithMultipleOptions()
+        {
+            List<ListenForResizeCallbackInfo> callerFeedbacks = new();
+
+            Action<ListenForResizeCallbackInfo> feedbackCaller = (x) =>
+            {
+                if (x.ListenerId == default)
+                {
+                    throw new ArgumentException();
+                }
+
+                callerFeedbacks.Add(x);
+            };
+
+            var options = new[]
+            {
+                new ResizeOptions(),
+                new ResizeOptions { EnableLogging = !(new ResizeOptions().EnableLogging) },
+                new ResizeOptions { ReportRate = 50 },
+                new ResizeOptions { SuppressInitEvent = !(new ResizeOptions().SuppressInitEvent) },
+            };
+
+            foreach (var item in options)
+            {
+                SetupJsMockForSubscription(item, true, feedbackCaller);
+            }
+
+            var subscriptionIds = options.ToDictionary(x => x, x => new HashSet<Guid>());
+
+            for (int i = 0; i < 40; i++)
+            {
+                var index = i % 4;
+                var option = options[index];
+
+                var subscritionResult = await _service.Subscribe((Breakpoint size) => { }, option);
+                subscriptionIds[option].Add(subscritionResult.SubscriptionId);
+            }
+
+            foreach (var item in subscriptionIds)
+            {
+                item.Value.Should().HaveCount(10);
+            }
+
+            callerFeedbacks.Should().HaveCount(4);
+            for (int i = 0; i < callerFeedbacks.Count; i++)
+            {
+                var feedback = callerFeedbacks[i];
+                feedback.options.Should().Be(options[i]);
+            }
+
+            callerFeedbacks.Select(x => x.ListenerId).ToHashSet().Should().HaveCount(4);
+
+            _jsruntimeMock.Verify();
+            _browserWindowSizeProvider.Verify(x => x.GetBrowserWindowSize(), Times.Once());
+        }
+
+        [Test]
+        public async Task Unsubscribe_Failed_NoActiveSubscription()
+        {
+            var result = await _service.Unsubscribe(Guid.NewGuid());
+
+            result.Should().BeFalse();
+        }
+
+        [Test]
+        public async Task Unsubscribe_Failed_SubscriptioonIdNotFound()
+        {
+            var customResizeOptioons = new ResizeOptions();
+
+            SetupJsMockForSubscription(customResizeOptioons, true);
+            var subscriptionId = await _service.Subscribe((Breakpoint size) => { }, null);
+
+            var result = await _service.Unsubscribe(Guid.NewGuid());
+
+            result.Should().BeFalse();
+        }
+
+
+        [Test]
+        public async Task DisposeAsync_Failed_NoActiveSubscription()
+        {
+            await _service.DisposeAsync();
+        }
+
+        [Test]
+        public async Task DisposeAsync_MultipleSubscription_WithMultipleOptions()
+        {
+            List<Guid> callerIds = new();
+
+            Action<ListenForResizeCallbackInfo> feedbackCaller = (x) =>
+            {
+                if (x.ListenerId == default)
+                {
+                    throw new ArgumentException();
+                }
+                callerIds.Add(x.ListenerId);
+            };
+
+            var options = new[]
+            {
+                new ResizeOptions(),
+                new ResizeOptions { EnableLogging = !(new ResizeOptions().EnableLogging) },
+                new ResizeOptions { ReportRate = 50 },
+                new ResizeOptions { SuppressInitEvent = !(new ResizeOptions().SuppressInitEvent) },
+            };
+
+            foreach (var item in options)
+            {
+                SetupJsMockForSubscription(item, true, feedbackCaller);
+            }
+
+            for (int i = 0; i < 40; i++)
+            {
+                var index = i % 4;
+                var option = options[index];
+
+                await _service.Subscribe((Breakpoint size) => { }, option);
+            }
+
+            Func<IEnumerable<Guid>, bool> idChecker = (ids) =>
+             {
+                 try
+                 {
+                     ids.Should().BeEquivalentTo(callerIds);
+                     return true;
+                 }
+                 catch (Exception)
+                 {
+                     return false;
+                 }
+             };
+
+            _jsruntimeMock.Setup(x => x.InvokeAsync<object>("mudResizeListenerFactory.cancelListeners",
+             It.Is<object[]>(z =>
+                 z[0] is IEnumerable<Guid> &&
+                 idChecker((IEnumerable<Guid>)z[0]) == true
+             ))).ReturnsAsync(new object()).Verifiable();
+
+            await _service.DisposeAsync();
+
+            _jsruntimeMock.Verify();
+        }
+
+        private class FakeSubscriber
+        {
+            public Guid SubscriptionId { get; private set; }
+            public Breakpoint ActualSize { get; private set; } = Breakpoint.None;
+
+            public async Task Subscribe(BreakpointListenerService service,
+                ResizeOptions options)
+            {
+                var result = await service.Subscribe((x) => ActualSize = x, options);
+                SubscriptionId = result.SubscriptionId;
+            }
+        }
+
+        [Test]
+        public async Task RaiseOnResized_MultipleSubscription_WithMultipleOptions()
+        {
+            Dictionary<ResizeOptions, Guid> listenerIds = new();
+            Action<ListenForResizeCallbackInfo> feedbackCaller = (x) => listenerIds.Add(x.options, x.ListenerId); ;
+
+            var options = new[]
+            {
+                (new ResizeOptions(), Breakpoint.Xl ),
+                (new ResizeOptions { EnableLogging = !(new ResizeOptions().EnableLogging) }, Breakpoint.Sm),
+                (new ResizeOptions { ReportRate = 50 },Breakpoint.Xs),
+                (new ResizeOptions { SuppressInitEvent = !(new ResizeOptions().SuppressInitEvent) }, Breakpoint.Lg)
+            };
+
+            Dictionary<FakeSubscriber, Breakpoint> subscribers = new();
+
+            foreach (var item in options)
+            {
+                SetupJsMockForSubscription(item.Item1, true, feedbackCaller);
+            }
+
+            for (int i = 0; i < 40; i++)
+            {
+                var index = i % 4;
+                var option = options[index];
+
+                var subscriber = new FakeSubscriber();
+                await subscriber.Subscribe(_service, option.Item1);
+
+                subscribers.Add(subscriber, option.Item2);
+            }
+
+            foreach (var item in options)
+            {
+                var listenerId = listenerIds[item.Item1];
+                _service.RaiseOnResized(new BrowserWindowSize { }, item.Item2, listenerId);
+            }
+
+            foreach (var item in subscribers)
+            {
+                item.Key.ActualSize.Should().Be(item.Value);
+            }
+
+            _jsruntimeMock.Verify();
+            _browserWindowSizeProvider.Verify(x => x.GetBrowserWindowSize(), Times.Once());
+        }
+
+        [Test]
+        public async Task RaiseOnResized_InvalidListenerId()
+        {
+            var customResizeOptions = new ResizeOptions();
+
+            SetupJsMockForSubscription(customResizeOptions, true);
+
+            FakeSubscriber subscriber = new FakeSubscriber();
+            await subscriber.Subscribe(_service, customResizeOptions);
+
+            _service.RaiseOnResized(new BrowserWindowSize { }, Breakpoint.Xl, Guid.NewGuid());
+
+            subscriber.ActualSize.Should().Be(Breakpoint.None);
+        }
+
+        [Test]
+        public async Task Subscribe_ChangeHappens_SecondSubscriptionGetNewValue()
+        {
+            var customResizeOptioons = new ResizeOptions();
+
+            SetupJsMockForSubscription(customResizeOptioons, true);
+            var firstSubscribeResult = await _service.Subscribe((Breakpoint size) => { }, customResizeOptioons);
+
+            firstSubscribeResult.Breakpoint.Should().Be(Breakpoint.Md);
+
+            _service.RaiseOnResized(new BrowserWindowSize { }, Breakpoint.Xl, Guid.NewGuid());
+
+            var secondSubscribeResult = await _service.Subscribe((Breakpoint size) => { }, customResizeOptioons);
+            secondSubscribeResult.Breakpoint.Should().Be(Breakpoint.Xl);
+
+            _browserWindowSizeProvider.Verify(x => x.GetBrowserWindowSize(), Times.Once());
+            _jsruntimeMock.Verify();
+
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task MatchMedia(bool interopResult)
+        {
+            var input = "some input, not relevant for test";
+
+            _jsruntimeMock.Setup(x => x.InvokeAsync<bool>("mudResizeListener.matchMedia",
+            It.Is<object[]>(z =>
+                z[0] is string &&
+                (string)z[0] == input
+            ))).ReturnsAsync(interopResult).Verifiable();
+
+            var result = await _service.MatchMedia(input);
+
+            result.Should().Be(interopResult);
+        }
+
+        [Test]
+        public void DefaultBreakpointDefinitions()
+        {
+            BreakpointListenerService.DefaultBreakpointDefinitions.Keys.Should().BeEquivalentTo(new[] {
+                Breakpoint.Xl, Breakpoint.Lg, Breakpoint.Md, Breakpoint.Sm, Breakpoint.Xs });
+
+            BreakpointListenerService.DefaultBreakpointDefinitions.Values.Should().BeEquivalentTo(new[] {
+                1920, 1280, 960, 600, 0 });
+        }
+
+        // 0 - 599
+        [TestCase(Breakpoint.Xs, 0, true)]
+        [TestCase(Breakpoint.Xs, 599, true)]
+        [TestCase(Breakpoint.Xs, 600, false)]
+
+        // 600 - 959
+        [TestCase(Breakpoint.Sm, 599, false)]
+        [TestCase(Breakpoint.Sm, 600, true)]
+        [TestCase(Breakpoint.Sm, 959, true)]
+        [TestCase(Breakpoint.Sm, 960, false)]
+
+        // 960 - 1279
+        [TestCase(Breakpoint.Md, 959, false)]
+        [TestCase(Breakpoint.Md, 960, true)]
+        [TestCase(Breakpoint.Md, 1279, true)]
+        [TestCase(Breakpoint.Md, 1280, false)]
+
+        // 1280 - 1919
+        [TestCase(Breakpoint.Lg, 1279, false)]
+        [TestCase(Breakpoint.Lg, 1280, true)]
+        [TestCase(Breakpoint.Lg, 1919, true)]
+        [TestCase(Breakpoint.Lg, 1920, false)]
+
+        // 1920 - *
+        [TestCase(Breakpoint.Xl, 1919, false)]
+        [TestCase(Breakpoint.Xl, 1920, true)]
+        [TestCase(Breakpoint.Xl, 9999, true)]
+
+        // >= 600
+        [TestCase(Breakpoint.SmAndUp, 599, false)]
+        [TestCase(Breakpoint.SmAndUp, 600, true)]
+        [TestCase(Breakpoint.SmAndUp, 9999, true)]
+
+        // >= 960
+        [TestCase(Breakpoint.MdAndUp, 959, false)]
+        [TestCase(Breakpoint.MdAndUp, 960, true)]
+        [TestCase(Breakpoint.MdAndUp, 9999, true)]
+
+        // >= 1280
+        [TestCase(Breakpoint.LgAndUp, 1279, false)]
+        [TestCase(Breakpoint.LgAndUp, 1280, true)]
+        [TestCase(Breakpoint.LgAndUp, 9999, true)]
+
+        // < 960
+        [TestCase(Breakpoint.SmAndDown, 960, false)]
+        [TestCase(Breakpoint.SmAndDown, 959, true)]
+        [TestCase(Breakpoint.SmAndDown, 0, true)]
+
+        // < 1280
+        [TestCase(Breakpoint.MdAndDown, 1280, false)]
+        [TestCase(Breakpoint.MdAndDown, 1279, true)]
+        [TestCase(Breakpoint.MdAndDown, 0, true)]
+
+        // < 1920
+        [TestCase(Breakpoint.LgAndDown, 1920, false)]
+        [TestCase(Breakpoint.LgAndDown, 1919, true)]
+        [TestCase(Breakpoint.LgAndDown, 0, true)]
+        public async Task IsMediaSizeReturnsCorrectValue(Breakpoint breakpoint, int browserWidth, bool expectedValue)
+        {
+            // Arrange
+            _browserWindowSizeProvider
+                .Setup(p => p.GetBrowserWindowSize())
+                .ReturnsAsync(new BrowserWindowSize { Width = browserWidth })
+                .Verifiable();
+
+            // Act
+            var actual = await _service.IsMediaSize(breakpoint);
+
+            // Assert
+            actual.Should().Be(expectedValue);
+
+            _browserWindowSizeProvider.Verify();
+        }
+
+        [Test]
+        public async Task IsMediaSize_ReturnFalseForNoneBreakpoint()
+        {
+            var actual = await _service.IsMediaSize(Breakpoint.None);
+            actual.Should().BeFalse();
+
+        }
+    }
+}

--- a/src/MudBlazor.UnitTests/Services/ResizeOptionsTests.cs
+++ b/src/MudBlazor.UnitTests/Services/ResizeOptionsTests.cs
@@ -1,0 +1,248 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MudBlazor.Services;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Services
+{
+    [TestFixture]
+    public class ResizeOptionsTests
+    {
+        [SetUp]
+        public void Setup()
+        {
+
+        }
+
+        [Test]
+        public void DefaultValues()
+        {
+            var option = new ResizeOptions();
+
+            option.ReportRate.Should().Be(100);
+            option.EnableLogging.Should().BeFalse();
+            option.SuppressInitEvent.Should().BeTrue();
+            option.NotifyOnBreakpointOnly.Should().BeTrue();
+            option.BreakpointDefinitions.Should().NotBeNull().And.BeEmpty();
+        }
+
+        [Test]
+        public void Equals_Same_Instance()
+        {
+            var option = new ResizeOptions();
+            option.Should().Be(option);
+        }
+
+        [Test]
+        public void Equals_Same_DefaultInstance()
+        {
+            var option1 = new ResizeOptions();
+            var option2 = new ResizeOptions();
+
+            option1.Should().Be(option2);
+            option2.Should().Be(option1);
+        }
+
+        [Test]
+        public void Equals_Same_NonDefaultValues()
+        {
+            var option1 = new ResizeOptions
+            {
+                EnableLogging = true,
+                NotifyOnBreakpointOnly = false,
+                ReportRate = 125,
+                SuppressInitEvent = false,
+            };
+
+            var option2 = new ResizeOptions
+            {
+                EnableLogging = true,
+                NotifyOnBreakpointOnly = false,
+                ReportRate = 125,
+                SuppressInitEvent = false,
+            };
+
+            option1.Should().Be(option2);
+            option2.Should().Be(option1);
+        }
+
+        [Test]
+        public void Equals_TheSame_WithBreakpointDefinitions()
+        {
+            var option1 = new ResizeOptions()
+            {
+                BreakpointDefinitions = new Dictionary<string, int>
+                {
+                    { "someKey", 12 },
+                    { "someKey2", 24 },
+                    { "someKey3", 36 },
+
+                }
+            };
+
+            var option2 = new ResizeOptions
+            {
+                BreakpointDefinitions = new Dictionary<string, int>
+                {
+                    { "someKey", 12 },
+                    { "someKey2", 24 },
+                    { "someKey3", 36 },
+                }
+            };
+
+            option1.Should().Be(option2);
+            option2.Should().Be(option1);
+        }
+
+        [Test]
+        public void Equals_NotTheSame_DiffersInReportRate()
+        {
+            var option1 = new ResizeOptions();
+
+            var option2 = new ResizeOptions
+            {
+                ReportRate = option1.ReportRate - 10,
+            };
+
+            option1.Should().NotBe(option2);
+            option2.Should().NotBe(option1);
+        }
+
+        [Test]
+        public void Equals_NotTheSame_DiffersInEnableLogging()
+        {
+            var option1 = new ResizeOptions();
+
+            var option2 = new ResizeOptions
+            {
+                EnableLogging = !option1.EnableLogging
+            };
+
+            option1.Should().NotBe(option2);
+            option2.Should().NotBe(option1);
+        }
+
+        [Test]
+        public void Equals_NotTheSame_DiffersInSuppressInitEvent()
+        {
+            var option1 = new ResizeOptions();
+
+            var option2 = new ResizeOptions
+            {
+                SuppressInitEvent = !option1.SuppressInitEvent
+            };
+
+            option1.Should().NotBe(option2);
+            option2.Should().NotBe(option1);
+        }
+
+        [Test]
+        public void Equals_NotTheSame_DiffersInNotifyOnBreakpointOnly()
+        {
+            var option1 = new ResizeOptions();
+
+            var option2 = new ResizeOptions
+            {
+                NotifyOnBreakpointOnly = !option1.NotifyOnBreakpointOnly
+            };
+
+            option1.Should().NotBe(option2);
+            option2.Should().NotBe(option1);
+        }
+
+        [Test]
+        public void Equals_NotTheSame_DiffersInBreakpointDefinitions_NullAndNotNull()
+        {
+            var option1 = new ResizeOptions();
+
+            var option2 = new ResizeOptions
+            {
+                BreakpointDefinitions = new Dictionary<string, int>
+                {
+                    { "someKey", 12 },
+                }
+            };
+
+            option1.Should().NotBe(option2);
+            option2.Should().NotBe(option1);
+        }
+
+        [Test]
+        public void Equals_NotTheSame_DiffersInBreakpointDefinitions_UnequalCount()
+        {
+            var option1 = new ResizeOptions()
+            {
+                BreakpointDefinitions = new Dictionary<string, int>
+                {
+                    { "someKey", 12 },
+                    { "someKey2", 24 },
+                }
+            };
+
+            var option2 = new ResizeOptions
+            {
+                BreakpointDefinitions = new Dictionary<string, int>
+                {
+                    { "someKey", 12 },
+                }
+            };
+
+            option1.Should().NotBe(option2);
+            option2.Should().NotBe(option1);
+        }
+
+        [Test]
+        public void Equals_NotTheSame_DiffersInBreakpointDefinitions_NotSameKeys()
+        {
+            var option1 = new ResizeOptions()
+            {
+                BreakpointDefinitions = new Dictionary<string, int>
+                {
+                    { "someKey", 12 },
+                }
+            };
+
+            var option2 = new ResizeOptions
+            {
+                BreakpointDefinitions = new Dictionary<string, int>
+                {
+                    { "someKey1", 12 },
+                }
+            };
+
+            option1.Should().NotBe(option2);
+            option2.Should().NotBe(option1);
+        }
+
+        [Test]
+        public void Equals_NotTheSame_DiffersInBreakpointDefinitions_DifferentValues()
+        {
+            var option1 = new ResizeOptions()
+            {
+                BreakpointDefinitions = new Dictionary<string, int>
+                {
+                    { "someKey", 12 },
+                }
+            };
+
+            var option2 = new ResizeOptions
+            {
+                BreakpointDefinitions = new Dictionary<string, int>
+                {
+                    { "someKey", 23 },
+                }
+            };
+
+            option1.Should().NotBe(option2);
+            option2.Should().NotBe(option1);
+        }
+    }
+}

--- a/src/MudBlazor.UnitTests/Services/SubscriptionBasedResizeListenerServiceTests.cs
+++ b/src/MudBlazor.UnitTests/Services/SubscriptionBasedResizeListenerServiceTests.cs
@@ -1,0 +1,519 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using Microsoft.JSInterop;
+using Moq;
+using MudBlazor.Services;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Services
+{
+    [TestFixture]
+    public class SubscriptionBasedResizeListenerServiceTests
+    {
+        private Mock<IBrowserWindowSizeProvider> _browserWindowSizeProvider;
+        private Mock<IJSRuntime> _jsruntimeMock;
+        private SubscriptionBasedResizeListenerService _service;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _browserWindowSizeProvider = new Mock<IBrowserWindowSizeProvider>();
+            _jsruntimeMock = new Mock<IJSRuntime>();
+            _service = new SubscriptionBasedResizeListenerService(_jsruntimeMock.Object, _browserWindowSizeProvider.Object);
+        }
+
+        [Test]
+        public async Task GetBrowserWindowSize()
+        {
+            var size = new BrowserWindowSize
+            {
+                Height = 200,
+                Width = 200,
+            };
+
+            _browserWindowSizeProvider.Setup(x => x.GetBrowserWindowSize()).ReturnsAsync(size);
+
+            var actualSize = await _service.GetBrowserWindowSize();
+
+            actualSize.Should().Be(size);
+            _browserWindowSizeProvider.Verify(x => x.GetBrowserWindowSize(), Times.Once());
+        }
+
+        private record ListenForResizeCallbackInfo(
+            DotNetObjectReference<SubscriptionBasedResizeListenerService> DotnetRef, ResizeOptions options, Guid ListenerId);
+
+
+        private void SetupJsMockForSubscription(ResizeOptions expectedOptions, Action<ListenForResizeCallbackInfo> callbackInfo = null)
+        {
+
+            _jsruntimeMock.Setup(x => x.InvokeAsync<object>("mudResizeListenerFactory.listenForResize",
+               It.Is<object[]>(z =>
+                   z[0] is DotNetObjectReference<SubscriptionBasedResizeListenerService> == true &&
+                   (ResizeOptions)z[1] == expectedOptions &&
+                   (Guid)z[2] != default
+               ))).ReturnsAsync(new object()).Callback<string, object[]>((x, z) => callbackInfo?.Invoke(new ListenForResizeCallbackInfo(
+                    (DotNetObjectReference<SubscriptionBasedResizeListenerService>)z[0],
+                    (ResizeOptions)z[1], (Guid)z[2]
+                   ))).Verifiable();
+
+        }
+
+        private void SetupJsMockForUnsubscription(Guid listenerId)
+        {
+            _jsruntimeMock.Setup(x => x.InvokeAsync<object>("mudResizeListenerFactory.cancelListener",
+               It.Is<object[]>(z =>
+                   (Guid)z[0] == listenerId
+               ))).ReturnsAsync(new object()).Verifiable();
+        }
+
+        private async Task CheckSubscriptionOptions(ResizeOptions expectedOptions)
+        {
+            SetupJsMockForSubscription(expectedOptions);
+
+            var subscriptionId = await _service.Subscribe((BrowserWindowSize size) => { });
+
+            subscriptionId.Should().NotBe(Guid.Empty);
+
+            _jsruntimeMock.Verify();
+        }
+
+        [Test]
+        public async Task Subscribe_WithDefaultOptions()
+        {
+            await CheckSubscriptionOptions(new ResizeOptions());
+        }
+
+        [Test]
+        public async Task Subscribe_WithOptionsSetInConstructor()
+        {
+            var customResizeOptioons = new ResizeOptions
+            {
+                ReportRate = 120,
+            };
+
+            var optionGetter = new Mock<IOptions<ResizeOptions>>();
+            optionGetter.SetupGet(x => x.Value).Returns(customResizeOptioons);
+
+            _service = new SubscriptionBasedResizeListenerService(_jsruntimeMock.Object, _browserWindowSizeProvider.Object, optionGetter.Object);
+            await CheckSubscriptionOptions(customResizeOptioons);
+        }
+
+        [Test]
+        public async Task Subscribe_WithPerCallOption()
+        {
+            var customResizeOptioons = new ResizeOptions
+            {
+                ReportRate = 130,
+            };
+
+            SetupJsMockForSubscription(customResizeOptioons);
+
+            var subscriptionId = await _service.Subscribe((BrowserWindowSize size) => { }, customResizeOptioons);
+
+            subscriptionId.Should().NotBe(Guid.Empty);
+            _jsruntimeMock.Verify();
+        }
+
+        [Test]
+        public async Task Subscribe_WithPerCallOptionSetAsNull()
+        {
+            var customResizeOptioons = new ResizeOptions();
+
+            SetupJsMockForSubscription(customResizeOptioons);
+            var subscriptionId = await _service.Subscribe((BrowserWindowSize size) => { }, null);
+
+            subscriptionId.Should().NotBe(Guid.Empty);
+            _jsruntimeMock.Verify();
+        }
+
+        [Test]
+        public void Subscribe_Failed_NullCallback()
+        {
+            Assert.ThrowsAsync<ArgumentNullException>(() => _service.Subscribe(null));
+            Assert.ThrowsAsync<ArgumentNullException>(() => _service.Subscribe(null, new ResizeOptions()));
+
+        }
+
+        [Test]
+        public async Task SubscribeAndUnsubcribe_SingleSubscription()
+        {
+            var customResizeOptioons = new ResizeOptions();
+
+            Action<ListenForResizeCallbackInfo> feedbackCaller = (x) =>
+            {
+                if (x.ListenerId == default)
+                {
+                    throw new ArgumentException();
+                }
+
+                SetupJsMockForUnsubscription(x.ListenerId);
+
+            };
+
+            SetupJsMockForSubscription(customResizeOptioons, feedbackCaller);
+            var subscriptionId = await _service.Subscribe((BrowserWindowSize size) => { }, null);
+
+            var result = await _service.Unsubscribe(subscriptionId);
+
+            result.Should().BeTrue();
+
+            _jsruntimeMock.Verify();
+
+        }
+
+        [Test]
+        public async Task SubscribeAndUnsubcribe_DisposeOfDotNet()
+        {
+            var customResizeOptioons = new ResizeOptions();
+
+            for (int i = 0; i < 4; i++)
+            {
+                var lastDotnetRefHashCode = 0;
+
+                Action<ListenForResizeCallbackInfo> feedbackCaller = (x) =>
+                {
+                    if (x.ListenerId == default)
+                    {
+                        throw new ArgumentException();
+                    }
+
+                    if (x.DotnetRef.GetHashCode() == lastDotnetRefHashCode)
+                    {
+                        throw new ArgumentException();
+                    }
+
+                    lastDotnetRefHashCode = x.DotnetRef.GetHashCode();
+
+                    SetupJsMockForUnsubscription(x.ListenerId);
+
+                };
+
+                SetupJsMockForSubscription(customResizeOptioons, feedbackCaller);
+                var subscriptionId = await _service.Subscribe((BrowserWindowSize size) => { }, null);
+
+                var result = await _service.Unsubscribe(subscriptionId);
+
+                result.Should().BeTrue();
+
+                _jsruntimeMock.Verify();
+            }
+        }
+
+        [Test]
+        public async Task SubscribeAndUnsubcribe_MultipleSubscription()
+        {
+            var customResizeOptioons = new ResizeOptions();
+
+            var feedbackCallerCount = 0;
+
+            Action<ListenForResizeCallbackInfo> feedbackCaller = (x) =>
+            {
+                if (x.ListenerId == default)
+                {
+                    throw new ArgumentException();
+                }
+
+                feedbackCallerCount++;
+            };
+
+            SetupJsMockForSubscription(customResizeOptioons, feedbackCaller);
+
+            HashSet<Guid> subscriptionIds = new HashSet<Guid>();
+
+            for (int i = 0; i < 10; i++)
+            {
+                var subscriptionId = await _service.Subscribe((BrowserWindowSize size) => { });
+                subscriptionIds.Add(subscriptionId);
+            }
+
+            feedbackCallerCount.Should().Be(1);
+            subscriptionIds.Should().HaveCount(10);
+
+            _jsruntimeMock.Verify();
+
+        }
+
+        [Test]
+        public async Task SubscribeAndUnsubcribe_MultipleSubscription_WithMultipleOptions()
+        {
+            List<ListenForResizeCallbackInfo> callerFeedbacks = new();
+
+            Action<ListenForResizeCallbackInfo> feedbackCaller = (x) =>
+            {
+                if (x.ListenerId == default)
+                {
+                    throw new ArgumentException();
+                }
+
+                callerFeedbacks.Add(x);
+            };
+
+            var options = new[]
+            {
+                new ResizeOptions(),
+                new ResizeOptions { EnableLogging = !(new ResizeOptions().EnableLogging) },
+                new ResizeOptions { ReportRate = 50 },
+                new ResizeOptions { SuppressInitEvent = !(new ResizeOptions().SuppressInitEvent) },
+            };
+
+            foreach (var item in options)
+            {
+                SetupJsMockForSubscription(item, feedbackCaller);
+            }
+
+            var subscriptionIds = options.ToDictionary(x => x, x => new HashSet<Guid>());
+
+            for (int i = 0; i < 40; i++)
+            {
+                var index = i % 4;
+                var option = options[index];
+
+                var subscriptionId = await _service.Subscribe((BrowserWindowSize size) => { }, option);
+                subscriptionIds[option].Add(subscriptionId);
+            }
+
+            foreach (var item in subscriptionIds)
+            {
+                item.Value.Should().HaveCount(10);
+            }
+
+            callerFeedbacks.Should().HaveCount(4);
+            for (int i = 0; i < callerFeedbacks.Count; i++)
+            {
+                var feedback = callerFeedbacks[i];
+                feedback.options.Should().Be(options[i]);
+            }
+
+            callerFeedbacks.Select(x => x.ListenerId).ToHashSet().Should().HaveCount(4);
+
+            _jsruntimeMock.Verify();
+
+        }
+
+        [Test]
+        public async Task Unsubscribe_Failed_NoActiveSubscription()
+        {
+            var result = await _service.Unsubscribe(Guid.NewGuid());
+
+            result.Should().BeFalse();
+
+        }
+
+        [Test]
+        public async Task Unsubscribe_Failed_SubscriptioonIdNotFound()
+        {
+            var customResizeOptioons = new ResizeOptions();
+
+            SetupJsMockForSubscription(customResizeOptioons);
+            var subscriptionId = await _service.Subscribe((BrowserWindowSize size) => { }, null);
+
+            var result = await _service.Unsubscribe(Guid.NewGuid());
+
+            result.Should().BeFalse();
+        }
+
+
+        [Test]
+        public async Task DisposeAsync_Failed_NoActiveSubscription()
+        {
+            await _service.DisposeAsync();
+
+        }
+
+        [Test]
+        public async Task DisposeAsync_MultipleSubscription_WithMultipleOptions()
+        {
+            List<Guid> callerIds = new();
+
+            Action<ListenForResizeCallbackInfo> feedbackCaller = (x) =>
+            {
+                if (x.ListenerId == default)
+                {
+                    throw new ArgumentException();
+                }
+                callerIds.Add(x.ListenerId);
+            };
+
+            var options = new[]
+            {
+                new ResizeOptions(),
+                new ResizeOptions { EnableLogging = !(new ResizeOptions().EnableLogging) },
+                new ResizeOptions { ReportRate = 50 },
+                new ResizeOptions { SuppressInitEvent = !(new ResizeOptions().SuppressInitEvent) },
+            };
+
+            foreach (var item in options)
+            {
+                SetupJsMockForSubscription(item, feedbackCaller);
+            }
+
+            for (int i = 0; i < 40; i++)
+            {
+                var index = i % 4;
+                var option = options[index];
+
+                await _service.Subscribe((BrowserWindowSize size) => { }, option);
+            }
+
+            Func<IEnumerable<Guid>, bool> idChecker = (ids) =>
+             {
+                 try
+                 {
+                     ids.Should().BeEquivalentTo(callerIds);
+                     return true;
+                 }
+                 catch (Exception)
+                 {
+                     return false;
+                 }
+             };
+
+            _jsruntimeMock.Setup(x => x.InvokeAsync<object>("mudResizeListenerFactory.cancelListeners",
+             It.Is<object[]>(z =>
+                 z[0] is IEnumerable<Guid> &&
+                 idChecker((IEnumerable<Guid>)z[0]) == true
+             ))).ReturnsAsync(new object()).Verifiable();
+
+            await _service.DisposeAsync();
+
+            _jsruntimeMock.Verify();
+
+        }
+
+        private class FakeSubscriber
+        {
+            public Guid SubscriptionId { get; set; }
+            public BrowserWindowSize ActualSize { get; set; } = new BrowserWindowSize { };
+
+            public async Task Subscribe(SubscriptionBasedResizeListenerService service,
+                ResizeOptions options)
+            {
+                SubscriptionId = await service.Subscribe((x) => ActualSize = x, options);
+            }
+        }
+
+
+        [Test]
+        public async Task RaiseOnResized_MultipleSubscription_WithMultipleOptions()
+        {
+            Dictionary<ResizeOptions, Guid> listenerIds = new();
+            Action<ListenForResizeCallbackInfo> feedbackCaller = (x) => listenerIds.Add(x.options, x.ListenerId); ;
+
+            var options = new[]
+            {
+                (new ResizeOptions(),new BrowserWindowSize { Height = 20,  Width = 200 }),
+                (new ResizeOptions { EnableLogging = !(new ResizeOptions().EnableLogging) }, new BrowserWindowSize { Height = 30,  Width = 300 }),
+                (new ResizeOptions { ReportRate = 50 },new BrowserWindowSize { Height = 40,  Width = 400 }),
+                (new ResizeOptions { SuppressInitEvent = !(new ResizeOptions().SuppressInitEvent) },new BrowserWindowSize { Height = 50,  Width = 500 })
+            };
+
+            Dictionary<FakeSubscriber, BrowserWindowSize> subscribers = new();
+
+            foreach (var item in options)
+            {
+                SetupJsMockForSubscription(item.Item1, feedbackCaller);
+            }
+
+            for (int i = 0; i < 40; i++)
+            {
+                var index = i % 4;
+                var option = options[index];
+
+                var subscriber = new FakeSubscriber();
+                await subscriber.Subscribe(_service, option.Item1);
+
+                subscribers.Add(subscriber, option.Item2);
+            }
+
+            foreach (var item in options)
+            {
+                var listenerId = listenerIds[item.Item1];
+                _service.RaiseOnResized(item.Item2, Breakpoint.None, listenerId);
+            }
+
+            foreach (var item in subscribers)
+            {
+                item.Key.ActualSize.Should().Be(item.Value);
+            }
+
+            _jsruntimeMock.Verify();
+        }
+
+        [Test]
+        public async Task RaiseOnResized_InvalidListenerId()
+        {
+            var customResizeOptions = new ResizeOptions();
+
+            SetupJsMockForSubscription(customResizeOptions);
+
+            FakeSubscriber subscriber = new FakeSubscriber();
+            await subscriber.Subscribe(_service, customResizeOptions);
+
+            _service.RaiseOnResized(new BrowserWindowSize { Height = 2000 }, Breakpoint.None, Guid.NewGuid());
+
+            subscriber.ActualSize.Height.Should().NotBe(2000);
+        }
+
+        [Test]
+        public async Task Unsubcribe_MultipleSubscription_InParallel()
+        {
+            var customResizeOptioons = new ResizeOptions();
+
+            var feedbackCallerCount = 0;
+            var listenerId = Guid.Empty;
+
+            Action<ListenForResizeCallbackInfo> feedbackCaller = (x) =>
+            {
+                if (x.ListenerId == default)
+                {
+                    throw new ArgumentException();
+                }
+                feedbackCallerCount++;
+                listenerId = x.ListenerId;
+            };
+
+            SetupJsMockForSubscription(customResizeOptioons, feedbackCaller);
+
+            var subscriptionIds = new HashSet<Guid>();
+
+            for (int i = 0; i < 40; i++)
+            {
+                var subscriptionId = await _service.Subscribe((BrowserWindowSize size) => { });
+                subscriptionIds.Add(subscriptionId);
+            }
+
+            subscriptionIds.Should().HaveCount(40);
+            feedbackCallerCount.Should().Be(1);
+
+            SetupJsMockForUnsubscription(listenerId);
+
+            var tasksToExecute = new Task[subscriptionIds.Count];
+            for (int i = 0; i < subscriptionIds.Count; i++)
+            {
+                var temp = i;
+                var task = Task.Run(async () =>
+                {
+                    _ = await _service.Unsubscribe(subscriptionIds.ElementAt(temp));
+                });
+
+                tasksToExecute[i] = task;
+            }
+
+            Task.WaitAll(tasksToExecute);
+
+            _jsruntimeMock.Verify((x => x.InvokeAsync<object>("mudResizeListenerFactory.cancelListener",
+               It.Is<object[]>(z =>
+                   (Guid)z[0] == listenerId
+               ))), Times.Once());
+        }
+    }
+}

--- a/src/MudBlazor.UnitTests/Services/SubscriptionInfoTests.cs
+++ b/src/MudBlazor.UnitTests/Services/SubscriptionInfoTests.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MudBlazor.Services;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Services
+{
+    [TestFixture]
+    public class SubscriptionInfoTests
+    {
+        [Test]
+        public void Constructor()
+        {
+            var option = new ResizeOptions();
+            var info = new ResizeListenerSubscriptionInfo(option);
+
+            info.Option.Should().Be(option);
+        }
+
+        [Test]
+        public void AddSubscription()
+        {
+            var info = new ResizeListenerSubscriptionInfo(new ResizeOptions());
+
+            var id = info.AddSubscription((x) => { });
+            info.ContainsSubscription(id).Should().BeTrue();
+        }
+
+        [Test]
+        public void ContainsSubscription_NotFound()
+        {
+            var info = new ResizeListenerSubscriptionInfo(new ResizeOptions());
+
+            info.ContainsSubscription(Guid.NewGuid()).Should().BeFalse();
+        }
+
+        [Test]
+        public void RemoveSubscription_IsNotLast()
+        {
+            var info = new ResizeListenerSubscriptionInfo(new ResizeOptions());
+
+            var firstId = info.AddSubscription((x) => { });
+            var secondId = info.AddSubscription((x) => { });
+
+            info.ContainsSubscription(firstId).Should().BeTrue();
+            info.RemoveSubscription(firstId).Should().BeFalse();
+            info.ContainsSubscription(firstId).Should().BeFalse();
+
+        }
+
+        [Test]
+        public void RemoveSubscription_IsLast()
+        {
+            var info = new ResizeListenerSubscriptionInfo(new ResizeOptions());
+
+            var firstId = info.AddSubscription((x) => { });
+            var secondId = info.AddSubscription((x) => { });
+
+            info.ContainsSubscription(firstId).Should().BeTrue();
+            info.RemoveSubscription(firstId).Should().BeFalse();
+            info.ContainsSubscription(firstId).Should().BeFalse();
+
+            info.ContainsSubscription(secondId).Should().BeTrue();
+            info.RemoveSubscription(secondId).Should().BeTrue();
+            info.ContainsSubscription(secondId).Should().BeFalse();
+        }
+
+    }
+}

--- a/src/MudBlazor/Components/BreakpointProvider/MudBreakpointProvider.razor
+++ b/src/MudBlazor/Components/BreakpointProvider/MudBreakpointProvider.razor
@@ -1,0 +1,11 @@
+﻿@namespace MudBlazor
+@inherits MudComponentBase
+
+<CascadingValue Value="Breakpoint">
+	@ChildContent
+</CascadingValue>
+
+
+@code {
+
+}

--- a/src/MudBlazor/Components/BreakpointProvider/MudBreakpointProvider.razor.cs
+++ b/src/MudBlazor/Components/BreakpointProvider/MudBreakpointProvider.razor.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using MudBlazor.Services;
+
+namespace MudBlazor
+{
+    public partial class MudBreakpointProvider : IAsyncDisposable
+    {
+        private Guid _breakPointListenerSubscriptionId;
+
+        public Breakpoint Breakpoint { get; private set; } = Breakpoint.Always;
+
+        [Parameter] public EventCallback<Breakpoint> OnBreakpointChanged { get; set; }
+
+        [Inject] public IBreakpointListenerService Service { get; set; }
+
+        [Parameter] public RenderFragment ChildContent { get; set; }
+
+        protected override async Task OnAfterRenderAsync(bool firstRender)
+        {
+            await base.OnAfterRenderAsync(firstRender);
+
+            if (firstRender == true)
+            {
+                var attachResult = await Service.Subscribe(SetBreakpointCallback);
+                _breakPointListenerSubscriptionId = attachResult.SubscriptionId;
+                Breakpoint = attachResult.Breakpoint;
+                await OnBreakpointChanged.InvokeAsync(Breakpoint);
+                StateHasChanged();
+            }
+        }
+
+        private void SetBreakpointCallback(Breakpoint breakpoint)
+        {
+            InvokeAsync(() =>
+            {
+                Breakpoint = breakpoint;
+                OnBreakpointChanged.InvokeAsync(breakpoint);
+                StateHasChanged();
+            }).AndForget();
+        }
+
+        public async ValueTask DisposeAsync() => await Service.Unsubscribe(_breakPointListenerSubscriptionId);
+    }
+}

--- a/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
+++ b/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
@@ -21,6 +21,8 @@ namespace MudBlazor
         private Breakpoint _breakpoint = Breakpoint.Md, _screenBreakpoint = Breakpoint.None;
         private DotNetObjectReference<MudDrawer> _dotNetRef;
 
+        private Guid _breakpointListenerSubscriptionId;
+
         private bool OverlayVisible => _open && !DisableOverlay &&
             (Variant == DrawerVariant.Temporary ||
              (_screenBreakpoint < Breakpoint && Variant == DrawerVariant.Mini) ||
@@ -57,12 +59,12 @@ namespace MudBlazor
             .AddStyle("height", Height, !string.IsNullOrWhiteSpace(Height))
             .AddStyle("--mud-drawer-content-height",
                 string.IsNullOrWhiteSpace(Height) ? $"{_height}px" : Height,
-                Anchor is Anchor.Bottom or Anchor.Top)
-            .AddStyle("visibility", "hidden", string.IsNullOrWhiteSpace(Height) && _height == 0 && Anchor is Anchor.Bottom or Anchor.Top)
+                Anchor == Anchor.Bottom || Anchor == Anchor.Top)
+            .AddStyle("visibility", "hidden", string.IsNullOrWhiteSpace(Height) && _height == 0 && (Anchor == Anchor.Bottom || Anchor == Anchor.Top))
             .AddStyle(Style)
         .Build();
 
-        [Inject] public IResizeListenerService ResizeListener { get; set; }
+        [Inject] public IBreakpointListenerService Breakpointistener { get; set; }
 
         [CascadingParameter] MudDrawerContainer DrawerContainer { get; set; }
 
@@ -179,7 +181,7 @@ namespace MudBlazor
                 {
                     _keepInitialState = false;
                 }
-                if (_isRendered && value && Anchor is Anchor.Top or Anchor.Bottom)
+                if (_isRendered && value && (Anchor == Anchor.Top || Anchor == Anchor.Bottom))
                 {
                     _ = UpdateHeight();
                 }
@@ -243,9 +245,12 @@ namespace MudBlazor
             if (firstRender)
             {
                 await UpdateHeight();
-                ResizeListener.OnBreakpointChanged += ResizeListener_OnBreakpointChanged;
+                var result = await Breakpointistener.Subscribe(UpdateBreakpointState);
+                var currentBreakpoint = result.Breakpoint;
 
-                _screenBreakpoint = await ResizeListener.GetBreakpoint();
+                _breakpointListenerSubscriptionId = result.SubscriptionId;
+
+                _screenBreakpoint = result.Breakpoint;
                 if (_screenBreakpoint < Breakpoint && _open)
                 {
                     _keepInitialState = true;
@@ -253,7 +258,7 @@ namespace MudBlazor
                 }
 
                 _isRendered = true;
-                if (string.IsNullOrWhiteSpace(Height) && Anchor is Anchor.Bottom or Anchor.Top)
+                if (string.IsNullOrWhiteSpace(Height) && (Anchor == Anchor.Bottom || Anchor == Anchor.Top))
                 {
                     StateHasChanged();
                 }
@@ -279,7 +284,6 @@ namespace MudBlazor
                 if (disposing)
                 {
                     DrawerContainer?.Remove(this);
-                    ResizeListener.OnBreakpointChanged -= ResizeListener_OnBreakpointChanged;
 
                     if (_mouseEnterListenerId != 0)
                         _ = _drawerRef.MudRemoveEventListenerAsync("mouseenter", _mouseEnterListenerId);
@@ -289,6 +293,11 @@ namespace MudBlazor
                     var toDispose = _dotNetRef;
                     _dotNetRef = null;
                     toDispose?.Dispose();
+
+                    if (_breakpointListenerSubscriptionId != default)
+                    {
+                        Breakpointistener.Unsubscribe(_breakpointListenerSubscriptionId).AndForget();
+                    }
                 }
             }
         }
@@ -304,7 +313,7 @@ namespace MudBlazor
         public async Task OnNavigation()
         {
             if (Variant == DrawerVariant.Temporary ||
-                (Variant == DrawerVariant.Responsive && await ResizeListener.GetBreakpoint() < Breakpoint))
+                (Variant == DrawerVariant.Responsive && await Breakpointistener.GetBreakpoint() < Breakpoint))
             {
                 await OpenChanged.InvokeAsync(false);
             }
@@ -328,7 +337,7 @@ namespace MudBlazor
             var isStateChanged = false;
             if (breakpoint == Breakpoint.None)
             {
-                breakpoint = await ResizeListener.GetBreakpoint();
+                breakpoint = await Breakpointistener.GetBreakpoint();
             }
 
             if (breakpoint < Breakpoint && _screenBreakpoint >= Breakpoint && Variant == DrawerVariant.Responsive)
@@ -373,6 +382,7 @@ namespace MudBlazor
 
             return Anchor.ToDescriptionString();
         }
+
 
         private bool closeOnMouseLeave = false;
         [JSInvokable]

--- a/src/MudBlazor/Components/Hidden/MudHidden.razor
+++ b/src/MudBlazor/Components/Hidden/MudHidden.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
 
-@if (!_is_hidden)
+@if (!_isHidden)
 {
     @ChildContent
 }

--- a/src/MudBlazor/Components/Hidden/MudHidden.razor.cs
+++ b/src/MudBlazor/Components/Hidden/MudHidden.razor.cs
@@ -1,14 +1,20 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.Services;
 
 namespace MudBlazor
 {
 
-    public partial class MudHidden : MudComponentBase
+    public partial class MudHidden : MudComponentBase, IAsyncDisposable
     {
+        private Breakpoint _currentBreakpoint = Breakpoint.None;
+        private bool _serviceIsReady = false;
+        private Guid _breakpointListenerSubscriptionId;
 
-        [Inject] IResizeListenerService ResizeListener { get; set; }
+        [Inject] public IBreakpointListenerService BreakpointListenerService { get; set; }
+
+        [CascadingParameter] public Breakpoint CurrentBreakpointFromProvider { get; set; } = Breakpoint.None;
 
         /// <summary>
         /// The screen size(s) depending on which the ChildContent should not be rendered (or should be, if Invert is true)
@@ -20,19 +26,23 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public bool Invert { get; set; }
 
+        private bool _isHidden = true;
+
         /// <summary>
         /// True if the component is not visible (two-way bindable)
         /// </summary>
         [Parameter]
         public bool IsHidden
         {
-            get => _is_hidden;
+            get => _isHidden;
             set
             {
-                if (_is_hidden == value)
-                    return;
-                _is_hidden = value;
-                StateHasChanged();
+                if (_isHidden != value)
+                {
+                    _isHidden = value;
+                    IsHiddenChanged.InvokeAsync(_isHidden);
+
+                }
             }
         }
 
@@ -46,34 +56,58 @@ namespace MudBlazor
         /// </summary>
         [Parameter] public RenderFragment ChildContent { get; set; }
 
-        private bool _is_hidden = true;
+        protected void Update(Breakpoint currentBreakpoint)
+        {
+            if (CurrentBreakpointFromProvider != Breakpoint.None)
+            {
+                currentBreakpoint = CurrentBreakpointFromProvider;
+            }
+            else if (_serviceIsReady == false) { return; }
+
+            if (currentBreakpoint == Breakpoint.None) { return; }
+
+            _currentBreakpoint = currentBreakpoint;
+
+            var hidden = BreakpointListenerService.IsMediaSize(Breakpoint, currentBreakpoint);
+            if (Invert == true)
+            {
+                hidden = !hidden;
+            }
+
+            IsHidden = hidden;
+        }
+
+        protected override void OnParametersSet()
+        {
+            base.OnParametersSet();
+            Update(_currentBreakpoint);
+        }
 
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
-            if (firstRender)
-            {
-                ResizeListener.OnBreakpointChanged += OnBreakpointChanged;
-                var breakpoint = await ResizeListener.GetBreakpoint();
-                Update(breakpoint);
-            }
             await base.OnAfterRenderAsync(firstRender);
+            if (firstRender == true)
+            {
+                if (CurrentBreakpointFromProvider == Breakpoint.None)
+                {
+                    var attachResult = await BreakpointListenerService.Subscribe((x) =>
+                    {
+                        Update(x);
+                        InvokeAsync(StateHasChanged);
+                    });
+
+                    _serviceIsReady = true;
+                    _breakpointListenerSubscriptionId = attachResult.SubscriptionId;
+                    Update(attachResult.Breakpoint);
+                    StateHasChanged();
+                }
+                else
+                {
+                    _serviceIsReady = true;
+                }
+            }
         }
 
-        protected void Update(Breakpoint breakpoint)
-        {
-            var hidden = ResizeListener.IsMediaSize(Breakpoint, breakpoint);
-            if (Invert)
-                hidden = !hidden;
-            if (hidden == _is_hidden)
-                return;
-            _is_hidden = hidden;
-            _ = InvokeAsync(StateHasChanged);
-            _ = IsHiddenChanged.InvokeAsync(_is_hidden);
-        }
-
-        private void OnBreakpointChanged(object sender, Breakpoint breakpoint)
-        {
-            Update(breakpoint);
-        }
+        public async ValueTask DisposeAsync() => await BreakpointListenerService.Unsubscribe(_breakpointListenerSubscriptionId);
     }
 }

--- a/src/MudBlazor/Services/ResizeListener/BreakpointListenerService.cs
+++ b/src/MudBlazor/Services/ResizeListener/BreakpointListenerService.cs
@@ -1,0 +1,235 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using Microsoft.JSInterop;
+
+namespace MudBlazor.Services
+{
+  
+    public class BreakpointListenerService :
+        ResizeListenerBasedService<BreakpointListenerService, BreakpointListenerSubscriptionInfo, Breakpoint, ResizeOptions>,
+        IBreakpointListenerService
+    {
+        private readonly IJSRuntime _jsRuntime;
+        private readonly ResizeOptions _options;
+        private IBrowserWindowSizeProvider _browserWindowSizeProvider;
+        private BrowserWindowSize _windowSize;
+        private Breakpoint _breakpoint = Breakpoint.None;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="jsRuntime"></param>
+        /// <param name="browserWindowSizeProvider"></param>
+        /// <param name="options"></param>
+        public BreakpointListenerService(IJSRuntime jsRuntime, IBrowserWindowSizeProvider browserWindowSizeProvider, IOptions<ResizeOptions> options = null)
+            : base(jsRuntime)
+        {
+            this._options = options?.Value ?? new ResizeOptions();
+            this._jsRuntime = jsRuntime;
+            this._browserWindowSizeProvider = browserWindowSizeProvider;
+        }
+
+        /// <summary>
+        /// Invoked by jsInterop, use the OnResized event handler to subscribe.
+        /// </summary>
+        /// <param name="browserWindowSize"></param>
+        /// <param name="breakpoint"></param>
+        /// <param name="optionId"></param>
+        [JSInvokable]
+        public void RaiseOnResized(BrowserWindowSize browserWindowSize, Breakpoint breakpoint, Guid optionId)
+        {
+            _windowSize = browserWindowSize;
+            _breakpoint = breakpoint;
+
+            if (Listeners.ContainsKey(optionId) == false) { return; }
+
+            var listenerInfo = Listeners[optionId];
+            listenerInfo.InvokeCallbacks(breakpoint);
+        }
+
+        /// <summary>
+        /// Determine if the Document matches the provided media query.
+        /// </summary>
+        /// <param name="mediaQuery"></param>
+        /// <returns>Returns true if matched.</returns>
+        public async ValueTask<bool> MatchMedia(string mediaQuery) =>
+            await _jsRuntime.InvokeAsync<bool>($"mudResizeListener.matchMedia", mediaQuery);
+
+        public static Dictionary<Breakpoint, int> DefaultBreakpointDefinitions { get; set; } = new Dictionary<Breakpoint, int>()
+        {
+            [Breakpoint.Xl] = 1920,
+            [Breakpoint.Lg] = 1280,
+            [Breakpoint.Md] = 960,
+            [Breakpoint.Sm] = 600,
+            [Breakpoint.Xs] = 0,
+        };
+
+        public async Task<Breakpoint> GetBreakpoint()
+        {
+            // note: we don't need to get the size if we are listening for updates, so only if onResized==null, get the actual size
+            if (_windowSize == null)
+                _windowSize = await _browserWindowSizeProvider.GetBrowserWindowSize();
+            if (_windowSize == null)
+                return Breakpoint.Xs;
+            if (_windowSize.Width >= DefaultBreakpointDefinitions[Breakpoint.Xl])
+                return Breakpoint.Xl;
+            else if (_windowSize.Width >= DefaultBreakpointDefinitions[Breakpoint.Lg])
+                return Breakpoint.Lg;
+            else if (_windowSize.Width >= DefaultBreakpointDefinitions[Breakpoint.Md])
+                return Breakpoint.Md;
+            else if (_windowSize.Width >= DefaultBreakpointDefinitions[Breakpoint.Sm])
+                return Breakpoint.Sm;
+            else
+                return Breakpoint.Xs;
+        }
+
+        public async Task<bool> IsMediaSize(Breakpoint breakpoint)
+        {
+            if (breakpoint == Breakpoint.None)
+                return false;
+
+            return IsMediaSize(breakpoint, await GetBreakpoint());
+        }
+
+        public bool IsMediaSize(Breakpoint breakpoint, Breakpoint reference)
+        {
+            if (breakpoint == Breakpoint.None)
+                return false;
+
+            return breakpoint switch
+            {
+                Breakpoint.Xs => reference == Breakpoint.Xs,
+                Breakpoint.Sm => reference == Breakpoint.Sm,
+                Breakpoint.Md => reference == Breakpoint.Md,
+                Breakpoint.Lg => reference == Breakpoint.Lg,
+                Breakpoint.Xl => reference == Breakpoint.Xl,
+                // * and down
+                Breakpoint.SmAndDown => reference <= Breakpoint.Sm,
+                Breakpoint.MdAndDown => reference <= Breakpoint.Md,
+                Breakpoint.LgAndDown => reference <= Breakpoint.Lg,
+                // * and up
+                Breakpoint.SmAndUp => reference >= Breakpoint.Sm,
+                Breakpoint.MdAndUp => reference >= Breakpoint.Md,
+                Breakpoint.LgAndUp => reference >= Breakpoint.Lg,
+                _ => false,
+            };
+        }
+
+        public async Task<BreakpointListenerSubscribeResult> Subscribe(Action<Breakpoint> callback) => await Subscribe(callback, _options);
+
+        public async Task<BreakpointListenerSubscribeResult> Subscribe(Action<Breakpoint> callback, ResizeOptions options)
+        {
+            if (callback is null)
+            {
+                throw new ArgumentNullException(nameof(callback));
+            }
+
+            options ??= _options;
+            if (options.BreakpointDefinitions == null || options.BreakpointDefinitions.Count == 0)
+            {
+                options.BreakpointDefinitions = DefaultBreakpointDefinitions.ToDictionary(x => x.Key.ToString(), x => x.Value);
+            }
+
+            if (DotNetRef == null)
+            {
+                DotNetRef = DotNetObjectReference.Create(this);
+            }
+
+            var existingOptionId = Listeners.Where(x => x.Value.Option == options).Select(x => x.Key).FirstOrDefault();
+
+            if (existingOptionId == default)
+            {
+                var subscriptionInfo = new BreakpointListenerSubscriptionInfo(options);
+                var subscriptionId = subscriptionInfo.AddSubscription(callback);
+                var listenerId = Guid.NewGuid();
+
+                Listeners.Add(listenerId, subscriptionInfo);
+
+                try
+                {
+                    await JsRuntime.InvokeVoidAsync($"mudResizeListenerFactory.listenForResize", DotNetRef, options, listenerId);
+                    if (_breakpoint == Breakpoint.None)
+                    {
+                        _breakpoint = await GetBreakpoint();
+
+                    }
+                    return new BreakpointListenerSubscribeResult(subscriptionId, _breakpoint);
+                }
+                catch (TaskCanceledException)
+                {
+                    return new BreakpointListenerSubscribeResult(subscriptionId, _breakpoint);
+                    // no worries here
+                }
+            }
+            else
+            {
+                var entry = Listeners[existingOptionId];
+                var subscriptionId = entry.AddSubscription(callback);
+
+                return new BreakpointListenerSubscribeResult(subscriptionId, _breakpoint);
+            }
+        }
+    }
+
+    /// <summary>
+    /// The result of a subscription to the BreakpointListener
+    /// </summary>
+    /// <param name="SubscriptionId">The subscription id, can be used for cancel the subscription later</param>
+    /// <param name="Breakpoint">The current breakpoint of the window</param>
+    public record BreakpointListenerSubscribeResult(Guid SubscriptionId, Breakpoint Breakpoint);
+
+    public interface IBreakpointListenerService : IAsyncDisposable
+    {
+        /// <summary>
+        /// Check if the current breakpoint fits within the current window size
+        /// </summary>
+        /// <param name="breakpoint"></param>
+        /// <returns>True if the media size is meet, false otherwise. For instance if the current window size is sm and the breakpoint is SmAndSmaller, this method returns true</returns>
+        Task<bool> IsMediaSize(Breakpoint breakpoint);
+
+        /// <summary>
+        /// Check if the current breakpoint fits within the reference size
+        /// </summary>
+        /// <param name="breakpoint">The breakpoint to check</param>
+        /// <param name="reference">The reference breakpoint (xs,sm,md,lg,xl)</param>
+        /// <returns>True if the media size is meet, false otherwise. For instance if the reference size is sm and the breakpoint is SmAndSmaller, this method returns true</returns>
+        bool IsMediaSize(Breakpoint breakpoint, Breakpoint reference);
+        
+        /// <summary>
+        /// Get the current breakpoint
+        /// </summary>
+        /// <returns></returns>
+        Task<Breakpoint> GetBreakpoint();
+
+        /// <summary>
+        /// Subscribe to size changes of the browser window with default options
+        /// </summary>
+        /// <param name="callback">The method (callbacK) that is invoke as soon as the size of the window has changed</param>
+        /// <returns>Returning an object containing the current breakpoint and a subscription id, that should be used for unsubscribe</returns>
+        Task<BreakpointListenerSubscribeResult> Subscribe(Action<Breakpoint> callback);
+
+        /// <summary>
+        /// Subscribe to size changes of the browser window using the provided options
+        /// </summary>
+        /// <param name="callback">The method (callbacK) that is invoke as soon as the size of the window has changed</param>
+        /// <param name="options">The options used to subscribe to changes</param>
+        /// <returns>Returning an object containing the current breakpoint and a subscription id, that should be used for unsubscribe</returns>
+        Task<BreakpointListenerSubscribeResult> Subscribe(Action<Breakpoint> callback, ResizeOptions options);
+
+        /// <summary>
+        /// Used for cancel the subscription to the resize event.
+        /// </summary>
+        /// <param name="subscriptionId">The subscription id (return of subscribe) to cancel</param>
+        /// <returns>True if the subscription could be cancel, false otherwise</returns>
+        Task<bool> Unsubscribe(Guid subscriptionId);
+    }
+}

--- a/src/MudBlazor/Services/ResizeListener/ResizeListenerBasedService.cs
+++ b/src/MudBlazor/Services/ResizeListener/ResizeListenerBasedService.cs
@@ -1,0 +1,97 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.JSInterop;
+
+namespace MudBlazor.Services
+{
+    public abstract class ResizeListenerBasedService<TSelf, TInfo, TAction, TaskOption> : IAsyncDisposable
+        where TSelf : class
+        where TInfo : SubscriptionInfo<TAction, TaskOption>
+    {
+        private static SemaphoreSlim _semaphore = new SemaphoreSlim(1, 1);
+
+        protected Dictionary<Guid, TInfo> Listeners { get; } = new();
+        protected IJSRuntime JsRuntime { get; init; }
+        protected DotNetObjectReference<TSelf> DotNetRef { get; set; }
+
+        public ResizeListenerBasedService(IJSRuntime jsRuntime)
+        {
+            JsRuntime = jsRuntime;
+        }
+
+
+        public async Task<bool> Unsubscribe(Guid subscriptionId)
+        {
+            if (DotNetRef == null)
+            {
+                return false;
+            }
+
+            var info = Listeners.FirstOrDefault(x => x.Value.ContainsSubscription(subscriptionId) == true);
+            if (info.Value == null)
+            {
+                return false;
+            }
+
+            try
+            {
+                await _semaphore.WaitAsync();
+
+                var isLastSubscriber = info.Value.RemoveSubscription(subscriptionId);
+                if (isLastSubscriber == true)
+                {
+                    Listeners.Remove(info.Key);
+
+                    try
+                    {
+                        await JsRuntime.InvokeVoidAsync($"mudResizeListenerFactory.cancelListener", info.Key);
+                    }
+                    catch (TaskCanceledException)
+                    {
+                        // no worries here
+                    }
+                }
+
+                if (Listeners.Count == 0)
+                {
+                    DotNetRef.Dispose();
+                    DotNetRef = null;
+                }
+            }
+            finally
+            {
+                _semaphore.Release();
+            }
+
+            return true;
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (DotNetRef == null) { return; }
+            if (Listeners.Count == 0) { return; }
+
+            var ids = Listeners.Keys.ToArray();
+            Listeners.Clear();
+
+            try
+            {
+                await JsRuntime.InvokeVoidAsync($"mudResizeListenerFactory.cancelListeners", ids);
+            }
+            catch (TaskCanceledException)
+            {
+                // no worries here
+            }
+
+            DotNetRef.Dispose();
+        }
+    }
+}

--- a/src/MudBlazor/Services/ResizeListener/ResizeOptions.cs
+++ b/src/MudBlazor/Services/ResizeListener/ResizeOptions.cs
@@ -1,8 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace MudBlazor.Services
 {
-    public class ResizeOptions
+    public class ResizeOptions : IEquatable<ResizeOptions>
     {
         /// <summary>
         /// Rate in milliseconds that the browsers `resize()` event should report a change.
@@ -23,11 +24,65 @@ namespace MudBlazor.Services
         /// <summary>
         /// If true, RaiseOnResized is called only when breakpoint has changed.
         /// </summary>
-        public bool NotifyOnBreakpointOnly { get; set; } = false;
+        public bool NotifyOnBreakpointOnly { get; set; } = true;
 
         /// <summary>
         /// Breakpoint definitions.
         /// </summary>
-        public Dictionary<string, int> BreakpointDefinitions { get; set; }
+        public Dictionary<string, int> BreakpointDefinitions { get; set; } = new();
+
+        public static bool operator ==(ResizeOptions l, ResizeOptions r) => l.Equals(r);
+        public static bool operator !=(ResizeOptions l, ResizeOptions r) => !l.Equals(r);
+
+        public override bool Equals(object obj)
+        {
+            if (obj is not ResizeOptions) { return false; }
+
+            return Equals((ResizeOptions)obj);
+        }
+
+        public bool Equals(ResizeOptions other)
+        {
+            if (ReportRate != other.ReportRate ||
+               EnableLogging != other.EnableLogging ||
+               SuppressInitEvent != other.SuppressInitEvent ||
+               NotifyOnBreakpointOnly != other.NotifyOnBreakpointOnly)
+            {
+                return false;
+            }
+
+            if (BreakpointDefinitions is not null)
+            {
+                if (other.BreakpointDefinitions is null) { return false; }
+                else
+                {
+                    if (BreakpointDefinitions.Count != other.BreakpointDefinitions.Count)
+                    {
+                        return false;
+                    }
+
+                    foreach (var item in BreakpointDefinitions.Keys)
+                    {
+                        if (other.BreakpointDefinitions.ContainsKey(item) == false)
+                        {
+                            return false;
+                        }
+
+                        if (BreakpointDefinitions[item] != other.BreakpointDefinitions[item])
+                        {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                }
+            }
+            else
+            {
+                return other.BreakpointDefinitions is null;
+            }
+        }
+
+        public override int GetHashCode() => ReportRate;
     }
 }

--- a/src/MudBlazor/Services/ResizeListener/SubscriptionBasedResizeListenerService.cs
+++ b/src/MudBlazor/Services/ResizeListener/SubscriptionBasedResizeListenerService.cs
@@ -1,0 +1,143 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using Microsoft.JSInterop;
+
+namespace MudBlazor.Services
+{
+    /// <summary>
+    /// This service listens to browser resize events and allows you to react to a changing window size in Blazor
+    /// </summary>
+    public class SubscriptionBasedResizeListenerService : 
+        ResizeListenerBasedService<SubscriptionBasedResizeListenerService, ResizeListenerSubscriptionInfo,BrowserWindowSize,ResizeOptions>, 
+        ISubscriptionBasedResizeListenerService
+    {
+        private readonly IBrowserWindowSizeProvider _browserWindowSizeProvider;
+        private readonly ResizeOptions _options;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="jsRuntime"></param>
+        /// <param name="browserWindowSizeProvider"></param>
+        /// <param name="options"></param>
+        public SubscriptionBasedResizeListenerService(IJSRuntime jsRuntime, IBrowserWindowSizeProvider browserWindowSizeProvider, IOptions<ResizeOptions> options = null) :
+            base(jsRuntime)
+        {
+            this._options = options?.Value ?? new ResizeOptions();
+            this._browserWindowSizeProvider = browserWindowSizeProvider;
+        }
+
+        /// <summary>
+        /// Get the current BrowserWindowSize, this includes the Height and Width of the document.
+        /// </summary>
+        public ValueTask<BrowserWindowSize> GetBrowserWindowSize() =>
+            _browserWindowSizeProvider.GetBrowserWindowSize();
+
+        /// <summary>
+        /// Invoked by jsInterop, use the OnResized event handler to subscribe.
+        /// </summary>
+        /// <param name="browserWindowSize"></param>
+        /// <param name="_"></param>
+        /// <param name="optionId"></param>
+        [JSInvokable]
+        public void RaiseOnResized(BrowserWindowSize browserWindowSize, Breakpoint _, Guid optionId)
+        {
+            if (Listeners.ContainsKey(optionId) == false) { return; }
+
+            var listenerInfo = Listeners[optionId];
+            listenerInfo.InvokeCallbacks(browserWindowSize);
+        }
+
+        /// <summary>
+        /// Subscribe to size changes of the browser window. Default ResizeOptions will be used
+        /// </summary>
+        /// <param name="callback">The method (callbacK) that is invoke as soon as the size of the window has changed</param>
+        /// <returns>The subscription id. This id is needed for unscribe </returns>
+        public async Task<Guid> Subscribe(Action<BrowserWindowSize> callback) => await Subscribe(callback, _options);
+
+        /// <summary>
+        /// Subscribe to size changes of the browser window using the provided options
+        /// </summary>
+        /// <param name="callback">The method (callbacK) that is invoke as soon as the size of the window has changed</param>
+        /// <param name="options"></param>
+        /// <returns>The subscription id. This id is needed for unscribe</returns>
+        public async Task<Guid> Subscribe(Action<BrowserWindowSize> callback, ResizeOptions options)
+        {
+            if (callback is null)
+            {
+                throw new ArgumentNullException(nameof(callback));
+            }
+
+            options ??= _options;
+
+            if (DotNetRef == null)
+            {
+                DotNetRef = DotNetObjectReference.Create(this);
+            }
+
+            var existingOptionId = Listeners.Where(x => x.Value.Option == options).Select(x => x.Key).FirstOrDefault();
+
+            if (existingOptionId == default)
+            {
+                var subscriptionInfo = new ResizeListenerSubscriptionInfo(options);
+                var subscriptionId = subscriptionInfo.AddSubscription(callback);
+                var listenerId = Guid.NewGuid();
+
+                Listeners.Add(listenerId, subscriptionInfo);
+
+                try
+                {
+                    await JsRuntime.InvokeVoidAsync($"mudResizeListenerFactory.listenForResize", DotNetRef, options, listenerId);
+                }
+                catch (TaskCanceledException)
+                {
+
+                    // no worries here
+                }
+
+                return subscriptionId;
+            }
+            else
+            {
+                var entry = Listeners[existingOptionId];
+                var subscriptionId = entry.AddSubscription(callback);
+
+                return subscriptionId;
+            }
+        }
+    }
+
+    public interface ISubscriptionBasedResizeListenerService : IAsyncDisposable
+    {
+        /// <summary>
+        /// Get the current size of the window
+        /// </summary>
+        /// <returns>A task representing the current browser size</returns>
+        ValueTask<BrowserWindowSize> GetBrowserWindowSize();
+
+        /// <summary>
+        /// Subscribe to size changes of the browser window. Default ResizeOptions will be used
+        /// </summary>
+        /// <param name="callback">The method (callbacK) that is invoke as soon as the size of the window has changed</param>
+        /// <returns>The subscription id. This id is needed for unscribe </returns>
+        Task<Guid> Subscribe(Action<BrowserWindowSize> callback);
+
+        /// <summary>
+        /// Subscribe to size changes of the browser window using the provided options
+        /// </summary>
+        /// <param name="callback">The method (callbacK) that is invoke as soon as the size of the window has changed</param>
+        /// <param name="options">The options used to subscribe to changes</param>
+        /// <returns>The subscription id. This id is needed for unscribe</returns>
+        Task<Guid> Subscribe(Action<BrowserWindowSize> callback, ResizeOptions options);
+        
+        /// <summary>
+        /// Used for cancel the subscription to the resize event.
+        /// </summary>
+        /// <param name="subscriptionId">The subscription id (return of subscribe) to cancel</param>
+        /// <returns>True if the subscription could be cancel, false otherwise</returns>
+        Task<bool> Unsubscribe(Guid subscriptionId);
+    }
+}

--- a/src/MudBlazor/Services/ResizeListener/SubscriptionInfo.cs
+++ b/src/MudBlazor/Services/ResizeListener/SubscriptionInfo.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MudBlazor.Services
+{
+    public class SubscriptionInfo<TAction,TOption>
+    {
+        private Dictionary<Guid, Action<TAction>> _subscriptions;
+        public TOption Option { get; init; }
+
+        public SubscriptionInfo(TOption options)
+        {
+            _subscriptions = new();
+
+            Option = options;
+            _subscriptions = new();
+        }
+
+        public Guid AddSubscription(Action<TAction> action)
+        {
+            var id = Guid.NewGuid();
+            _subscriptions.Add(id, action);
+
+            return id;
+        }
+
+        public bool ContainsSubscription(Guid listenerId) => _subscriptions.ContainsKey(listenerId);
+
+        public bool RemoveSubscription(Guid listenerId)
+        {
+            _subscriptions.Remove(listenerId);
+            return _subscriptions.Count == 0;
+        }
+
+        public void InvokeCallbacks(TAction browserWindowSize)
+        {
+            foreach (var item in _subscriptions.Values)
+            {
+                item.Invoke(browserWindowSize);
+            }
+        }
+    }
+
+    public class ResizeListenerSubscriptionInfo : SubscriptionInfo<BrowserWindowSize,ResizeOptions>
+    {
+        public ResizeListenerSubscriptionInfo(ResizeOptions options) : base(options)
+        {
+        }
+    }
+
+    public class BreakpointListenerSubscriptionInfo : SubscriptionInfo<Breakpoint, ResizeOptions>
+    {
+        public BreakpointListenerSubscriptionInfo(ResizeOptions options) : base(options)
+        {
+        }
+    }
+}

--- a/src/MudBlazor/Services/ServiceCollectionExtensions.cs
+++ b/src/MudBlazor/Services/ServiceCollectionExtensions.cs
@@ -76,6 +76,8 @@ namespace MudBlazor.Services
         {
             services.TryAddScoped<IResizeListenerService, ResizeListenerService>();
             services.TryAddScoped<IBrowserWindowSizeProvider, BrowserWindowSizeProvider>();
+            services.TryAddScoped<ISubscriptionBasedResizeListenerService, SubscriptionBasedResizeListenerService>();
+            services.TryAddScoped<IBreakpointListenerService, BreakpointListenerService>();
             services.Configure(options);
             return services;
         }

--- a/src/MudBlazor/TScripts/mudResizeListener.js
+++ b/src/MudBlazor/TScripts/mudResizeListener.js
@@ -1,14 +1,15 @@
 ﻿class MudResizeListener {
 
-    constructor() {
+    constructor(id) {
         this.logger = function (message) { };
         this.options = {};
         this.throttleResizeHandlerId = -1;
         this.dotnet = undefined;
         this.breakpoint = -1;
+        this.id = id;
     }
 
-    listenForResize (dotnetRef, options) {
+    listenForResize(dotnetRef, options) {
         if (this.dotnet) {
             this.options = options;
             return;
@@ -42,30 +43,43 @@
 
         try {
             //console.log("[MudBlazor] RaiseOnResized invoked");
-            this.dotnet.invokeMethodAsync('RaiseOnResized',
-                {
-                    height: window.innerHeight,
-                    width: window.innerWidth
-                }, this.getBreakpoint(window.innerWidth));
+            if (this.id) {
+                this.dotnet.invokeMethodAsync('RaiseOnResized',
+                    {
+                        height: window.innerHeight,
+                        width: window.innerWidth
+                    },
+                    this.getBreakpoint(window.innerWidth),
+                    this.id);
+            }
+            else {
+                this.dotnet.invokeMethodAsync('RaiseOnResized',
+                    {
+                        height: window.innerHeight,
+                        width: window.innerWidth
+                    },
+                    this.getBreakpoint(window.innerWidth));
+            }
+
             //this.logger("[MudBlazor] RaiseOnResized invoked");
         } catch (error) {
             this.logger("[MudBlazor] Error in resizeHandler:", { error });
         }
     }
 
-    cancelListener () {
+    cancelListener() {
         this.dotnet = undefined;
         //console.log("[MudBlazor] cancelListener");
         window.removeEventListener("resize", this.throttleResizeHandler);
     }
 
-    matchMedia (query) {
+    matchMedia(query) {
         let m = window.matchMedia(query).matches;
         //this.logger(`[MudBlazor] matchMedia "${query}": ${m}`);
         return m;
     }
 
-    getBrowserWindowSize () {
+    getBrowserWindowSize() {
         //this.logger("[MudBlazor] getBrowserWindowSize");
         return {
             height: window.innerHeight,
@@ -73,9 +87,7 @@
         };
     }
 
-    getBreakpoint (width) {
-        if (width >= this.options.breakpointDefinitions["Xxl"])
-            return 5;
+    getBreakpoint(width) {
         if (width >= this.options.breakpointDefinitions["Xl"])
             return 4;
         else if (width >= this.options.breakpointDefinitions["Lg"])
@@ -88,4 +100,36 @@
             return 0;
     }
 };
+
 window.mudResizeListener = new MudResizeListener();
+window.mudResizeListenerFactory = {
+    mapping: {},
+    listenForResize: (dotnetRef, options, id) => {
+        var map = window.mudResizeListenerFactory.mapping;
+        if (map[id]) {
+            return;
+        }
+
+        var listener = new MudResizeListener(id);
+        listener.listenForResize(dotnetRef, options);
+        map[id] = listener;
+    },
+
+    cancelListener: (id) => {
+        var map = window.mudResizeListenerFactory.mapping;
+
+        if (!map[id]) {
+            return;
+        }
+
+        var listener = map[id];
+        listener.cancelListener();
+        delete map[id];
+    },
+
+    cancelListeners: (ids) => {
+        for (let i = 0; i < ids.length; i++) {
+            window.mudResizeListenerFactory.cancelListener(ids[i]);
+        }
+    }
+}


### PR DESCRIPTION
## A new approach for the ResizeListener

Before this PR, the Resizelistener is used to raise events in case the browser window size changes. Components can use this information to change their layout accordingly. ``MudHidden`` and ``MudDrawer`` are two components using this service.  The implementation relayed on the event system in dotnet plus a mingle between js calls do add/remove js event listeners. It wasn't always clear when the JS methods are actually called,  which causes predictable issues and creating obstacles for server-side prerendering.

### Split into two services
This PR split the existing functionality into two distinct services ``ISubscriptionBasedResizeListenerService`` and ``IBreakpointListenerService``. While the first one returns an object with the window size, the second one provides the mechanism for the breakpoints. 

### A scoped service within the internal subscription management

The services manage subscriptions of components that are interested in a change of the window size.  The component put the callback in that it wants to execute in case of a change. The service itself manages this subscription and a mapping between different ``ResizeOptions`` and subscriptions.  The JS event registration on a per option base is a new feature. It makes it possible that different options can be used while avoiding unnecessary messages between the JS and .NET world. So, if 100 components subscribed to changes but all using the same options, there will be only one call from JS to .NET, and then the 100 callbacks are invoked.  

If the last subscriber for a particular option has been canceled, the service also deregisters the js events. In case, there no subscriber left, additional dispose logic is executed to make sure that these services have the least possible footprint. 

### MudBreakpointProvider

There is also a new component within this PR: ``MudBreakpointProvider``. This uses the IBreakpointListenerService to expose and propagate a cascading value of the current breakpoint. This implementation makes scenarios where layout heavily relies on such features more performant. MudHidden has also been redesigned to work either with a server or this cascading value. If the cascading value is provided, no service calls are issued. I've added an example to the docs to showcase this scenario.

```
<MudBreakpointProvider>
   <MudHidden>..</MudHidden>
   <MudHidden>..</MudHidden>
   <MudHidden>..</MudHidden>
</MudBreakpointProvider>
```

### No breaking changes
All internal reference to the "old" ``IResizeListenerService`` has been removed and replaced with the new services. However, either the interface nor the implementation of the ``IResizeListenerService`` have changed. There is an extra bit inside the .js file to handle both versions. So, there are no breaking changes. This gives us the possibility to encourage a change instead of enforcing it. I've updated the docs page with a hint to that scenario.

### First calls on OnAfterRenderAsync
The internal components (``MudHidden`` and ``MudDrawer``) subscribing to the ``IBreakpointListenerService`` first during the ``OnAfterRenderAsync`` method. This ensures that this component can be used in a server-side prerendering scenario.   In case of a dispose within this cycle, the subscription id will be ``000000-00...``.  The ``Unsubscribe`` method of the service will be called with this id. However, the services only do something if a know subscription id is used. So no JS is invoked. 

### Naming
To avoid a naming conflict with the existing interface and implementation, the new approach gets a longer name like ``ISubscriptionBasedResizeListenerService`` or ``SubscriptionBasedResizeListenerService``. Both can hopefully change later on into the shorter names when we declare the IResizeListenerService as deprecated. 

