### PR TITLE
NumericField: Nullable Fix

### DIFF
--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -380,12 +380,34 @@ namespace MudBlazor.UnitTests
             comp.WaitForAssertion(() => comp.Instance.FieldNotImmediate.Text.Should().Be("1.234,00"));
             comp.WaitForAssertion(() => comp.Instance.FieldNotImmediate.Value.Should().Be(1234.0));
 
+            notImmediate.Change("0");
+            notImmediate.Blur();
+            comp.WaitForAssertion(() => comp.Instance.FieldNotImmediate.Text.Should().Be("0,00"));
+            comp.WaitForAssertion(() => comp.Instance.FieldNotImmediate.Value.Should().Be(0.0));
+
+            notImmediate.Change("");
+            notImmediate.Blur();
+            comp.WaitForAssertion(() => comp.Instance.FieldNotImmediate.Text.Should().Be(null));
+            comp.WaitForAssertion(() => comp.Instance.FieldNotImmediate.Value.Should().Be(null));
+
             // English
             immediate.Input("1234");
             immediate.Blur();
 
             comp.WaitForAssertion(() => comp.Instance.FieldImmediate.Text.Should().Be("1,234.00"));
             comp.WaitForAssertion(() => comp.Instance.FieldImmediate.Value.Should().Be(1234.0));
+
+            immediate.Input("0");
+            immediate.Blur();
+
+            comp.WaitForAssertion(() => comp.Instance.FieldImmediate.Text.Should().Be("0.00"));
+            comp.WaitForAssertion(() => comp.Instance.FieldImmediate.Value.Should().Be(0.0));
+
+            immediate.Input("");
+            immediate.Blur();
+
+            comp.WaitForAssertion(() => comp.Instance.FieldImmediate.Text.Should().Be(null));
+            comp.WaitForAssertion(() => comp.Instance.FieldImmediate.Value.Should().Be(null));
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -196,6 +196,19 @@ namespace MudBlazor
                 return (Max, true);
             else if (value < min)
                 return (Min, true);
+            //return T default (null) when it has a nullable type and value to 0
+            //If needed specifying the variable type, we can change this if block as follows. It gives the same result.
+            //else if ((typeof(T) == typeof(int?) || typeof(T) == typeof(uint?) || typeof(T) == typeof(double?) || typeof(T) == typeof(sbyte?) ||
+            //    typeof(T) == typeof(byte?) || typeof(T) == typeof(short?) || typeof(T) == typeof(ushort?) || typeof(T) == typeof(decimal?) ||
+            //    typeof(T) == typeof(long?) || typeof(T) == typeof(ulong?) || typeof(T) == typeof(float?)) && (value == 0))
+            //{
+            //    return (default(T), true);
+            //}
+            else if (value == 0)
+            {
+                return (default(T), true);
+            }
+
             return (Num.To<T>(value), false);
         }
 
@@ -414,7 +427,7 @@ namespace MudBlazor
             {
                 _keyDownPreventDefault = false;
             }
-            
+
             OnKeyUp.InvokeAsync(obj).AndForget();
         }
 

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -196,15 +196,8 @@ namespace MudBlazor
                 return (Max, true);
             else if (value < min)
                 return (Min, true);
-            //return T default (null) when it has a nullable type and value to 0
-            //If needed specifying the variable type, we can change this if block as follows. It gives the same result.
-            //else if ((typeof(T) == typeof(int?) || typeof(T) == typeof(uint?) || typeof(T) == typeof(double?) || typeof(T) == typeof(sbyte?) ||
-            //    typeof(T) == typeof(byte?) || typeof(T) == typeof(short?) || typeof(T) == typeof(ushort?) || typeof(T) == typeof(decimal?) ||
-            //    typeof(T) == typeof(long?) || typeof(T) == typeof(ulong?) || typeof(T) == typeof(float?)) && (value == 0))
-            //{
-            //    return (default(T), true);
-            //}
-            else if (value == 0)
+            //return T default (null) when there is no value
+            else if (v == null)
             {
                 return (default(T), true);
             }


### PR DESCRIPTION
As we discussed in #2643, nullable MudNumericField's value didn't set to null, instead of it showed 0.

This PR should fix that and #2678 . When it's nullable value is 0 it goes automatically to null.

Also it works with HideSpinButtons, arrow keys and shift + mousewheel properly.

Non-nullable fields not affected this.

https://user-images.githubusercontent.com/78308169/132679252-cb29c5f6-5321-4c5b-b594-db7b03580396.mp4

fix #2678